### PR TITLE
Add rudimentary ExplicitImplicit semantic rewrite.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 # Trigger build 8
 build:
-  image: olafurpg/scalafix:0.0.1
+  image: ensime/ensime:v2.x-cache
   commands:
     - apt-get install nailgun
     - alias ng=ng-nailgun

--- a/.scalafmt
+++ b/.scalafmt
@@ -1,3 +1,0 @@
---assumeStandardLibraryStripMargin true
---alignTokens %;Infix,%%;Infix,%%%;Infix
-

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,6 @@
+assumeStandardLibraryStripMargin = true
+align.tokens = [
+  { code = "%", owner = "Infix" }
+  { code = "%%", owner = "Infix" }
+  { code = "%%%", owner = "Infix" }
+]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# scalafix [![codecov.io](https://codecov.io/github/scalacenter/scalafix/coverage.svg?branch=master)](https://codecov.io/github/scalacenter/scalafix?branch=master) [![Build Status](http://stats.lassie.io:8001/api/badges/scalacenter/scalafix/status.svg)](http://stats.lassie.io:8001/scalacenter/scalafix) [![Join the chat at https://gitter.im/scalacenter/scalafix](https://badges.gitter.im/scalacenter/scalafix.svg)](https://gitter.im/scalacenter/scalafix?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+# scalafix [![Build Status](http://stats.lassie.io:8001/api/badges/scalacenter/scalafix/status.svg)](http://stats.lassie.io:8001/scalacenter/scalafix) [![Join the chat at https://gitter.im/scalacenter/scalafix](https://badges.gitter.im/scalacenter/scalafix.svg)](https://gitter.im/scalacenter/scalafix?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 The [first meeting of the Scala Center advisory board](http://scala-lang.org/blog/2016/05/30/scala-center-advisory-board.html#the-first-meeting)
 approved a proposal to define a migration path from Scala 2.x to Dotty.

--- a/bin/nailgun_integration_test.sh
+++ b/bin/nailgun_integration_test.sh
@@ -2,6 +2,7 @@
 set -e
 
 echo "Running nailgun integration test..."
+ng ng-stop || true
 
 cwd=$(pwd)
 cd cli/target/pack

--- a/bin/testAll.sh
+++ b/bin/testAll.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -e
 
-sbt clean coverage test
+
+sbt -Dpersist.enable clean semanticCompile/compile
+#sbt coverage test # coverage seems to break the semantic tests :/
+sbt test
 sbt "; publishLocal ; scripted ; cli/pack"
-sbt coverageAggregate
+#sbt coverageAggregate
 
 # Integration tests
 ./bin/nailgun_integration_test.sh

--- a/build.sbt
+++ b/build.sbt
@@ -3,13 +3,14 @@ import sbt.ScriptedPlugin._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys._
 
 scalafmtConfig in ThisBuild := Some(file(".scalafmt"))
+val Versions = _root_.scalafix.Versions
 
 lazy val buildSettings = Seq(
   organization := "ch.epfl.scala",
   assemblyJarName in assembly := "scalafix.jar",
   // See core/src/main/scala/ch/epfl/scala/Versions.scala
-  version := scalafix.Versions.nightly,
-  scalaVersion := scalafix.Versions.scala,
+  version := Versions.nightly,
+  scalaVersion := Versions.scala,
   updateOptions := updateOptions.value.withCachedResolution(true)
 )
 
@@ -97,6 +98,7 @@ lazy val root = project
     core,
     cli,
     readme,
+    semanticCompile,
     sbtScalafix
   )
   .dependsOn(core)
