### PR TITLE
Support hocon configuration.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,6 +15,7 @@ build:
     - test -d /drone/.ivy2 && cp -a /drone/.ivy2 /root
     - rm -rf /drone/.ivy2
 
+    - sbt "very publishLocal" # necessary for 2.11/2.12 cross publish.
     - sbt clean test scripted
 
     - cp -a /root/.ivy2 /drone

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,6 +19,7 @@ build:
 
     - cp -a /root/.ivy2 /drone
     - cp -a /root/.sbt /drone
+    - sbt clean test scripted
 cache:
   mount:
     - /drone/.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -104,6 +104,7 @@ lazy val core = project
     addCompilerPlugin(
       "org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
     libraryDependencies ++= Seq(
+      "com.typesafe"   % "config"        % "1.3.1",
       "com.lihaoyi"    %% "sourcecode"   % "0.1.3",
       "org.scalameta"  %% "scalameta"    % Build.metaV,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,14 @@
 import sbt.ScriptedPlugin
 import sbt.ScriptedPlugin._
+import sbtbuildinfo.BuildInfoKey.Entry
 organization in ThisBuild := "ch.epfl.scala"
-version in ThisBuild := scalafix.Versions.nightly
+version in ThisBuild := "0.2.0-SNAPSHOT"
 
 lazy val crossVersions = Seq("2.11.8", "2.12.1")
 
 lazy val buildSettings = Seq(
   assemblyJarName in assembly := "scalafix.jar",
-  // See core/src/main/scala/ch/epfl/scala/Versions.scala
-  scalaVersion := scalafix.Versions.scala,
+  scalaVersion := "2.11.8",
   updateOptions := updateOptions.value.withCachedResolution(true)
 )
 
@@ -72,14 +72,28 @@ lazy val noPublish = Seq(
   publishLocal := {}
 )
 
-lazy val allSettings = commonSettings ++ buildSettings ++ publishSettings
+lazy val buildInfoSettings: Seq[Def.Setting[_]] = Seq(
+  buildInfoKeys := Seq[BuildInfoKey](
+    name,
+    version,
+    scalaVersion,
+    sbtVersion
+  ),
+  buildInfoPackage := "scalafix",
+  buildInfoObject := "Versions"
+)
 
-lazy val root = project
+lazy val allSettings =
+  commonSettings ++
+    buildSettings ++
+    publishSettings
+
+lazy val `scalafix-root` = project
   .in(file("."))
-  .settings(moduleName := "scalafix")
-  .settings(allSettings)
-  .settings(noPublish)
   .settings(
+    moduleName := "scalafix",
+    allSettings,
+    noPublish,
     initialCommands in console :=
       """
         |import scala.meta._
@@ -99,6 +113,7 @@ lazy val root = project
 lazy val core = project
   .settings(
     allSettings,
+    buildInfoSettings,
     crossScalaVersions := crossVersions,
     moduleName := "scalafix-core",
     addCompilerPlugin(
@@ -113,6 +128,7 @@ lazy val core = project
       "com.googlecode.java-diff-utils" % "diffutils"  % "1.3.0"     % "test"
     )
   )
+  .enablePlugins(BuildInfoPlugin)
 
 lazy val `scalafix-nsc` = project
   .settings(
@@ -181,24 +197,25 @@ lazy val publishedArtifacts = Seq(
   publishLocal in core
 )
 
-lazy val `scalafix-sbt` = project.settings(
-  allSettings,
-  ScriptedPlugin.scriptedSettings,
-  sbtPlugin := true,
-  scripted := scripted.dependsOn(publishedArtifacts: _*).evaluated,
-  scalaVersion := "2.10.5",
-  moduleName := "sbt-scalafix",
-  sources in Compile +=
-    baseDirectory.value / "../core/src/main/scala/scalafix/Versions.scala",
-  scriptedLaunchOpts ++= Seq(
-    "-Dplugin.version=" + version.value,
-    // .jvmopts is ignored, simulate here
-    "-XX:MaxPermSize=256m",
-    "-Xmx2g",
-    "-Xss2m"
-  ),
-  scriptedBufferLog := false
-)
+lazy val `scalafix-sbt` = project
+  .settings(
+    allSettings,
+    buildInfoSettings,
+    ScriptedPlugin.scriptedSettings,
+    sbtPlugin := true,
+    scripted := scripted.dependsOn(publishedArtifacts: _*).evaluated,
+    scalaVersion := "2.10.5",
+    moduleName := "sbt-scalafix",
+    scriptedLaunchOpts ++= Seq(
+      "-Dplugin.version=" + version.value,
+      // .jvmopts is ignored, simulate here
+      "-XX:MaxPermSize=256m",
+      "-Xmx2g",
+      "-Xss2m"
+    ),
+    scriptedBufferLog := false
+  )
+  .enablePlugins(BuildInfoPlugin)
 
 lazy val `scalafix-tests` = project
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -203,8 +203,10 @@ lazy val `scalafix-sbt` = project
     buildInfoSettings,
     ScriptedPlugin.scriptedSettings,
     sbtPlugin := true,
-    scripted := scripted.dependsOn(publishedArtifacts: _*).evaluated,
+    // Doesn't work because we need to publish 2.11 and 2.12.
+//    scripted := scripted.dependsOn(publishedArtifacts: _*).evaluated,
     scalaVersion := "2.10.5",
+    crossScalaVersions := Seq(scalaVersion.value),
     moduleName := "sbt-scalafix",
     scriptedLaunchOpts ++= Seq(
       "-Dplugin.version=" + version.value,

--- a/cli/src/main/scala/scalafix/cli/Cli.scala
+++ b/cli/src/main/scala/scalafix/cli/Cli.scala
@@ -30,7 +30,7 @@ case class CommonOptions(
 )
 
 @AppName("scalafix")
-@AppVersion(scalafix.Versions.nightly)
+@AppVersion(scalafix.Versions.version)
 @ProgName("scalafix")
 case class ScalafixOptions(
     @HelpMessage(

--- a/core/src/main/scala/scalafix/ScalafixConfig.scala
+++ b/core/src/main/scala/scalafix/ScalafixConfig.scala
@@ -6,7 +6,6 @@ import scala.meta.dialects.Scala211
 import scala.meta.parsers.Parse
 import scala.util.control.NonFatal
 import scalafix.rewrite.Rewrite
-import scalafix.util.logger
 
 import java.io.File
 
@@ -53,7 +52,6 @@ object ScalafixConfig {
               s"Valid rules are: ${Rewrite.name2rewrite.keys.mkString(",")}")
         } else {
           val rewrites = names.map(Rewrite.name2rewrite)
-          logger.elem(rewrites)
           Right(ScalafixConfig(rewrites = rewrites))
         }
     }

--- a/core/src/main/scala/scalafix/ScalafixConfig.scala
+++ b/core/src/main/scala/scalafix/ScalafixConfig.scala
@@ -4,7 +4,14 @@ import scala.meta.Dialect
 import scala.meta.Tree
 import scala.meta.dialects.Scala211
 import scala.meta.parsers.Parse
+import scala.util.control.NonFatal
 import scalafix.rewrite.Rewrite
+import scalafix.util.logger
+
+import java.io.File
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
 
 case class ScalafixConfig(
     rewrites: Seq[Rewrite] = Rewrite.allRewrites,
@@ -13,7 +20,27 @@ case class ScalafixConfig(
 )
 
 object ScalafixConfig {
-  def fromNames(names: List[String]): Either[String, ScalafixConfig] = {
+  private def saferThanTypesafe(
+      op: () => Config): Either[String, ScalafixConfig] =
+    try fromConfig(op())
+    catch {
+      case NonFatal(e) => Left(e.getMessage)
+    }
+
+  def fromFile(file: File): Either[String, ScalafixConfig] =
+    saferThanTypesafe(() => ConfigFactory.parseFile(file))
+
+  def fromString(contents: String): Either[String, ScalafixConfig] =
+    saferThanTypesafe(() => ConfigFactory.parseString(contents))
+
+  def fromConfig(config: Config): Either[String, ScalafixConfig] = {
+    import scala.collection.JavaConverters._
+    if (config.hasPath("rewrites"))
+      fromNames(config.getStringList("rewrites").asScala.toList)
+    else Right(ScalafixConfig())
+  }
+
+  def fromNames(names: List[String]): Either[String, ScalafixConfig] =
     names match {
       case "all" :: Nil =>
         Right(ScalafixConfig(rewrites = Rewrite.allRewrites))
@@ -26,8 +53,8 @@ object ScalafixConfig {
               s"Valid rules are: ${Rewrite.name2rewrite.keys.mkString(",")}")
         } else {
           val rewrites = names.map(Rewrite.name2rewrite)
+          logger.elem(rewrites)
           Right(ScalafixConfig(rewrites = rewrites))
         }
     }
-  }
 }

--- a/core/src/main/scala/scalafix/Versions.scala
+++ b/core/src/main/scala/scalafix/Versions.scala
@@ -1,7 +1,0 @@
-package scalafix
-
-object Versions {
-  val nightly = "0.2.0-RC2-SNAPSHOT"
-  val stable: String = nightly
-  val scala = "2.11.8"
-}

--- a/core/src/test/resources/ExplicitImplicit/basic.source
+++ b/core/src/test/resources/ExplicitImplicit/basic.source
@@ -1,4 +1,4 @@
-// foo
+rewrites = [ExplicitImplicit]
 <<< list
 class A {
   implicit val x = List(1)

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,3 +1,0 @@
-sources in Compile += {
-  baseDirectory.value / "../core/src/main/scala/scalafix/Versions.scala"
-}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+addSbtPlugin("com.eed3si9n"    % "sbt-doge"            % "0.1.5")
 addSbtPlugin("com.eed3si9n"    % "sbt-buildinfo"       % "0.6.1")
 addSbtPlugin("com.eed3si9n"    % "sbt-assembly"        % "0.14.3")
 addSbtPlugin("com.lihaoyi"     % "scalatex-sbt-plugin" % "0.3.5")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+addSbtPlugin("com.eed3si9n"    % "sbt-buildinfo"       % "0.6.1")
 addSbtPlugin("com.eed3si9n"    % "sbt-assembly"        % "0.14.3")
 addSbtPlugin("com.lihaoyi"     % "scalatex-sbt-plugin" % "0.3.5")
 addSbtPlugin("io.get-coursier" % "sbt-coursier"        % "1.0.0-M15")

--- a/readme/Installation.scalatex
+++ b/readme/Installation.scalatex
@@ -53,7 +53,7 @@
 
   @sect{sbt}
     @hl.scala
-      addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "@scalafix.Versions.stable")
+      addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "@scalafix.Versions.version")
 
     @ul
       @li
@@ -66,7 +66,7 @@
     Scalafix can be used directly as a compiler plugin:
     @hl.scala
       // download
-      "ch.epfl.scala" %% "scalafix-nsc" % "@scalafix.Versions.stable"
+      "ch.epfl.scala" %% "scalafix-nsc" % "@scalafix.Versions.version"
       // compile
       scalac -Xplugin:/path/to/scalafix-nsc.jar mycode.scala
 

--- a/readme/Readme.scalatex
+++ b/readme/Readme.scalatex
@@ -1,7 +1,7 @@
 @import Main._
 @import scalafix.Readme._
 
-@sect("scalafix - a Scala rewrite tool", scalafix.Versions.stable)
+@sect("scalafix - a Scala rewrite tool", scalafix.Versions.version)
   @scalatex.Intro()
   @scalatex.Installation()
   @scalatex.Configuration()

--- a/scalafix-nsc/src/main/scala/scalafix/nsc/ScalafixNscComponent.scala
+++ b/scalafix-nsc/src/main/scala/scalafix/nsc/ScalafixNscComponent.scala
@@ -9,6 +9,7 @@ import scala.util.control.NonFatal
 import scalafix.Fixed
 import scalafix.ScalafixConfig
 import scalafix.util.FileOps
+import scalafix.util.logger
 
 class ScalafixNscComponent(plugin: Plugin,
                            val global: Global,
@@ -23,6 +24,7 @@ class ScalafixNscComponent(plugin: Plugin,
     if (unit.source.file.exists &&
         unit.source.file.file.isFile &&
         !unit.isJava) {
+      logger.elem(getConfig())
       fix(unit, getConfig()) match {
         case Fixed.Success(fixed) =>
           if (fixed.nonEmpty && fixed != new String(unit.source.content)) {

--- a/scalafix-nsc/src/main/scala/scalafix/nsc/ScalafixNscComponent.scala
+++ b/scalafix-nsc/src/main/scala/scalafix/nsc/ScalafixNscComponent.scala
@@ -9,7 +9,6 @@ import scala.util.control.NonFatal
 import scalafix.Fixed
 import scalafix.ScalafixConfig
 import scalafix.util.FileOps
-import scalafix.util.logger
 
 class ScalafixNscComponent(plugin: Plugin,
                            val global: Global,
@@ -24,7 +23,6 @@ class ScalafixNscComponent(plugin: Plugin,
     if (unit.source.file.exists &&
         unit.source.file.file.isFile &&
         !unit.isJava) {
-      logger.elem(getConfig())
       fix(unit, getConfig()) match {
         case Fixed.Success(fixed) =>
           if (fixed.nonEmpty && fixed != new String(unit.source.content)) {

--- a/scalafix-nsc/src/main/scala/scalafix/nsc/ScalafixNscPlugin.scala
+++ b/scalafix-nsc/src/main/scala/scalafix/nsc/ScalafixNscPlugin.scala
@@ -7,22 +7,33 @@ import scala.tools.nsc.plugins.Plugin
 import scala.tools.nsc.plugins.PluginComponent
 import scalafix.ScalafixConfig
 import scalafix.rewrite.Rewrite
+import scalafix.util.logger
+
+import java.io.File
 
 class ScalafixNscPlugin(val global: Global) extends Plugin {
+  logger.info("HELLO FROM SCALAFIX!!!")
   val name = "scalafix"
   val description = "Refactoring tool."
-  var config: ScalafixConfig = ScalafixConfig(rewrites = Rewrite.allRewrites)
+  var config: ScalafixConfig = ScalafixConfig()
   val components: List[PluginComponent] =
     new ScalafixNscComponent(this, global, () => config) :: Nil
 
   override def init(options: List[String], error: (String) => Unit): Boolean = {
-    ScalafixConfig.fromNames(options) match {
-      case Left(msg) =>
-        error(msg)
-        false
-      case Right(userConfig) =>
-        config = userConfig
-        true
+    logger.elem(options)
+    options match {
+      case Nil => true
+      case file :: Nil =>
+        ScalafixConfig.fromFile(new File(file)) match {
+          case Left(msg) =>
+            error(msg)
+            false
+          case Right(userConfig) =>
+            config = userConfig
+            true
+        }
+      case els =>
+        super.init(els, error)
     }
   }
 }

--- a/scalafix-nsc/src/main/scala/scalafix/nsc/ScalafixNscPlugin.scala
+++ b/scalafix-nsc/src/main/scala/scalafix/nsc/ScalafixNscPlugin.scala
@@ -6,13 +6,10 @@ import scala.tools.nsc.Global
 import scala.tools.nsc.plugins.Plugin
 import scala.tools.nsc.plugins.PluginComponent
 import scalafix.ScalafixConfig
-import scalafix.rewrite.Rewrite
-import scalafix.util.logger
 
 import java.io.File
 
 class ScalafixNscPlugin(val global: Global) extends Plugin {
-  logger.info("HELLO FROM SCALAFIX!!!")
   val name = "scalafix"
   val description = "Refactoring tool."
   var config: ScalafixConfig = ScalafixConfig()
@@ -20,7 +17,6 @@ class ScalafixNscPlugin(val global: Global) extends Plugin {
     new ScalafixNscComponent(this, global, () => config) :: Nil
 
   override def init(options: List[String], error: (String) => Unit): Boolean = {
-    logger.elem(options)
     options match {
       case Nil => true
       case file :: Nil =>

--- a/scalafix-nsc/src/test/scala/scalafix/DiffTest.scala
+++ b/scalafix-nsc/src/test/scala/scalafix/DiffTest.scala
@@ -23,7 +23,10 @@ object DiffTest {
 
     val style: ScalafixConfig = {
       val firstLine = split.head
-      ScalafixConfig(rewrites = List(ExplicitImplicit))
+      ScalafixConfig.fromString(firstLine) match {
+        case Right(x) => x
+        case Left(e) => throw new IllegalArgumentException(e)
+      }
     }
 
     split.tail.map { t =>

--- a/scalafix-nsc/src/test/scala/scalafix/SemanticTests.scala
+++ b/scalafix-nsc/src/test/scala/scalafix/SemanticTests.scala
@@ -40,8 +40,8 @@ class SemanticTests extends FunSuite {
 
   private object fixer extends NscSemanticApi {
     lazy val global: SemanticTests.this.g.type = SemanticTests.this.g
-    def apply(unit: g.CompilationUnit): Fixed =
-      fix(unit, ScalafixConfig(rewrites = List(rewrite)))
+    def apply(unit: g.CompilationUnit, config: ScalafixConfig): Fixed =
+      fix(unit, config)
   }
 
   def wrap(code: String, diffTest: DiffTest): String = {
@@ -79,8 +79,8 @@ class SemanticTests extends FunSuite {
     unit
   }
 
-  def fix(code: String): String = {
-    val Fixed.Success(fixed) = fixer(getTypedCompilationUnit(code))
+  def fix(code: String, config: ScalafixConfig): String = {
+    val Fixed.Success(fixed) = fixer(getTypedCompilationUnit(code), config)
     fixed
   }
   case class MismatchException(details: String) extends Exception
@@ -141,7 +141,7 @@ class SemanticTests extends FunSuite {
   }
 
   def check(original: String, expectedStr: String, diffTest: DiffTest): Unit = {
-    val fixed = fix(wrap(original, diffTest))
+    val fixed = fix(wrap(original, diffTest), diffTest.config)
     val obtained = parse(fixed)
     val expected = parse(expectedStr)
     try {

--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -24,22 +24,28 @@ object rewrite {
 object ScalafixPlugin extends AutoPlugin with ScalafixKeys {
   object autoImport extends ScalafixKeys
   private val Version = "2\\.(\\d\\d)\\..*".r
-  private val nightlyVersion = _root_.scalafix.Versions.nightly
+  private val scalafixVersion = _root_.scalafix.Versions.version
   private val disabled = sys.props.contains("scalafix.disable")
   private def jar(report: UpdateReport): Option[File] =
-    report.allFiles.find(
-      _.getAbsolutePath.matches(s".*scalafix-nsc_2.[12].jar$$"))
-  private def stub(version: String) =
-    Project(id = "scalafix-stub", base = file("project/scalafix")).settings(
-      description :=
-        """Serves as a caching layer for extracting the jar location of the
-          |scalafix-nsc compiler plugin. If the dependecy was added to all
-          |projects, the (slow) update task will be re-run for every project.""".stripMargin,
-      scalaVersion := version,
-      libraryDependencies ++= Seq(
-        "ch.epfl.scala" %% "scalafix-nsc" % nightlyVersion
+    report.allFiles.find { x =>
+      println("X: " + x)
+      x.getAbsolutePath.matches(s".*scalafix-nsc_2.1[12].jar$$")
+    }
+
+  private def stub(version: String) = {
+    val Version(id) = version
+    Project(id = s"scalafix-$id", base = file(s"project/scalafix/$id"))
+      .settings(
+        description :=
+          """Serves as a caching layer for extracting the jar location of the
+            |scalafix-nsc compiler plugin. If the dependecy was added to all
+            |projects, the (slow) update task will be re-run for every project.""".stripMargin,
+        scalaVersion := version,
+        libraryDependencies ++= Seq(
+          "ch.epfl.scala" %% "scalafix-nsc" % scalafixVersion
+        )
       )
-    )
+  }
   private val scalafix211 = stub("2.11.8")
   private val scalafix212 = stub("2.12.1")
 

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/basic/.scalafix.conf
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/basic/.scalafix.conf
@@ -1,0 +1,1 @@
+rewrites = [ExplicitImplicit]

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/basic/.scalafix.conf
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/basic/.scalafix.conf
@@ -1,1 +1,1 @@
-rewrites = [ExplicitImplicit]
+rewrites = [ExplicitImplicit, ProcedureSyntax]

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/basic/build.sbt
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/basic/build.sbt
@@ -1,31 +1,20 @@
-val commonSettings: Seq[Def.Setting[String]] = Seq(
-  scalaVersion := "2.11.8"
-)
-
 scalafixConfig in ThisBuild := Some(baseDirectory.value / ".scalafix.conf")
 
 lazy val root = project
   .in(file("."))
-  .settings(commonSettings)
   .aggregate(
     p1,
     p2,
     p3
   )
 
-lazy val p1 = project.settings(
-  commonSettings
-)
-lazy val p2 = project.settings(
-  scalaVersion := "2.10.5"
-)
-
-lazy val p3 = project.settings(
-  scalaVersion := "2.12.1"
-)
+lazy val p1 = project.settings(scalaVersion := "2.11.8")
+lazy val p2 = project.settings(scalaVersion := "2.10.5")
+lazy val p3 = project.settings(scalaVersion := "2.12.1")
 
 TaskKey[Unit]("check") := {
-  def assertContentMatches(file: String, expectedUntrimmed: String): Unit = {
+  // returns true if test succeeded, else false.
+  def assertContentMatches(file: String, expectedUntrimmed: String): Boolean = {
     val expected = expectedUntrimmed.trim
     val obtained = new String(
       java.nio.file.Files.readAllBytes(
@@ -34,44 +23,35 @@ TaskKey[Unit]("check") := {
         ))
     ).trim
 
-    val msg =
-      s"""File: $file
-         |Obtained output:
-         |$obtained
-         |Expected:
-         |$expected
-         |Diff:
-         |${obtained.diff(expected)}
-         |${expected.diff(obtained)}
-         |""".stripMargin
-    println(msg)
     if (obtained.diff(expected).nonEmpty ||
         expected.diff(obtained).nonEmpty) {
+      val msg =
+        s"""File: $file
+           |Obtained output:
+           |$obtained
+           |Expected:
+           |$expected
+           |Diff:
+           |${obtained.diff(expected)}
+           |${expected.diff(obtained)}
+           |""".stripMargin
       streams.value.log.error(file)
-      throw new Exception(msg)
+      streams.value.log.error(msg)
+      false
     } else {
       streams.value.log.success(file)
+      true
     }
   }
   val expected =
     """object Main {
-      |  implicit val x: Int = 23
+      |  implicit val x: Int = 2
       |  lazy val y = 2
       |  def main(args: Array[String]): Unit = {
       |    println("hello")
       |  }
       |}""".stripMargin
   val testExpected = expected.replaceFirst("Main", "TestMain")
-  Seq("", "p1/", "p3/").foreach { prefix =>
-    assertContentMatches(
-      prefix + "src/test/scala/Test.scala",
-      testExpected
-    )
-    assertContentMatches(
-      prefix + "src/main/scala/Test.scala",
-      expected
-    )
-  }
   val unchanged =
     """object Main {
       |  implicit val x = 2
@@ -81,16 +61,30 @@ TaskKey[Unit]("check") := {
       |  }
       |}
     """.stripMargin
-
   val unchangedTest = unchanged.replaceFirst("Main", "TestMain")
 
-  // 2.10 projects are left unchanged.
-  assertContentMatches(
-    "p2/src/main/scala/Test.scala",
-    unchanged
-  )
-  assertContentMatches(
-    "p2/src/test/scala/Test.scala",
-    unchangedTest
-  )
+  val results: Seq[Boolean] =
+    Seq("p1/", "p3/").flatMap { prefix =>
+      Seq(
+        assertContentMatches(
+          prefix + "src/test/scala/Test.scala",
+          testExpected
+        ),
+        assertContentMatches(
+          prefix + "src/main/scala/Test.scala",
+          expected
+        )
+      )
+    } ++ Seq(
+      // 2.10 projects are left unchanged.
+      assertContentMatches(
+        "p2/src/main/scala/Test.scala",
+        unchanged
+      ),
+      assertContentMatches(
+        "p2/src/test/scala/Test.scala",
+        unchangedTest
+      )
+    )
+  if (results.contains(false)) ??? // non-zero exit code
 }

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/basic/build.sbt
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/basic/build.sbt
@@ -1,6 +1,9 @@
 val commonSettings: Seq[Def.Setting[String]] = Seq(
   scalaVersion := "2.11.8"
 )
+
+scalafixConfig in ThisBuild := Some(baseDirectory.value / ".scalafix.conf")
+
 lazy val root = project
   .in(file("."))
   .settings(commonSettings)
@@ -31,17 +34,19 @@ TaskKey[Unit]("check") := {
         ))
     ).trim
 
-    if (obtained.diff(expected).nonEmpty) {
-      val msg =
-        s"""File: $file
-           |Obtained output:
-           |$obtained
-           |Expected:
-           |$expected
-           |Diff:
-           |${obtained.diff(expected)}
-           |${expected.diff(obtained)}
-           |""".stripMargin
+    val msg =
+      s"""File: $file
+         |Obtained output:
+         |$obtained
+         |Expected:
+         |$expected
+         |Diff:
+         |${obtained.diff(expected)}
+         |${expected.diff(obtained)}
+         |""".stripMargin
+    println(msg)
+    if (obtained.diff(expected).nonEmpty ||
+        expected.diff(obtained).nonEmpty) {
       streams.value.log.error(file)
       throw new Exception(msg)
     } else {

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/basic/p2/src/test/scala/Test.scala
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/basic/p2/src/test/scala/Test.scala
@@ -1,3 +1,7 @@
 object TestMain {
   implicit val x = 2
+  lazy val y = 2
+  def main(args: Array[String]) {
+    println("hello")
+  }
 }

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/basic/project/build.properties
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/basic/project/build.properties
@@ -1,1 +1,2 @@
 sbt.version=0.13.13
+

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/basic/src/main/java/Test.java
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/basic/src/main/java/Test.java
@@ -1,5 +1,0 @@
-class Test {
-  public static void main(String args[]) {
-    System.out.println("HELLO WORLD!!");
-  }
-}

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/basic/src/main/scala/Test.scala
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/basic/src/main/scala/Test.scala
@@ -1,7 +1,0 @@
-object Main {
-  implicit val x = 23
-  lazy val y = 2
-  def main(args: Array[String]) {
-    println("hello")
-  }
-}

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/basic/src/test/scala/Test.scala
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/basic/src/test/scala/Test.scala
@@ -1,7 +1,0 @@
-object TestMain {
-  implicit val x = 2
-  lazy val y = 2
-  def main(args: Array[String]) {
-    println("hello")
-  }
-}

--- a/scalafix-tests/src/test/scala/scalafix/tests/IntegrationPropertyTest.scala
+++ b/scalafix-tests/src/test/scala/scalafix/tests/IntegrationPropertyTest.scala
@@ -80,7 +80,7 @@ abstract class IntegrationPropertyTest(t: ItTest, skip: Boolean = false)
     write.append(
       t.workingPath / "project" / "plugins.sbt",
       s"""
-         |addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "${scalafix.Versions.nightly}")
+         |addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "${scalafix.Versions.version}")
          |""".stripMargin
     )
   }


### PR DESCRIPTION
My experience from scalafmt is that the configuration quickly grows and using a robust configuration from the start is useful. I went with HOCON because

- HOCON appears to be the least controversial choice in the Scala community
- I can automatically read HOCON into a case class using metaconfig from scalafmt (not implemented yet since config class is small)
