### PR TITLE
Experimenting with scala.meta mirror

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -167,7 +167,6 @@ lazy val `scalafix-nsc` = project
       // integration property tests
       "org.typelevel"      %% "catalysts-platform" % "0.0.5"    % Test,
       "com.typesafe.slick" %% "slick"              % "3.2.0-M2" % Test,
-      "org.typelevel"      %% "cats-core"          % "0.7.2"    % Test,
       "com.chuusai"        %% "shapeless"          % "2.3.2"    % Test,
       "org.scalacheck"     %% "scalacheck"         % "1.13.4"   % Test
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -167,7 +167,6 @@ lazy val `scalafix-nsc` = project
       // integration property tests
       "org.typelevel"      %% "catalysts-platform" % "0.0.5"    % Test,
       "com.typesafe.slick" %% "slick"              % "3.2.0-M2" % Test,
-      "io.circe"           %% "circe-core"         % "0.6.0"    % Test,
       "org.typelevel"      %% "cats-core"          % "0.7.2"    % Test,
       "com.chuusai"        %% "shapeless"          % "2.3.2"    % Test,
       "org.scalacheck"     %% "scalacheck"         % "1.13.4"   % Test

--- a/core/src/main/scala/scalafix/rewrite/ExplicitImplicit.scala
+++ b/core/src/main/scala/scalafix/rewrite/ExplicitImplicit.scala
@@ -17,7 +17,7 @@ case object ExplicitImplicit extends Rewrite {
   }
   override def rewrite(ast: m.Tree, ctx: RewriteCtx): Seq[Patch] = {
     import scala.meta._
-    val semantic = getSemanticApi(ctx)
+    val semantic = getMirror(ctx)
     def fix(defn: Defn, body: Term): Seq[Patch] = {
       import ctx.tokenList._
       for {

--- a/core/src/main/scala/scalafix/rewrite/Rewrite.scala
+++ b/core/src/main/scala/scalafix/rewrite/Rewrite.scala
@@ -7,9 +7,10 @@ import scalafix.util.Patch
 import scala.collection.immutable.Seq
 
 abstract class Rewrite {
-  def getSemanticApi(ctx: RewriteCtx): ScalafixMirror = ctx.semantic.getOrElse {
-    throw MissingSemanticApi(this)
-  }
+  def getSemanticApi(ctx: RewriteCtx): ScalafixMirror =
+    ctx.semantic.getOrElse {
+      throw MissingSemanticApi(this)
+    }
   def rewrite(code: Tree, rewriteCtx: RewriteCtx): Seq[Patch]
 }
 
@@ -22,7 +23,10 @@ object Rewrite {
     ProcedureSyntax,
     VolatileLazyVal
   )
-  val semanticRewrites: Seq[Rewrite] = Seq(ExplicitImplicit)
+  val semanticRewrites: Seq[Rewrite] = Seq(
+    ExplicitImplicit,
+    Xor2Either
+  )
   val allRewrites: Seq[Rewrite] = syntaxRewrites ++ semanticRewrites
   val defaultRewrites: Seq[Rewrite] =
     allRewrites.filterNot(_ == VolatileLazyVal)

--- a/core/src/main/scala/scalafix/rewrite/Rewrite.scala
+++ b/core/src/main/scala/scalafix/rewrite/Rewrite.scala
@@ -7,10 +7,9 @@ import scalafix.util.Patch
 import scala.collection.immutable.Seq
 
 abstract class Rewrite {
-  def getSemanticApi(ctx: RewriteCtx): ScalafixMirror =
-    ctx.semantic.getOrElse {
-      throw MissingSemanticApi(this)
-    }
+  def getMirror(ctx: RewriteCtx): ScalafixMirror = ctx.semantic.getOrElse {
+    throw MissingSemanticApi(this)
+  }
   def rewrite(code: Tree, rewriteCtx: RewriteCtx): Seq[Patch]
 }
 

--- a/core/src/main/scala/scalafix/rewrite/Xor2Either.scala
+++ b/core/src/main/scala/scalafix/rewrite/Xor2Either.scala
@@ -1,0 +1,25 @@
+package scalafix.rewrite
+import scala.collection.immutable.Seq
+import scala.meta._
+import scalafix.util.Patch
+import scala.meta.internal.ast.Helpers._
+
+import org.scalameta.logger
+
+case object Xor2Either extends Rewrite {
+  override def rewrite(code: Tree, rewriteCtx: RewriteCtx): Seq[Patch] = {
+    implicit val semantic = getSemanticApi(rewriteCtx)
+    object traverser extends Traverser {
+      override def apply(tree: Tree): Unit = {
+        Importee
+        tree match {
+          case ref: Term.Ref if ref.isStableId =>
+            logger.elem(ref)
+          case _ => super.apply(tree)
+        }
+      }
+    }
+    traverser(code)
+    Nil
+  }
+}

--- a/core/src/main/scala/scalafix/rewrite/Xor2Either.scala
+++ b/core/src/main/scala/scalafix/rewrite/Xor2Either.scala
@@ -1,25 +1,37 @@
 package scalafix.rewrite
 import scala.collection.immutable.Seq
-import scala.meta._
-import scalafix.util.Patch
+import scala.meta.contrib._
 import scala.meta.internal.ast.Helpers._
-
-import org.scalameta.logger
+import scala.meta.{Symbol => _, _}
+import scala.meta.semantic.v1._
+import scalafix.syntax._
+import scalafix.util.TreeExtractors._
+import scalafix.util.Patch
+import scalafix.util.TreePatch._
+import scalafix.util.logger
 
 case object Xor2Either extends Rewrite {
   override def rewrite(code: Tree, rewriteCtx: RewriteCtx): Seq[Patch] = {
     implicit val semantic = getSemanticApi(rewriteCtx)
-    object traverser extends Traverser {
-      override def apply(tree: Tree): Unit = {
-        Importee
-        tree match {
-          case ref: Term.Ref if ref.isStableId =>
-            logger.elem(ref)
-          case _ => super.apply(tree)
-        }
-      }
-    }
-    traverser(code)
-    Nil
+    code.collectFirst {
+      case t: Term.Name
+          if semantic
+            .symbol(t)
+            .toOption
+            .exists(_.normalized == Symbol("_root_.cats.data.Xor.map.")) =>
+        AddGlobalImport(importer"cats.implicits._")
+    }.toList ++
+      Seq(
+        Replace(Symbol("_root_.cats.data.XorT."),
+                q"EitherT",
+                List(importer"cats.data.EitherT")),
+        Replace(Symbol("_root_.cats.data.Xor."), q"Either"),
+        Replace(Symbol("_root_.cats.data.Xor.Left."), q"Left"),
+        Replace(Symbol("_root_.cats.data.Xor.Right."), q"Right"),
+        Replace(Symbol("_root_.cats.data.XorFunctions.left."), q"Left"),
+        Replace(Symbol("_root_.cats.data.XorFunctions.right."), q"Right"),
+        RemoveGlobalImport(importer"cats.data.Xor"),
+        RemoveGlobalImport(importer"cats.data.XorT")
+      )
   }
 }

--- a/core/src/main/scala/scalafix/rewrite/Xor2Either.scala
+++ b/core/src/main/scala/scalafix/rewrite/Xor2Either.scala
@@ -12,7 +12,7 @@ import scalafix.util.logger
 
 case object Xor2Either extends Rewrite {
   override def rewrite(code: Tree, rewriteCtx: RewriteCtx): Seq[Patch] = {
-    implicit val semantic = getSemanticApi(rewriteCtx)
+    implicit val semantic = getMirror(rewriteCtx)
     code.collectFirst {
       case t: Term.Name
           if semantic

--- a/core/src/main/scala/scalafix/syntax/package.scala
+++ b/core/src/main/scala/scalafix/syntax/package.scala
@@ -1,7 +1,10 @@
 package scalafix
 
-import scala.meta.Importee
+import scala.meta._
+import scala.meta.semantic.v1.Completed
+import scala.meta.semantic.v1.Symbol
 import scala.meta.tokens.Token
+import scala.util.Try
 import scalafix.util.CanonicalImport
 import scalafix.util.ImportPatch
 import scalafix.util.logger
@@ -24,6 +27,23 @@ package object syntax {
     def getBoolOrElse(key: String, els: Boolean): Boolean =
       if (config.hasPath(key)) config.getBoolean(key)
       else els
+  }
+  implicit class XtensionCompleted[T](completed: Completed[T]) {
+    def toOption: Option[T] = completed match {
+      case Completed.Success(e) => Some(e)
+      case _ => None
+    }
+  }
+  implicit class XtensionSymbol(symbol: Symbol) {
+    def toTermRef: Option[Term.Ref] =
+      Try {
+        symbol.syntax
+          .stripPrefix("_root_.")
+          .stripSuffix(".")
+          .parse[Term]
+          .get
+          .asInstanceOf[Term.Ref]
+      }.toOption
   }
   implicit class XtensionString(str: String) {
     def reveal: String = logger.reveal(str)

--- a/core/src/main/scala/scalafix/syntax/package.scala
+++ b/core/src/main/scala/scalafix/syntax/package.scala
@@ -2,6 +2,7 @@ package scalafix
 
 import scala.meta._
 import scala.meta.semantic.v1.Completed
+import scala.meta.semantic.v1.Signature
 import scala.meta.semantic.v1.Symbol
 import scala.meta.tokens.Token
 import scala.util.Try
@@ -17,6 +18,14 @@ package object syntax {
       i.ref.structure == patch.importer.ref.structure &&
         (i.importee.is[Importee.Wildcard] ||
           i.importee.structure == patch.importee.structure)
+  }
+  implicit class XtensionTermRef(ref: Term.Ref) {
+    def toTypeRef: Type.Ref = ref match {
+      case Term.Name(name) => Type.Name(name)
+      case Term.Select(qual: Term.Ref, Term.Name(name)) =>
+        Type.Select(qual, Type.Name(name))
+      case _ => ref.syntax.parse[Type].get.asInstanceOf[Type.Ref]
+    }
   }
 
   implicit class XtensionToken(token: Token) {
@@ -35,17 +44,42 @@ package object syntax {
     }
   }
   implicit class XtensionSymbol(symbol: Symbol) {
-    def toTermRef: Option[Term.Ref] =
-      Try {
-        symbol.syntax
-          .stripPrefix("_root_.")
-          .stripSuffix(".")
-          .parse[Term]
-          .get
-          .asInstanceOf[Term.Ref]
-      }.toOption
+    def /(name: String): Symbol = symbol match {
+      case Symbol.Global(sym, term: Signature.Term) =>
+        Symbol.Global(Symbol.Global(sym, term), Signature.Term(name))
+    }
+
+    /** Returns simplified version of this Symbol.
+      *
+      * - No Symbol.Multi
+      * - No Signature.{Type,Method}
+      */
+    def normalized: Symbol = symbol match {
+      case Symbol.Multi(sym +: _) => sym.normalized
+      case Symbol.Global(sym, Signature.Type(name)) =>
+        Symbol.Global(sym, Signature.Term(name))
+      case Symbol.Global(Symbol.Global(sym, Signature.Term(name)),
+                         Signature.Method("apply", _)) =>
+        Symbol.Global(sym, Signature.Term(name))
+      case Symbol.Global(sym, Signature.Method(name, _)) =>
+        Symbol.Global(sym.normalized, Signature.Term(name))
+      case x => x
+    }
+
+    def to[T <: Tree]: T = {
+      val tree = symbol match {
+        case Symbol.Global(Symbol.None, Signature.Term(name)) =>
+          Term.Name(name)
+        case Symbol.Global(sym, Signature.Type(name)) =>
+          Type.Select(sym.to[Term.Ref], Type.Name(name))
+        case Symbol.Global(sym, Signature.Term(name)) =>
+          Term.Select(sym.to[Term], Term.Name(name))
+      }
+      tree.asInstanceOf[T] // crash intended
+    }
   }
   implicit class XtensionString(str: String) {
+    def asSymbol: Symbol = Symbol(s"_root_.$str")
     def reveal: String = logger.reveal(str)
   }
 }

--- a/core/src/main/scala/scalafix/util/OrganizeImports.scala
+++ b/core/src/main/scala/scalafix/util/OrganizeImports.scala
@@ -4,6 +4,7 @@ import scala.collection.immutable.Seq
 import scala.collection.mutable
 import scala.meta.Importee.Wildcard
 import scala.meta._
+import scala.meta.semantic.v1.Completed
 import scala.meta.tokens.Token.Comment
 import scalafix.FilterMatcher
 import scalafix.rewrite.RewriteCtx
@@ -105,10 +106,11 @@ private[this] class OrganizeImports private (implicit ctx: RewriteCtx) {
   def fullyQualify(imp: CanonicalImport): Option[Term.Ref] =
     for {
       semantic <- ctx.semantic
+//      sym <- semantic.symbol(imp.ref).toOption
+//      fqnRef <- sym.toTermRef
       fqnRef <- semantic.fqn(imp.ref)
       // Avoid inserting unneeded `package`
       if rootPkgName(fqnRef) != rootPkgName(imp.ref)
-      if fqnRef.is[Term.Ref]
     } yield fqnRef.asInstanceOf[Term.Ref]
 
   def groupImports(imports0: Seq[CanonicalImport]): Seq[Seq[Import]] = {

--- a/core/src/main/scala/scalafix/util/OrganizeImports.scala
+++ b/core/src/main/scala/scalafix/util/OrganizeImports.scala
@@ -106,6 +106,7 @@ private[this] class OrganizeImports private (implicit ctx: RewriteCtx) {
   def fullyQualify(imp: CanonicalImport): Option[Term.Ref] =
     for {
       semantic <- ctx.semantic
+      // TODO(olafur) switch to scala.meta mirror instead of scalafix homebrew.
 //      sym <- semantic.symbol(imp.ref).toOption
 //      fqnRef <- sym.toTermRef
       fqnRef <- semantic.fqn(imp.ref)

--- a/core/src/main/scala/scalafix/util/Patch.scala
+++ b/core/src/main/scala/scalafix/util/Patch.scala
@@ -2,15 +2,14 @@ package scalafix.util
 
 import scala.collection.immutable.Seq
 import scala.meta._
+import scala.meta.internal.ast.Helpers._
 import scala.meta.tokens.Token
 import scala.meta.tokens.Token
-import scalafix.ImportsConfig
-import scalafix.ScalafixConfig
 import scalafix.rewrite.RewriteCtx
+import scalafix.syntax._
 import scalafix.util.TokenPatch.Add
 import scalafix.util.TokenPatch.Remove
-import scalafix.syntax._
-
+import scalafix.util.TreePatch.Replace
 sealed abstract class Patch
 abstract class TreePatch extends Patch
 abstract class TokenPatch(val tok: Token, val newTok: String)
@@ -24,6 +23,12 @@ abstract class ImportPatch(val importer: Importer) extends TreePatch {
   def toImport: Import = Import(Seq(importer))
 }
 object TreePatch {
+  case class Replace(from: Symbol,
+                     to: Term.Ref,
+                     additionalImports: List[Importer] = Nil)
+      extends TreePatch {
+    require(to.isStableId)
+  }
   case class RemoveGlobalImport(override val importer: Importer)
       extends ImportPatch(importer)
   case class AddGlobalImport(override val importer: Importer)
@@ -60,11 +65,19 @@ object Patch {
   def apply(ast: Tree, patches: Seq[Patch])(implicit ctx: RewriteCtx): String = {
     val input = ast.tokens
     val tokenPatches = patches.collect { case e: TokenPatch => e }
-    val importPatches = OrganizeImports.organizeImports(ast, patches.collect {
-      case e: ImportPatch => e
+    val replacePatches = Replacer.toTokenPatches(ast, patches.collect {
+      case e: Replace => e
     })
+    val importPatches = OrganizeImports.organizeImports(
+      ast,
+      patches.collect { case e: ImportPatch => e } ++
+        replacePatches.collect { case e: ImportPatch => e }
+    )
+    val replaceTokenPatches = replacePatches.collect {
+      case t: TokenPatch => t
+    }
     val patchMap: Map[(Int, Int), String] =
-      (importPatches ++ tokenPatches)
+      (importPatches ++ tokenPatches ++ replaceTokenPatches)
         .groupBy(_.tok.posTuple)
         .mapValues(_.reduce(merge).newTok)
     input.toIterator

--- a/core/src/main/scala/scalafix/util/Patch.scala
+++ b/core/src/main/scala/scalafix/util/Patch.scala
@@ -22,6 +22,7 @@ abstract class ImportPatch(val importer: Importer) extends TreePatch {
   def importee: Importee = importer.importees.head
   def toImport: Import = Import(Seq(importer))
 }
+
 object TreePatch {
   case class Replace(from: Symbol,
                      to: Term.Ref,
@@ -29,6 +30,8 @@ object TreePatch {
       extends TreePatch {
     require(to.isStableId)
   }
+  // TODO(olafur) implement this
+  //  case class Rename(from: Symbol, to: Term.Name) extends TreePatch
   case class RemoveGlobalImport(override val importer: Importer)
       extends ImportPatch(importer)
   case class AddGlobalImport(override val importer: Importer)

--- a/core/src/main/scala/scalafix/util/Replacer.scala
+++ b/core/src/main/scala/scalafix/util/Replacer.scala
@@ -32,7 +32,6 @@ private[this] class Replacer(implicit ctx: RewriteCtx) {
             builder ++=
               replacements
                 .find { x =>
-//                  logger.elem(x.from.syntax, symbol.syntax)
                   x.from == symbol
                 }
                 .toList
@@ -53,5 +52,6 @@ private[this] class Replacer(implicit ctx: RewriteCtx) {
 object Replacer {
   def toTokenPatches(ast: Tree, replacements: Seq[Replace])(
       implicit ctx: RewriteCtx): Seq[Patch] =
-    new Replacer().toTokenPatches(ast, replacements)
+    if (replacements.isEmpty) Nil
+    else new Replacer().toTokenPatches(ast, replacements)
 }

--- a/core/src/main/scala/scalafix/util/Replacer.scala
+++ b/core/src/main/scala/scalafix/util/Replacer.scala
@@ -1,0 +1,57 @@
+package scalafix.util
+
+import scalafix.syntax._
+import scala.meta.{Symbol => _, _}
+import scala.meta.semantic.v1._
+import scala.collection.immutable.Seq
+import scalafix.rewrite.RewriteCtx
+import scalafix.util.TreePatch.Replace
+import scala.meta.internal.ast.Helpers._
+import scala.util.Try
+import scalafix.util.TreePatch.AddGlobalImport
+
+private[this] class Replacer(implicit ctx: RewriteCtx) {
+  private implicit val mirror = ctx.semantic.get
+  object `:withSymbol:` {
+    def unapply(ref: Ref): Option[(Ref, Symbol)] =
+      Try(
+        mirror.symbol(ref) match {
+          case Completed.Success(symbol) =>
+            Some(ref -> symbol.normalized)
+          case _ => None
+        }
+      ).toOption.flatten
+  }
+
+  def toTokenPatches(ast: Tree, replacements: Seq[Replace]): Seq[Patch] = {
+    val builder = Seq.newBuilder[Patch]
+    object traverser extends Traverser {
+      override def apply(tree: Tree): Unit = {
+        tree match {
+          case (ref: Ref) `:withSymbol:` symbol =>
+            builder ++=
+              replacements
+                .find { x =>
+//                  logger.elem(x.from.syntax, symbol.syntax)
+                  x.from == symbol
+                }
+                .toList
+                .flatMap(replace =>
+                  TokenPatch.AddLeft(ref.tokens.head, replace.to.syntax) +:
+                    (ref.tokens.map(TokenPatch.Remove.apply) ++
+                      replace.additionalImports.map(x => AddGlobalImport(x))))
+          case imp: Import => // Do nothing
+          case _ => super.apply(tree)
+        }
+      }
+    }
+    traverser(ast)
+    builder.result()
+  }
+
+}
+object Replacer {
+  def toTokenPatches(ast: Tree, replacements: Seq[Replace])(
+      implicit ctx: RewriteCtx): Seq[Patch] =
+    new Replacer().toTokenPatches(ast, replacements)
+}

--- a/core/src/main/scala/scalafix/util/TreeExtractors.scala
+++ b/core/src/main/scala/scalafix/util/TreeExtractors.scala
@@ -1,0 +1,9 @@
+package scalafix.util
+import scala.meta._
+object TreeExtractors {
+  object `:WithParent:` {
+    def unapply(tree: Tree): Option[(Tree, Tree)] =
+      tree.parent.map(parent => tree -> parent)
+  }
+
+}

--- a/core/src/main/scala/scalafix/util/TreeExtractors.scala
+++ b/core/src/main/scala/scalafix/util/TreeExtractors.scala
@@ -5,5 +5,4 @@ object TreeExtractors {
     def unapply(tree: Tree): Option[(Tree, Tree)] =
       tree.parent.map(parent => tree -> parent)
   }
-
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,7 +5,7 @@ style = defaultWithAlign
 }*/
 
 object Build {
-  val scalametaV = "1.6.0-671"
+  val scalametaV = "1.6.0-654"
   val ammoniteV  = "0.8.2"
   val scalatestV = "3.0.0"
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,7 +5,7 @@ style = defaultWithAlign
 }*/
 
 object Build {
-  val scalametaV = "1.6.0-652.1486561574113"
+  val scalametaV = "1.6.0-671"
   val ammoniteV  = "0.8.2"
   val scalatestV = "3.0.0"
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,12 +5,13 @@ style = defaultWithAlign
 }*/
 
 object Build {
-  val scalametaV = "1.6.0-641"
+  val scalametaV = "1.6.0-652.1486561574113"
   val ammoniteV  = "0.8.2"
   val scalatestV = "3.0.0"
 }
 
 object Dependencies {
+  var testClasspath: String = "empty"
   import Build._
   def scalahost(scalaVersion: String): ModuleID = "org.scalameta" % s"scalahost_$scalaVersion" % scalametaV
   def scalameta: ModuleID                       = "org.scalameta" %% "contrib"                 % scalametaV

--- a/scalafix-nsc/src/main/scala/scalafix/nsc/NscScalafixMirror.scala
+++ b/scalafix-nsc/src/main/scala/scalafix/nsc/NscScalafixMirror.scala
@@ -54,7 +54,7 @@ trait NscScalafixMirror extends ReflectToolkit with HijackImportInfos {
     val builder = mutable.Map.empty[Int, m.Type]
     def add(gtree: g.Tree, ctx: SemanticContext): Unit = {
 
-      /** Removes redudant Foo.this.ActualType prefix from a type */
+      // Removes redudant Foo.this.ActualType prefix from a type
       val stripRedundantThis: m.Type => m.Type = _.transform {
         case m.Term.Select(m.Term.This(m.Name.Indeterminate(_)), qual) =>
           qual

--- a/scalafix-nsc/src/main/scala/scalafix/nsc/ScalafixNscComponent.scala
+++ b/scalafix-nsc/src/main/scala/scalafix/nsc/ScalafixNscComponent.scala
@@ -43,7 +43,6 @@ class ScalafixNscComponent(plugin: Plugin,
     override def name: String = "scalafix"
     override def run(): Unit = {
       implicit val mirror = new Mirror(global)
-      mirror.database
       global.currentRun.units.foreach { unit =>
         try {
           runOn(unit)

--- a/scalafix-nsc/src/main/scala/scalafix/nsc/ScalafixNscComponent.scala
+++ b/scalafix-nsc/src/main/scala/scalafix/nsc/ScalafixNscComponent.scala
@@ -1,18 +1,17 @@
 package scalafix.nsc
 
-import scala.collection.mutable
+import scala.meta.internal.scalahost.v1.online.Mirror
 import scala.meta.semantic.v1
+import scala.meta.semantic.v1._
 import scala.tools.nsc.Global
 import scala.tools.nsc.Phase
 import scala.tools.nsc.plugins.Plugin
 import scala.tools.nsc.plugins.PluginComponent
-import scala.tools.nsc.typechecker.Contexts
 import scala.util.control.NonFatal
 import scalafix.Failure.ParseError
 import scalafix.ScalafixConfig
 import scalafix.util.FileOps
 import scalafix.util.logger
-import scala.meta.internal.scalahost.v1.online.Mirror
 
 class ScalafixNscComponent(plugin: Plugin,
                            val global: Global,
@@ -20,14 +19,14 @@ class ScalafixNscComponent(plugin: Plugin,
     extends PluginComponent
     with ReflectToolkit
     with NscScalafixMirror {
-
   // warnUnusedImports could be set triggering a compiler error
   // if fatal warnings is also enabled.
   g.settings.warnUnusedImport.tryToSetFromPropertyValue("true")
   g.settings.fatalWarnings.tryToSetFromPropertyValue("false")
 
   override val phaseName: String = "scalafix"
-  override val runsAfter: List[String] = "typer" :: Nil
+  override val runsRightAfter: Option[String] = Some("typer")
+  override val runsAfter: List[String] = Nil
 
   private def runOn(unit: g.CompilationUnit)(implicit mirror: Mirror): Unit = {
     if (unit.source.file.exists &&

--- a/scalafix-nsc/src/main/scala/scalafix/nsc/ScalafixNscComponent.scala
+++ b/scalafix-nsc/src/main/scala/scalafix/nsc/ScalafixNscComponent.scala
@@ -43,6 +43,7 @@ class ScalafixNscComponent(plugin: Plugin,
     override def name: String = "scalafix"
     override def run(): Unit = {
       implicit val mirror = new Mirror(global)
+      mirror.database
       global.currentRun.units.foreach { unit =>
         try {
           runOn(unit)

--- a/scalafix-nsc/src/main/scala/scalafix/nsc/ScalafixNscPlugin.scala
+++ b/scalafix-nsc/src/main/scala/scalafix/nsc/ScalafixNscPlugin.scala
@@ -19,6 +19,7 @@ class ScalafixNscPlugin(val global: Global) extends Plugin {
   // It seems warn-unused-imports still uses the old g.analyzer to collect import infos.
   scalafixComponent.hijackImportInfos()
   private val scalahostPlugin = new ScalahostPlugin(global) // let scalahost hijack global
+  global.settings.plugin.appendToValue("scalahost")
   val mirror = new Mirror(global)
   val name = "scalafix"
   val description = "Refactoring tool."

--- a/scalafix-nsc/src/main/scala/scalafix/nsc/ScalafixNscPlugin.scala
+++ b/scalafix-nsc/src/main/scala/scalafix/nsc/ScalafixNscPlugin.scala
@@ -18,8 +18,12 @@ class ScalafixNscPlugin(val global: Global) extends Plugin {
   // original global.analyzer instead of the Scalahost hijacked analyzer.
   // It seems warn-unused-imports still uses the old g.analyzer to collect import infos.
   scalafixComponent.hijackImportInfos()
+  // manually configure scalahost plugin. We could force users to pass in -Xplugin/scalahost.jar,
+  // but that would complicate integrations and give us less control over in which order
+  // hijacking happens.
   private val scalahostPlugin = new ScalahostPlugin(global) // let scalahost hijack global
   global.settings.plugin.appendToValue("scalahost")
+
   val mirror = new Mirror(global)
   val name = "scalafix"
   val description = "Refactoring tool."

--- a/scalafix-nsc/src/test/resources/syntactic/Xor2Either.source
+++ b/scalafix-nsc/src/test/resources/syntactic/Xor2Either.source
@@ -1,0 +1,36 @@
+rewrites = [Xor2Either]
+<<< ONLY xor 1
+import scala.concurrent.Future
+import cats.data.{ Xor, XorT }
+trait A {
+type MyDisjunction = Xor[Int, String]
+  val r: MyDisjunction = Xor.Right.apply("")
+  val s: Xor[Int, String] = cats.data.Xor.Left(1 /* comment */)
+  val t: Xor[Int, String] = r.map(_ + "!")
+  val nest: Seq[Xor[Int, cats.data.Xor[String, Int]]]
+  val u: XorT[Future, Int, String] = ???
+}
+>>>
+import cats.data.EitherT
+import cats.implicits._
+import scala.util.Either
+import scala.concurrent.Future
+import cats.data.{ Xor, XorT }
+trait A {
+type MyDisjunction = Either[Int, String]
+  val r: MyDisjunction = Right("")
+  val s: Either[Int, String] = Left(1 /* comment */)
+  val t: Either[Int, String] = r.map(_ + "!")
+  val nest: Seq[Either[Int, Either[String, Int]]]
+  val u: EitherT[Future, Int, String] = ???
+}
+<<< xor do not modify when not present
+import scala.concurrent.Future
+trait A {
+  val num = 1
+}
+>>>
+import scala.concurrent.Future
+trait A {
+  val num = 1
+}

--- a/scalafix-nsc/src/test/resources/syntactic/Xor2Either.source
+++ b/scalafix-nsc/src/test/resources/syntactic/Xor2Either.source
@@ -1,5 +1,5 @@
 rewrites = [Xor2Either]
-<<< ONLY xor 1
+<<< xor 1
 import scala.concurrent.Future
 import cats.data.{ Xor, XorT }
 trait A {
@@ -11,11 +11,10 @@ type MyDisjunction = Xor[Int, String]
   val u: XorT[Future, Int, String] = ???
 }
 >>>
+import scala.concurrent.Future
+
 import cats.data.EitherT
 import cats.implicits._
-import scala.util.Either
-import scala.concurrent.Future
-import cats.data.{ Xor, XorT }
 trait A {
 type MyDisjunction = Either[Int, String]
   val r: MyDisjunction = Right("")
@@ -24,13 +23,22 @@ type MyDisjunction = Either[Int, String]
   val nest: Seq[Either[Int, Either[String, Int]]]
   val u: EitherT[Future, Int, String] = ???
 }
-<<< xor do not modify when not present
-import scala.concurrent.Future
-trait A {
-  val num = 1
+<<< no implicits
+object a { val x = cats.data.Xor.left[String, Int]("str") }
+>>>
+object a { val x = Left[String, Int]("str") }
+<<< SKIP .right
+import cats.data.Xor
+class a {
+  val x: Xor[Int, String] = Xor.right("foo")
+  for {
+    y <- x
+  } yield y
 }
 >>>
-import scala.concurrent.Future
-trait A {
-  val num = 1
+class a {
+  val x: Either[Int, String] = Right("foo")
+  for {
+    y <- x.right
+  } yield y
 }

--- a/scalafix-nsc/src/test/scala/cats/data/Xor.scala
+++ b/scalafix-nsc/src/test/scala/cats/data/Xor.scala
@@ -1,0 +1,20 @@
+package cats.data
+import scala.language.higherKinds
+
+sealed abstract class Xor[+A, +B] extends Product with Serializable {
+  def map[C](f: B => C) = ???
+}
+
+object Xor extends XorFunctions {
+  final case class Left[+A](a: A) extends (A Xor Nothing)
+  final case class Right[+B](b: B) extends (Nothing Xor B)
+}
+
+trait XorFunctions {
+  def left[A, B](a: A): A Xor B = Xor.Left(a)
+  def right[A, B](b: B): A Xor B = Xor.Right(b)
+}
+
+sealed abstract class XorT[F[_], A, B](value: F[A Xor B])
+
+sealed abstract class EitherT[F[_], A, B](value: F[Either[A, B]])

--- a/scalafix-nsc/src/test/scala/cats/implicits.scala
+++ b/scalafix-nsc/src/test/scala/cats/implicits.scala
@@ -1,0 +1,9 @@
+package cats
+
+import scala.language.implicitConversions
+
+package object implicits {
+  implicit class EitherOps[A, B](from: Either[A, B]) {
+    def map[C](f: B => C): Either[A, C] = ???
+  }
+}

--- a/scalafix-nsc/src/test/scala/scalafix/SemanticTests.scala
+++ b/scalafix-nsc/src/test/scala/scalafix/SemanticTests.scala
@@ -32,7 +32,6 @@ class SemanticTests extends FunSuite with DiffAssertions { self =>
     def fail(msg: String) =
       sys.error(s"ReflectToMeta initialization failed: $msg")
     val classpath = System.getProperty("sbt.paths.scalafixNsc.test.classes")
-//    logger.elem(classpath)
     val scalacOptions = Seq(
       "-cp",
       classpath,

--- a/scalafix-nsc/src/test/scala/scalafix/SemanticTests.scala
+++ b/scalafix-nsc/src/test/scala/scalafix/SemanticTests.scala
@@ -2,9 +2,9 @@ package scalafix
 
 import scala.collection.immutable.Seq
 import scala.meta.Term
-import scala.meta.internal.scalahost.v1.online.Mirror
 import scala.meta.contrib._
 import scala.meta.internal.scalahost.ScalahostPlugin
+import scala.meta.internal.scalahost.v1.online.Mirror
 import scala.meta.semantic.v1.Database
 import scala.reflect.io.AbstractFile
 import scala.tools.cmd.CommandLineParser
@@ -22,8 +22,6 @@ import scalafix.util.logger
 
 import java.io.File
 import java.io.PrintWriter
-import java.nio.file.Files
-import java.nio.file.Paths
 
 import org.scalatest.FunSuite
 
@@ -34,15 +32,15 @@ class SemanticTests extends FunSuite with DiffAssertions { self =>
     def fail(msg: String) =
       sys.error(s"ReflectToMeta initialization failed: $msg")
     val classpath = System.getProperty("sbt.paths.scalafixNsc.test.classes")
-    val pluginpath = System.getProperty("sbt.paths.plugin.jar")
+//    logger.elem(classpath)
     val scalacOptions = Seq(
+      "-cp",
+      classpath,
       "-Yrangepos",
       "-Ywarn-unused-import"
     ).mkString(" ", " ", " ")
-    val options = "-cp " + classpath + " -Xplugin:" + pluginpath + ":" +
-        classpath + " -Xplugin-require:scalafix" + scalacOptions
 
-    val args = CommandLineParser.tokenize(options)
+    val args = CommandLineParser.tokenize(scalacOptions)
     val emptySettings = new Settings(
       error => fail(s"couldn't apply settings because $error"))
     val reporter = new StoreReporter()

--- a/scalafix-tests/src/test/scala/scalafix/tests/IntegrationPropertyTest.scala
+++ b/scalafix-tests/src/test/scala/scalafix/tests/IntegrationPropertyTest.scala
@@ -82,7 +82,8 @@ abstract class IntegrationPropertyTest(t: ItTest, skip: Boolean = false)
         ) ++ cmds.map(_.toString)
       failAfter(maxTime) {
         import sys.process._
-        Process(args, cwd = t.workingPath.toIO).!
+        val status = Process(args, cwd = t.workingPath.toIO).!
+        assert(status == 0)
       }
       logger.info(s"Completed $id")
     }

--- a/scalafix-tests/src/test/scala/scalafix/tests/IntegrationPropertyTest.scala
+++ b/scalafix-tests/src/test/scala/scalafix/tests/IntegrationPropertyTest.scala
@@ -127,7 +127,6 @@ class Slick
         name = "slick",
         repo = "https://github.com/slick/slick.git",
         rewrites = Seq(),
-        testPatch = true,
         hash = "bd3c24be419ff2791c123067668c81e7de858915"
       ),
       skip = false

--- a/scalafix-tests/src/test/scala/scalafix/tests/ItTest.scala
+++ b/scalafix-tests/src/test/scala/scalafix/tests/ItTest.scala
@@ -7,14 +7,15 @@ import java.io.File
 
 import ammonite.ops.Path
 
-case class ItTest(name: String,
-                  repo: String,
-                  hash: String,
-                  config: String = "",
-                  commands: Seq[Command] = Command.default,
-                  rewrites: Seq[Rewrite] = Rewrite.defaultRewrites,
-                  addCoursier: Boolean = true,
-                  testPatch: Boolean = false) {
+case class ItTest(
+    name: String,
+    repo: String,
+    hash: String,
+    config: String = "",
+    commands: Seq[Command] = Command.default,
+    rewrites: Seq[Rewrite] = Rewrite.defaultRewrites,
+    addCoursier: Boolean = true
+) {
   def repoName: String = repo match {
     case Command.RepoName(x) => x
     case _ =>


### PR DESCRIPTION
This PR integrates the scala.meta mirror even more tightly into scalafix. It includes an example Xor2Either rewrite using the Symbol/Signature API.

cc/ #29 @ShaneDelmore 