@@ -105,11 +107,12 @@ lazy val core = project
   .settings(allSettings)
   .settings(
     moduleName := "scalafix-core",
+    fork := true,
     addCompilerPlugin(
       "org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
     libraryDependencies ++= Seq(
       "com.lihaoyi"    %% "sourcecode"   % "0.1.2",
-      "org.scalameta"  %% "scalameta"    % "1.0.0",
+      "com.geirsson"   %% "scalameta"    % "2.0.0-M7",
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
       // Test dependencies
       "org.scalatest"                  %% "scalatest" % "3.0.0" % "test",
@@ -158,6 +161,13 @@ lazy val sbtScalafix = project
     ),
     scriptedBufferLog := false
   )
+
+lazy val semanticCompile = project
+    .settings(
+      allSettings,
+      addCompilerPlugin(Versions.paradiseOrg % "paradise_2.11.8" % Versions.paradiseVersion),
+      scalacOptions += "-Ybackend:GenBCode"
+    )
 
 lazy val readme = scalatex
   .ScalatexReadme(projectId = "readme",

--- a/core/src/main/scala/scala/meta/Mirror.scala
+++ b/core/src/main/scala/scala/meta/Mirror.scala
@@ -1,0 +1,11 @@
+package scala.meta
+
+object Mirror {
+  def apply(artifacts: Artifact*)(implicit resolver: Resolver): Mirror = {
+    new Mirror {
+      lazy val domain = Domain(artifacts: _*)(resolver)
+      override def toString =
+        s"""Context(${artifacts.mkString(", ")})($resolver)"""
+    }
+  }
+}

--- a/core/src/main/scala/scalafix/Scalafix.scala
+++ b/core/src/main/scala/scalafix/Scalafix.scala
@@ -2,6 +2,7 @@ package scalafix
 
 import scala.meta._
 import scala.meta.inputs.Input
+import scalafix.config.ScalafixConfig
 import scalafix.rewrite.RewriteCtx
 import scalafix.util.Patch
 import scalafix.util.TokenList
@@ -14,7 +15,13 @@ object Scalafix {
   def fix(code: Input, config: ScalafixConfig): Fixed = {
     config.parser.apply(code, config.dialect) match {
       case Parsed.Success(ast) =>
-        val ctx = RewriteCtx(config, new TokenList(ast.tokens))
+        val m = Mirror(
+          config.project.targetFiles.map(x => Artifact(x.getAbsolutePath)): _*)
+        val ctx = RewriteCtx(
+          config,
+          new TokenList(ast.tokens),
+          Some(m)
+        )
         val patches: Seq[Patch] = config.rewrites.flatMap(_.rewrite(ast, ctx))
         Right(Patch.apply(ast.tokens, patches))
       case Parsed.Error(pos, msg, e) =>

--- a/core/src/main/scala/scalafix/Versions.scala
+++ b/core/src/main/scala/scalafix/Versions.scala
@@ -1,7 +1,9 @@
 package scalafix
 
 object Versions {
-  val nightly = "0.1.0"
+  val nightly = "0.1.0-SNAPSHOT"
   val stable = nightly
   val scala = "2.11.8"
+  val paradiseVersion = "4.0.0-M3"
+  val paradiseOrg = "com.geirsson"
 }

--- a/core/src/main/scala/scalafix/config/ProjectFiles.scala
+++ b/core/src/main/scala/scalafix/config/ProjectFiles.scala
@@ -1,0 +1,8 @@
+package scalafix.config
+
+import java.io.File
+
+case class ProjectFiles(
+    targetFiles: Seq[File] = Nil,
+    files: Seq[File] = Nil
+)

--- a/core/src/main/scala/scalafix/config/ScalafixConfig.scala
+++ b/core/src/main/scala/scalafix/config/ScalafixConfig.scala
@@ -1,4 +1,4 @@
-package scalafix
+package scalafix.config
 
 import scala.meta.Dialect
 import scala.meta.Tree
@@ -6,8 +6,11 @@ import scala.meta.dialects.Scala211
 import scala.meta.parsers.Parse
 import scalafix.rewrite.Rewrite
 
+import java.io.File
+
 case class ScalafixConfig(
     rewrites: Seq[Rewrite] = Rewrite.default,
     parser: Parse[_ <: Tree] = Parse.parseSource,
-    dialect: Dialect = Scala211
+    dialect: Dialect = Scala211,
+    project: ProjectFiles = ProjectFiles()
 )

--- a/core/src/main/scala/scalafix/rewrite/ExplicitImplicit.scala
+++ b/core/src/main/scala/scalafix/rewrite/ExplicitImplicit.scala
@@ -1,0 +1,29 @@
+package scalafix.rewrite
+
+import scala.meta._
+import scala.meta.internal.prettyprinters.Attributes
+import scala.meta.tokens.Token.Comment
+import scala.meta.tokens.Token.LeftBrace
+import scala.meta.tokens.Token.RightBrace
+import scala.meta.tokens.Token.RightParen
+import scala.meta.tokens.Token.Space
+import scalafix.util.Patch
+import scalafix.util.SemanticOracle
+import scalafix.util.logger
+
+case object ExplicitImplicit extends Rewrite {
+
+  override def rewrite(ast: Tree, ctx: RewriteCtx): Seq[Patch] = {
+    val builder = Seq.newBuilder[Patch]
+    val oracle = new SemanticOracle(ctx.mirror.get)
+    ast.collect {
+      case Defn.Val(mods, Seq(Pat.Var.Term(t: Term.Name)), decltpe, _)
+          if decltpe.isEmpty && mods.exists(_.syntax == "implicit") =>
+        oracle.getType(t).foreach { typ =>
+          val toks = t.tokens
+          builder += Patch(toks.head, toks.last, s"${t.syntax}: $typ")
+        }
+    }
+    builder.result()
+  }
+}

--- a/core/src/main/scala/scalafix/rewrite/Rewrite.scala
+++ b/core/src/main/scala/scalafix/rewrite/Rewrite.scala
@@ -4,9 +4,7 @@ import scala.meta._
 import scalafix.util.Patch
 
 abstract class Rewrite {
-
   def rewrite(code: Tree, rewriteCtx: RewriteCtx): Seq[Patch]
-
 }
 
 object Rewrite {
@@ -15,6 +13,7 @@ object Rewrite {
   }
 
   val name2rewrite: Map[String, Rewrite] = nameMap[Rewrite](
+    ExplicitImplicit,
     ProcedureSyntax,
     VolatileLazyVal
   )

--- a/core/src/main/scala/scalafix/rewrite/RewriteCtx.scala
+++ b/core/src/main/scala/scalafix/rewrite/RewriteCtx.scala
@@ -1,9 +1,18 @@
 package scalafix.rewrite
 
-import scalafix.ScalafixConfig
+import scala.meta.Tree
+import scala.meta.inputs.Input
+import scala.meta.semantic.Mirror
+import scalafix.config.ScalafixConfig
 import scalafix.util.TokenList
+
+case class RewriteInput(
+    input: Input,
+    ast: Tree
+)
 
 case class RewriteCtx(
     config: ScalafixConfig,
-    tokenList: TokenList
+    tokenList: TokenList,
+    mirror: Option[Mirror]
 )

--- a/core/src/main/scala/scalafix/rewrite/VolatileLazyVal.scala
+++ b/core/src/main/scala/scalafix/rewrite/VolatileLazyVal.scala
@@ -10,13 +10,13 @@ case object VolatileLazyVal extends Rewrite {
         case x if x.syntax == "@volatile" =>
           None
         case x if x.syntax == "lazy" =>
-          Some(x.tokens.head)
+          Some(defn.mods.head.tokens.head)
       }
     }.flatten
   }
   override def rewrite(ast: Tree, ctx: RewriteCtx): Seq[Patch] = {
     ast.collect {
-      case NonVolatileLazyVal(tok) => Patch(tok, tok, "@volatile lazy")
+      case NonVolatileLazyVal(tok) => Patch(tok, tok, s"@volatile ${tok.syntax}")
     }
   }
 }

--- a/core/src/main/scala/scalafix/util/SemanticOracle.scala
+++ b/core/src/main/scala/scalafix/util/SemanticOracle.scala
@@ -1,0 +1,82 @@
+package scalafix.util
+
+import scala.annotation.tailrec
+import scala.meta._
+import scala.meta.internal.prettyprinters.Attributes
+import scala.meta.semantic.Mirror
+
+/** Super low-tech "solution" to make semantic info useful from a syntactic tree.
+  *
+  * The approach is roughly this:
+  *
+  * 1. Create "search index" (i.e., Map[String, String]) from a semantic Mirror.
+  *    For example, the code
+  *    {{{
+  *       package bar
+  *       class X {
+  *         val x: foo.Y = new foo.Y
+  *       }
+  *    }}}
+  *    creates index Map(bar.X.x -> foo.Y)
+  * 2. Create string "query" from a syntactic tree node. Following the above
+  *    example, to lookup the type of x the query is "bar.X.x".
+  * 3. Lookup query in search index. Profit.
+  */
+class SemanticOracle(mirror: Mirror) {
+
+  /** Returns the type annotation for the name, if any */
+  def getType(name: Term.Name): Option[String] = {
+    val query = getQuery(name)
+    typeIndex.get(query)
+  }
+
+  private def getQuery(tree: Tree): String =
+    "_root_." +
+      TreeOps
+        .getParents(tree)
+        .map(getQueryPart)
+        .filter(_.nonEmpty)
+        .mkString(".")
+
+  val escapedName = "`([\\w\\d_]+) `".r
+  private def getQueryPart(tree: Tree): String = {
+    val result = tree match {
+      case Pkg(ref, _) => ref.syntax
+      case Defn.Def(_, name, _, _, _, _) => name.syntax
+      case Defn.Val(_, Seq(Pat.Var.Term(name)), _, _) => name.syntax
+      case t: Defn.Class => t.name.syntax
+      case t: Defn.Object => t.name.syntax + "$"
+      case t: Defn.Trait => t.name.syntax
+      case _ => ""
+    }
+    result match {
+      case escapedName(name) => name
+      case name => name.trim
+    }
+  }
+
+  private def getQueries(tree: Tree): Seq[(String, String)] = {
+    val builder = Seq.newBuilder[(String, String)]
+    def loop(query: String)(curr: Tree): Unit = {
+      val append = getQueryPart(curr)
+      val nextQuery = if (append.nonEmpty) s"$query.$append" else query
+      curr match {
+        case Type.Name(name) =>
+          builder += (query -> name)
+        case els =>
+      }
+      curr.children.foreach(loop(nextQuery))
+    }
+    loop("_root_")(tree)
+    builder.result()
+  }
+
+  private val typeIndex: Map[String, String] = {
+    val builder = Map.newBuilder[String, String]
+    mirror.domain.sources.foreach { source =>
+      builder ++= getQueries(source)
+    }
+    builder.result()
+  }
+
+}

--- a/core/src/main/scala/scalafix/util/TreeOps.scala
+++ b/core/src/main/scala/scalafix/util/TreeOps.scala
@@ -1,0 +1,15 @@
+package scalafix.util
+
+import scala.annotation.tailrec
+import scala.meta.Tree
+
+object TreeOps {
+
+  @tailrec
+  final def getParents(tree: Tree, accum: Seq[Tree] = Nil): Seq[Tree] = {
+    tree.parent match {
+      case Some(parent) => getParents(parent, parent +: accum)
+      case _ => accum
+    }
+  }
+}

--- a/core/src/main/scala/scalafix/util/logger.scala
+++ b/core/src/main/scala/scalafix/util/logger.scala
@@ -10,6 +10,16 @@ import java.io.File
   */
 object logger {
 
+  /** Pretty-prints deeply nested scala.meta structures using clang-format. */
+  def clangPrint(x: Any): String = {
+    import scala.sys.process._
+    import java.io.ByteArrayInputStream
+    val bais = new ByteArrayInputStream(x.toString.getBytes("UTF-8"))
+    val command = List("clang-format",
+                       "-style={ContinuationIndentWidth: 2, ColumnLimit: 120}")
+    (command #< bais).!!.trim
+  }
+
   private def log[T](t: sourcecode.Text[T],
                      logLevel: LogLevel,
                      line: sourcecode.Line,

--- a/core/src/test/scala/scalafix/rewrite/ExplicitImplicitTest.scala
+++ b/core/src/test/scala/scalafix/rewrite/ExplicitImplicitTest.scala
@@ -1,0 +1,47 @@
+package scalafix.rewrite
+
+import scala.meta.inputs.Input
+import scalafix.Scalafix
+import scalafix.config.ProjectFiles
+import scalafix.config.ScalafixConfig
+import scalafix.util.DiffAssertions
+
+import java.io.File
+
+import org.scalatest.FunSuite
+
+class ExplicitImplicitTest extends FunSuite with DiffAssertions {
+
+  def check(target: String, filename: String): String = {
+    val config = ScalafixConfig(
+      rewrites = Seq(ExplicitImplicit),
+      project = ProjectFiles(
+        targetFiles = Seq(new File(target))
+      )
+    )
+    val Right(output) = Scalafix.fix(Input.File(filename), config)
+    output
+  }
+  test("basic") {
+    val obtained =
+      check("../semanticCompile/target",
+            "../semanticCompile/src/main/scala/semantic/CompileMe.scala")
+    val expected =
+      """|package semantic
+         |
+         |class Goodbye
+         |
+         |class CompileMe() {
+         |  implicit val x: scala.Int = 1
+         |  implicit val goodbye: semantic.Goodbye = new Goodbye
+         |}
+         |
+         |object CompileMe {
+         |  implicit val y = "string"
+         |  implicit def method = new CompileMe
+         |}
+         |""".stripMargin.trim
+    assertNoDiff(obtained, expected)
+  }
+}
+

--- a/core/src/test/scala/scalafix/rewrite/LazyValSuite.scala
+++ b/core/src/test/scala/scalafix/rewrite/LazyValSuite.scala
@@ -10,6 +10,7 @@ class LazyValSuite extends RewriteSuite(VolatileLazyVal) {
        |
        |val foo = 1
        |
+       |  private lazy val x = 2
        |  lazy val x = 2
        |  @volatile lazy val dontChangeMe = 2
        |
@@ -24,6 +25,7 @@ class LazyValSuite extends RewriteSuite(VolatileLazyVal) {
        |
        |val foo = 1
        |
+       |  @volatile private lazy val x = 2
        |  @volatile lazy val x = 2
        |  @volatile lazy val dontChangeMe = 2
        |

--- a/core/src/test/scala/scalafix/rewrite/RewriteSuite.scala
+++ b/core/src/test/scala/scalafix/rewrite/RewriteSuite.scala
@@ -1,7 +1,7 @@
 package scalafix.rewrite
 
 import scalafix.Scalafix
-import scalafix.ScalafixConfig
+import scalafix.config.ScalafixConfig
 import scalafix.util.DiffAssertions
 
 import org.scalatest.FunSuiteLike

--- a/sbtScalafix/src/main/scala/scalafix/sbt/HasScalafix.scala
+++ b/sbtScalafix/src/main/scala/scalafix/sbt/HasScalafix.scala
@@ -32,6 +32,7 @@ case class HasScalafix(reflective: ScalafixLike,
                        configFile: Option[File],
                        streams: TaskStreams,
                        sourceDirectories: Seq[File],
+                       targetDirectory: Seq[File],
                        includeFilter: FileFilter,
                        excludeFilter: FileFilter,
                        ref: ProjectRef) {
@@ -49,7 +50,11 @@ case class HasScalafix(reflective: ScalafixLike,
     inc.Analysis
       .counted("Scala source", "", "s", files.size)
       .foreach(logFun("Fixed %s %s ..."))
-    val args: Seq[String] = Seq("-i") ++ files.toSeq.map(_.getPath)
+    val args: Seq[String] = Seq(
+        "--target",
+        targetDirectory.map(_.getAbsolutePath).mkString(","),
+        "-i"
+      ) ++ files.toSeq.map(_.getAbsolutePath)
     reflective.main(args.toArray)
   }
 

--- a/sbtScalafix/src/sbt-test/scalafix-sbt/basic/build.sbt
+++ b/sbtScalafix/src/sbt-test/scalafix-sbt/basic/build.sbt
@@ -1,4 +1,4 @@
-sbtPlugin := true
+scalaVersion := "2.11.8" // 2.11.8 is required for "-Ybackend:GenBCode"
 
 TaskKey[Unit]("check") := {
   val obtained =
@@ -7,12 +7,19 @@ TaskKey[Unit]("check") := {
       .getLines()
       .mkString("\n")
   val expected =
-    """
-      |object Main {
-      |  def main(args: Array[String]): Unit = {
-      |    println("hello")
-      |  }
-      |}
+    """|package main
+       |
+       |object Main {
+       |  def main(args: String): Unit = {
+       |    println("hello")
+       |  }
+       |}
+       |
+       |class Y
+       |
+       |class X {
+       |  implicit val y: main.Y = new Y
+       |}t¬
     """.stripMargin
 
   if (obtained.trim != expected.trim) {

--- a/sbtScalafix/src/sbt-test/scalafix-sbt/basic/project/build.properties
+++ b/sbtScalafix/src/sbt-test/scalafix-sbt/basic/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.11

--- a/sbtScalafix/src/sbt-test/scalafix-sbt/basic/src/main/scala/Test.scala
+++ b/sbtScalafix/src/sbt-test/scalafix-sbt/basic/src/main/scala/Test.scala
@@ -1,5 +1,13 @@
+package main
+
 object Main {
-  def main(args: Array[String]) {
+  def main(args: String) {
     println("hello")
   }
+}
+
+class Y
+
+class X {
+  implicit val y = new Y
 }

--- a/semanticCompile/src/main/scala/semantic/CompileMe.scala
+++ b/semanticCompile/src/main/scala/semantic/CompileMe.scala
@@ -1,0 +1,14 @@
+package semantic
+
+class Goodbye
+
+class CompileMe() {
+  implicit val x = 1
+  implicit val goodbye = new Goodbye
+}
+
+object CompileMe {
+  implicit val y = "string"
+  implicit def method = new CompileMe
+}
+


### PR DESCRIPTION
# \- Use (super experimental) 2.0 version of scalameta
- Use (super experimental) 4.0 version of scala.meta paradise
- SBT plugin injects the 4.0 paradise compiler plugin and compiles with -Dpersist.enable
- ExplicitImplicit inserts the fully qualified type name, no fancy imports yet
- Everything is tested, including the SBT plugin interaction!
