### PR TITLE
Exclude unused deps in sbt plugin

### DIFF
--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -46,10 +46,11 @@ object ScalafixPlugin extends AutoPlugin with ScalafixKeys {
         publishLocal := {},
         publish := {},
         publishArtifact := false,
+        publishMavenStyle := false, // necessary to support intransitive dependencies.
         scalaVersion := version,
-        libraryDependencies ++= Seq(
-          "ch.epfl.scala" %% "scalafix-nsc" % scalafixVersion
-        )
+        libraryDependencies := Nil, // remove injected dependencies from random sbt plugins.
+        libraryDependencies +=
+          ("ch.epfl.scala" %% "scalafix-nsc" % scalafixVersion).intransitive()
       )
   }
   private val scalafix211 = stub("2.11.8")


### PR DESCRIPTION
- removing unused dependencies injected by sbt plugins (e.g. DocTest).
  This prevents errors when using the sbt plugin on projects like
  refined.
- avoid unnecessary downloads on scalafix-nsc dependencies, since it's
  published as a fat jar.