### PR TITLE
Refactor rewrite api.

### DIFF
--- a/cli/src/main/scala/scalafix/cli/ArgParserImplicits.scala
+++ b/cli/src/main/scala/scalafix/cli/ArgParserImplicits.scala
@@ -1,6 +1,7 @@
 package scalafix.cli
 
 import scalafix.rewrite.Rewrite
+import scalafix.rewrite.ScalafixRewrite
 
 import java.io.InputStream
 import java.io.PrintStream
@@ -9,15 +10,15 @@ import caseapp.core.ArgParser
 
 object ArgParserImplicits {
 
-  implicit val rewriteRead: ArgParser[Rewrite] = ArgParser.instance[Rewrite] {
-    str =>
+  implicit val rewriteRead: ArgParser[ScalafixRewrite] =
+    ArgParser.instance[ScalafixRewrite] { str =>
       Rewrite.name2rewrite.get(str) match {
         case Some(x) => Right(x)
         case _ =>
           val availableKeys = Rewrite.name2rewrite.keys.mkString(", ")
           Left(s"invalid input $str, must be one of $availableKeys")
       }
-  }
+    }
 
   implicit val inputStreamRead: ArgParser[InputStream] =
     ArgParser.instance[InputStream](x => Right(System.in))

--- a/cli/src/main/scala/scalafix/cli/Cli.scala
+++ b/cli/src/main/scala/scalafix/cli/Cli.scala
@@ -16,6 +16,7 @@ import ArgParserImplicits._
 import scala.util.control.NonFatal
 import scalafix.Fixed
 import scalafix.cli.termdisplay.TermDisplay
+import scalafix.rewrite.ScalafixRewrite
 
 import caseapp._
 import caseapp.core.Messages
@@ -35,7 +36,7 @@ case class CommonOptions(
 case class ScalafixOptions(
     @HelpMessage(
       s"Rules to run, one of: ${Rewrite.allRewrites.mkString(", ")}"
-    ) rewrites: List[Rewrite] = Rewrite.syntaxRewrites.toList,
+    ) rewrites: List[ScalafixRewrite] = Rewrite.syntaxRewrites.toList,
     @Hidden @HelpMessage(
       "Files to fix. Runs on all *.scala files if given a directory."
     ) @ExtraName("f") files: List[String] = List.empty[String],

--- a/core/src/main/scala/scalafix/Failure.scala
+++ b/core/src/main/scala/scalafix/Failure.scala
@@ -6,12 +6,7 @@ import scalafix.rewrite.Rewrite
 class Failure(e: Throwable) extends Exception(e.getMessage)
 
 object Failure {
-
   case class ParseError(pos: Position, message: String, exception: Throwable)
       extends Failure(exception)
-  case class MissingSemanticApi(rewrite: Rewrite)
-      extends Failure(new IllegalStateException(
-        s"The semantic API is required to run rewrite $rewrite. " +
-          s"Use the scalafix-nsc compiler plugin to access the semantic API."))
   case class Unexpected(e: Throwable) extends Failure(e)
 }

--- a/core/src/main/scala/scalafix/Scalafix.scala
+++ b/core/src/main/scala/scalafix/Scalafix.scala
@@ -5,10 +5,9 @@ import scala.meta._
 import scala.meta.inputs.Input
 import scala.meta.parsers.Parsed
 import scalafix.rewrite.RewriteCtx
+import scalafix.rewrite.ScalafixCtx
 import scalafix.rewrite.ScalafixMirror
-import scalafix.util.AssociatedComments
 import scalafix.util.Patch
-import scalafix.util.TokenList
 
 object Scalafix {
   def fix(code: Input,
@@ -25,8 +24,11 @@ object Scalafix {
           config: ScalafixConfig,
           semanticApi: Option[ScalafixMirror]): Fixed = {
     val tokens = ast.tokens
-    implicit val ctx = RewriteCtx.fromCode(ast, config, semanticApi)
-    val patches = config.rewrites.flatMap(_.rewrite(ast, ctx))
+    implicit val ctx: ScalafixCtx = RewriteCtx(
+      ast,
+      config,
+      semanticApi.getOrElse(ScalafixMirror.empty(config.dialect)))
+    val patches = config.rewrites.flatMap(_.rewrite(ctx))
     Fixed.Success(Patch.apply(ast, patches))
   }
 

--- a/core/src/main/scala/scalafix/ScalafixConfig.scala
+++ b/core/src/main/scala/scalafix/ScalafixConfig.scala
@@ -6,6 +6,8 @@ import scala.meta.dialects.Scala211
 import scala.meta.parsers.Parse
 import scala.util.control.NonFatal
 import scalafix.rewrite.Rewrite
+import scalafix.rewrite.ScalafixCtx
+import scalafix.rewrite.ScalafixRewrite
 import scalafix.syntax._
 
 import java.io.File
@@ -31,7 +33,7 @@ object ImportsConfig {
   def default: ImportsConfig = ImportsConfig()
 }
 case class ScalafixConfig(
-    rewrites: Seq[Rewrite] = Rewrite.defaultRewrites,
+    rewrites: Seq[ScalafixRewrite] = Rewrite.defaultRewrites,
     parser: Parse[_ <: Tree] = Parse.parseSource,
     imports: ImportsConfig = ImportsConfig(),
     fatalWarning: Boolean = true,
@@ -81,7 +83,7 @@ object ScalafixConfig {
     else Right(ScalafixConfig())
   }
 
-  def fromNames(names: List[String]): Either[String, Seq[Rewrite]] =
+  def fromNames(names: List[String]): Either[String, Seq[ScalafixRewrite]] =
     names match {
       case "all" :: Nil => Right(Rewrite.allRewrites)
       case _ =>

--- a/core/src/main/scala/scalafix/rewrite/ProcedureSyntax.scala
+++ b/core/src/main/scala/scalafix/rewrite/ProcedureSyntax.scala
@@ -10,10 +10,10 @@ import scalafix.util.Patch
 import scala.collection.immutable.Seq
 import scalafix.util.TokenPatch
 
-case object ProcedureSyntax extends Rewrite {
-  override def rewrite(ast: Tree, ctx: RewriteCtx): Seq[Patch] = {
+class ProcedureSyntax[T]() extends Rewrite[T] {
+  override def rewrite(ctx: RewriteCtx[T]): Seq[Patch] = {
     import ctx.tokenList._
-    val patches: Seq[Patch] = ast.collect {
+    val patches: Seq[Patch] = ctx.tree.collect {
       case t: Defn.Def
           if t.decltpe.exists(_.tokens.isEmpty) &&
             t.body.tokens.head.is[LeftBrace] =>
@@ -33,4 +33,8 @@ case object ProcedureSyntax extends Rewrite {
     }
     patches
   }
+}
+
+object ProcedureSyntax {
+  def apply[T](): Rewrite[T] = new ProcedureSyntax[T]()
 }

--- a/core/src/main/scala/scalafix/rewrite/ProcedureSyntax.scala
+++ b/core/src/main/scala/scalafix/rewrite/ProcedureSyntax.scala
@@ -36,5 +36,6 @@ class ProcedureSyntax[T]() extends Rewrite[T] {
 }
 
 object ProcedureSyntax {
+  val default: ScalafixRewrite = apply()
   def apply[T](): Rewrite[T] = new ProcedureSyntax[T]()
 }

--- a/core/src/main/scala/scalafix/rewrite/Rewrite.scala
+++ b/core/src/main/scala/scalafix/rewrite/Rewrite.scala
@@ -1,16 +1,12 @@
 package scalafix.rewrite
 
-import scala.meta._
-import scalafix.Failure.MissingSemanticApi
-import scalafix.util.TreePatch
-import scalafix.util.Patch
 import scala.collection.immutable.Seq
+import scala.meta._
+import scalafix.util.Patch
 
-abstract class Rewrite {
-  def getMirror(ctx: RewriteCtx): ScalafixMirror = ctx.semantic.getOrElse {
-    throw MissingSemanticApi(this)
-  }
-  def rewrite(code: Tree, rewriteCtx: RewriteCtx): Seq[Patch]
+abstract class Rewrite[T](implicit sourceName: sourcecode.Name) {
+  def name: String = sourceName.value
+  def rewrite(ctx: RewriteCtx[T]): Seq[Patch]
 }
 
 object Rewrite {
@@ -18,17 +14,17 @@ object Rewrite {
     t.map(x => x.source -> x.value).toMap
   }
 
-  val syntaxRewrites: Seq[Rewrite] = Seq(
-    ProcedureSyntax,
-    VolatileLazyVal
+  val syntaxRewrites: Seq[ScalafixRewrite] = Seq(
+    ProcedureSyntax(),
+    VolatileLazyVal()
   )
-  val semanticRewrites: Seq[Rewrite] = Seq(
+  val semanticRewrites: Seq[ScalafixRewrite] = Seq(
     ExplicitImplicit,
     Xor2Either
   )
-  val allRewrites: Seq[Rewrite] = syntaxRewrites ++ semanticRewrites
-  val defaultRewrites: Seq[Rewrite] =
+  val allRewrites: Seq[ScalafixRewrite] = syntaxRewrites ++ semanticRewrites
+  val defaultRewrites: Seq[ScalafixRewrite] =
     allRewrites.filterNot(_ == VolatileLazyVal)
-  val name2rewrite: Map[String, Rewrite] =
-    allRewrites.map(x => x.toString -> x).toMap
+  val name2rewrite: Map[String, ScalafixRewrite] =
+    allRewrites.map(x => x.name -> x).toMap
 }

--- a/core/src/main/scala/scalafix/rewrite/Rewrite.scala
+++ b/core/src/main/scala/scalafix/rewrite/Rewrite.scala
@@ -15,8 +15,8 @@ object Rewrite {
   }
 
   val syntaxRewrites: Seq[ScalafixRewrite] = Seq(
-    ProcedureSyntax(),
-    VolatileLazyVal()
+    ProcedureSyntax.default,
+    VolatileLazyVal.default
   )
   val semanticRewrites: Seq[ScalafixRewrite] = Seq(
     ExplicitImplicit,
@@ -24,7 +24,7 @@ object Rewrite {
   )
   val allRewrites: Seq[ScalafixRewrite] = syntaxRewrites ++ semanticRewrites
   val defaultRewrites: Seq[ScalafixRewrite] =
-    allRewrites.filterNot(_ == VolatileLazyVal)
+    allRewrites.filterNot(_ == VolatileLazyVal.default)
   val name2rewrite: Map[String, ScalafixRewrite] =
     allRewrites.map(x => x.name -> x).toMap
 }

--- a/core/src/main/scala/scalafix/rewrite/RewriteCtx.scala
+++ b/core/src/main/scala/scalafix/rewrite/RewriteCtx.scala
@@ -5,25 +5,15 @@ import scalafix.ScalafixConfig
 import scalafix.util.AssociatedComments
 import scalafix.util.TokenList
 
-case class RewriteCtx(
-    config: ScalafixConfig,
-    tokens: Tokens,
-    tokenList: TokenList,
-    comments: AssociatedComments,
-    semantic: Option[ScalafixMirror]
-)
+class RewriteCtx[T](implicit val tree: Tree,
+                    val config: ScalafixConfig,
+                    val mirror: T) {
+  implicit lazy val tokens: Tokens = tree.tokens(config.dialect)
+  implicit lazy val tokenList: TokenList = new TokenList(tokens)
+  implicit lazy val comments: AssociatedComments = AssociatedComments(tokens)
+}
 
 object RewriteCtx {
-  def fromCode(ast: Tree,
-               config: ScalafixConfig = ScalafixConfig(),
-               semanticApi: Option[ScalafixMirror] = None): RewriteCtx = {
-    val tokens = ast.tokens(config.dialect)
-    RewriteCtx(
-      config,
-      tokens,
-      new TokenList(tokens),
-      AssociatedComments(tokens),
-      semanticApi
-    )
-  }
+  def apply[T](tree: Tree, config: ScalafixConfig, mirror: T): RewriteCtx[T] =
+    new RewriteCtx()(tree, config, mirror)
 }

--- a/core/src/main/scala/scalafix/rewrite/ScalafixMirror.scala
+++ b/core/src/main/scala/scalafix/rewrite/ScalafixMirror.scala
@@ -5,6 +5,8 @@ import scala.meta._
 import scala.meta.semantic.v1.Completed
 import scala.meta.semantic.v1.Database
 
+import sourcecode.Enclosing
+
 /** An extension to scala.meta Mirror with custom methods for scalafix rewrites.
   *
   * We should try to contribute all useful methods upstream to scala.meta.
@@ -22,4 +24,31 @@ trait ScalafixMirror extends Mirror {
   /** Returns true if importee is not used in this compilation unit, false otherwise */
   def isUnusedImport(importee: Importee): Boolean
 
+}
+
+object ScalafixMirror {
+  private def error(implicit enclosing: Enclosing) =
+    new UnsupportedOperationException(
+      s"${enclosing.value} requires the semantic api,")
+  private def unsupported(implicit enclosing: Enclosing) = throw error
+
+  def fromMirror(mirror: Mirror): ScalafixMirror = new ScalafixMirror {
+    override def fqn(name: Ref): Nothing = unsupported
+    override def isUnusedImport(importee: Importee): Nothing = unsupported
+    override def typeSignature(defn: Defn): Option[Type] = unsupported
+    override def dialect: Dialect = mirror.dialect
+    override def sources: Seq[Source] = mirror.sources
+    override def database: Database = mirror.database
+    override def symbol(ref: Ref): Completed[Symbol] = mirror.symbol(ref)
+  }
+
+  def empty(implicit dialect: Dialect): ScalafixMirror = new ScalafixMirror {
+    override def fqn(name: Ref): Option[Ref] = None
+    override def isUnusedImport(importee: Importee): Boolean = false
+    override def typeSignature(defn: Defn): Option[Type] = None
+    override def sources = Nil
+    override def dialect: Dialect = dialect
+    override def database: Database = Database()
+    override def symbol(ref: Ref): Completed[Symbol] = Completed.Error(error)
+  }
 }

--- a/core/src/main/scala/scalafix/rewrite/VolatileLazyVal.scala
+++ b/core/src/main/scala/scalafix/rewrite/VolatileLazyVal.scala
@@ -25,5 +25,6 @@ class VolatileLazyVal[T]() extends Rewrite[T] {
 }
 
 object VolatileLazyVal {
+  val default: ScalafixRewrite = apply[ScalafixMirror]()
   def apply[T](): VolatileLazyVal[T] = new VolatileLazyVal[T]()
 }

--- a/core/src/main/scala/scalafix/rewrite/VolatileLazyVal.scala
+++ b/core/src/main/scala/scalafix/rewrite/VolatileLazyVal.scala
@@ -5,7 +5,7 @@ import scalafix.util.Patch
 import scala.collection.immutable.Seq
 import scalafix.util.TokenPatch
 
-case object VolatileLazyVal extends Rewrite {
+class VolatileLazyVal[T]() extends Rewrite[T] {
   private object NonVolatileLazyVal {
     def unapply(defn: Defn.Val): Option[Token] = {
       defn.mods.collectFirst {
@@ -16,10 +16,14 @@ case object VolatileLazyVal extends Rewrite {
       }
     }.flatten
   }
-  override def rewrite(ast: Tree, ctx: RewriteCtx): Seq[Patch] = {
-    ast.collect {
+  override def rewrite(ctx: RewriteCtx[T]): Seq[Patch] = {
+    ctx.tree.collect {
       case NonVolatileLazyVal(tok) =>
         TokenPatch.AddLeft(tok, s"@volatile ")
     }
   }
+}
+
+object VolatileLazyVal {
+  def apply[T](): VolatileLazyVal[T] = new VolatileLazyVal[T]()
 }

--- a/core/src/main/scala/scalafix/rewrite/Xor2Either.scala
+++ b/core/src/main/scala/scalafix/rewrite/Xor2Either.scala
@@ -10,12 +10,12 @@ import scalafix.util.Patch
 import scalafix.util.TreePatch._
 import scalafix.util.logger
 
-case object Xor2Either extends Rewrite {
-  override def rewrite(code: Tree, rewriteCtx: RewriteCtx): Seq[Patch] = {
-    implicit val semantic = getMirror(rewriteCtx)
-    code.collectFirst {
+case object Xor2Either extends Rewrite[ScalafixMirror] {
+  override def rewrite(ctx: ScalafixCtx): Seq[Patch] = {
+    import ctx._
+    tree.collectFirst {
       case t: Term.Name
-          if semantic
+          if mirror
             .symbol(t)
             .toOption
             .exists(_.normalized == Symbol("_root_.cats.data.Xor.map.")) =>

--- a/core/src/main/scala/scalafix/rewrite/package.scala
+++ b/core/src/main/scala/scalafix/rewrite/package.scala
@@ -1,0 +1,6 @@
+package scalafix
+
+package object rewrite {
+  type ScalafixRewrite = Rewrite[ScalafixMirror]
+  type ScalafixCtx = RewriteCtx[ScalafixMirror]
+}

--- a/core/src/main/scala/scalafix/syntax/package.scala
+++ b/core/src/main/scala/scalafix/syntax/package.scala
@@ -6,6 +6,8 @@ import scala.meta.semantic.v1.Signature
 import scala.meta.semantic.v1.Symbol
 import scala.meta.tokens.Token
 import scala.util.Try
+import scalafix.rewrite.ScalafixCtx
+import scalafix.rewrite.ScalafixMirror
 import scalafix.util.CanonicalImport
 import scalafix.util.ImportPatch
 import scalafix.util.logger
@@ -50,6 +52,7 @@ package object syntax {
     def toTry: Try[T] = Try(completed.get)
   }
   implicit class XtensionSymbol(symbol: Symbol) {
+
     /** Returns simplified version of this Symbol.
       *
       * - No Symbol.Multi

--- a/core/src/main/scala/scalafix/util/CanonicalImport.scala
+++ b/core/src/main/scala/scalafix/util/CanonicalImport.scala
@@ -3,14 +3,14 @@ package scalafix.util
 import scala.collection.immutable.Seq
 import scala.meta._
 import scala.meta.tokens.Token.Comment
-import scalafix.rewrite.RewriteCtx
+import scalafix.rewrite.ScalafixCtx
 
 object CanonicalImport {
   def fromWildcard(ref: Term.Ref,
                    wildcard: Importee.Wildcard,
                    unimports: Seq[Importee.Unimport],
                    renames: Seq[Importee.Rename])(
-      implicit ctx: RewriteCtx,
+      implicit ctx: ScalafixCtx,
       ownerImport: Import
   ): CanonicalImport =
     new CanonicalImport(
@@ -24,7 +24,7 @@ object CanonicalImport {
       None
     ) {}
   def fromImportee(ref: Term.Ref, importee: Importee)(
-      implicit ctx: RewriteCtx,
+      implicit ctx: ScalafixCtx,
       ownerImport: Import
   ): CanonicalImport =
     new CanonicalImport(
@@ -53,7 +53,7 @@ sealed case class CanonicalImport(
     leadingComments: Set[Comment],
     trailingComments: Set[Comment],
     fullyQualifiedRef: Option[Term.Ref]
-)(implicit ctx: RewriteCtx) {
+)(implicit ctx: ScalafixCtx) {
 
   def isRootImport: Boolean =
     ref.collect {

--- a/core/src/main/scala/scalafix/util/Patch.scala
+++ b/core/src/main/scala/scalafix/util/Patch.scala
@@ -5,7 +5,7 @@ import scala.meta._
 import scala.meta.internal.ast.Helpers._
 import scala.meta.tokens.Token
 import scala.meta.tokens.Token
-import scalafix.rewrite.RewriteCtx
+import scalafix.rewrite.ScalafixCtx
 import scalafix.syntax._
 import scalafix.util.TokenPatch.Add
 import scalafix.util.TokenPatch.Remove
@@ -65,7 +65,8 @@ object Patch {
                    |1. $a
                    |2. $b""".stripMargin)
   }
-  def apply(ast: Tree, patches: Seq[Patch])(implicit ctx: RewriteCtx): String = {
+  def apply(ast: Tree, patches: Seq[Patch])(
+      implicit ctx: ScalafixCtx): String = {
     val input = ast.tokens
     val tokenPatches = patches.collect { case e: TokenPatch => e }
     val replacePatches = Replacer.toTokenPatches(ast, patches.collect {

--- a/core/src/main/scala/scalafix/util/Replacer.scala
+++ b/core/src/main/scala/scalafix/util/Replacer.scala
@@ -4,14 +4,14 @@ import scalafix.syntax._
 import scala.meta.{Symbol => _, _}
 import scala.meta.semantic.v1._
 import scala.collection.immutable.Seq
-import scalafix.rewrite.RewriteCtx
+import scalafix.rewrite.ScalafixCtx
 import scalafix.util.TreePatch.Replace
 import scala.meta.internal.ast.Helpers._
 import scala.util.Try
 import scalafix.util.TreePatch.AddGlobalImport
 
-private[this] class Replacer(implicit ctx: RewriteCtx) {
-  private implicit val mirror = ctx.semantic.get
+private[this] class Replacer(implicit ctx: ScalafixCtx) {
+  import ctx._
   object `:withSymbol:` {
     def unapply(ref: Ref): Option[(Ref, Symbol)] =
       Try(
@@ -51,7 +51,7 @@ private[this] class Replacer(implicit ctx: RewriteCtx) {
 }
 object Replacer {
   def toTokenPatches(ast: Tree, replacements: Seq[Replace])(
-      implicit ctx: RewriteCtx): Seq[Patch] =
+      implicit ctx: ScalafixCtx): Seq[Patch] =
     if (replacements.isEmpty) Nil
     else new Replacer().toTokenPatches(ast, replacements)
 }

--- a/scalafix-nsc/src/test/scala/scalafix/ImportPatches.sc
+++ b/scalafix-nsc/src/test/scala/scalafix/ImportPatches.sc
@@ -1,7 +1,7 @@
 // Small worksheet to demonstrate usage of import patches
 import scala.collection.immutable.Seq
 import scala.meta._
-import scalafix.rewrite.RewriteCtx
+import scalafix.rewrite.ScalafixCtx
 import scalafix.util.Patch
 import scalafix.util.TreePatch.AddGlobalImport
 import scalafix.util.TreePatch.RemoveGlobalImport
@@ -14,7 +14,7 @@ val code =
     |
     |object a
   """.stripMargin.parse[Source].get
-implicit val ctx: RewriteCtx = RewriteCtx.fromCode(code)
+implicit val ctx: ScalafixCtx = RewriteCtx.fromCode(code)
 val add = AddGlobalImport(importer"cats.data.EitherT")
 val addRedundant = AddGlobalImport(importer"scala.collection.mutable._")
 val remove = RemoveGlobalImport(importer"scala.language.higherKinds")

--- a/scalafix-nsc/src/test/scala/scalafix/SemanticTests.scala
+++ b/scalafix-nsc/src/test/scala/scalafix/SemanticTests.scala
@@ -17,6 +17,7 @@ import scala.{meta => m}
 import scalafix.nsc.ScalafixNscPlugin
 import scalafix.rewrite.ExplicitImplicit
 import scalafix.rewrite.Rewrite
+import scalafix.rewrite.ScalafixRewrite
 import scalafix.util.DiffAssertions
 import scalafix.util.logger
 
@@ -26,7 +27,7 @@ import java.io.PrintWriter
 import org.scalatest.FunSuite
 
 class SemanticTests extends FunSuite with DiffAssertions { self =>
-  val rewrite: Rewrite = ExplicitImplicit
+  val rewrite: ScalafixRewrite = ExplicitImplicit
   val parseAsCompilationUnit: Boolean = false
   private val testGlobal: Global = {
     def fail(msg: String) =

--- a/scalafix-nsc/src/test/scala/scalafix/rewrite/ErrorSuite.scala
+++ b/scalafix-nsc/src/test/scala/scalafix/rewrite/ErrorSuite.scala
@@ -4,7 +4,7 @@ import scalafix.Failure
 import scalafix.Fixed
 import scalafix.Scalafix
 
-class ErrorSuite extends RewriteSuite(ProcedureSyntax) {
+class ErrorSuite extends RewriteSuite(ProcedureSyntax()) {
 
   test("on parse error") {
     val Fixed.Failed(err: Failure.ParseError) = Scalafix.fix("object A {")

--- a/scalafix-nsc/src/test/scala/scalafix/rewrite/RewriteSuite.scala
+++ b/scalafix-nsc/src/test/scala/scalafix/rewrite/RewriteSuite.scala
@@ -8,7 +8,9 @@ import scala.collection.immutable.Seq
 
 import org.scalatest.FunSuiteLike
 
-class RewriteSuite(rewrite: Rewrite) extends FunSuiteLike with DiffAssertions {
+class RewriteSuite(rewrite: ScalafixRewrite)
+    extends FunSuiteLike
+    with DiffAssertions {
 
   def check(name: String, original: String, expected: String): Unit = {
     test(name) {

--- a/scalafix-tests/src/test/scala/scalafix/tests/ItTest.scala
+++ b/scalafix-tests/src/test/scala/scalafix/tests/ItTest.scala
@@ -1,8 +1,9 @@
 package scalafix.tests
 
 import scalafix.rewrite.Rewrite
-import ammonite.ops._
+import scalafix.rewrite.ScalafixRewrite
 
+import ammonite.ops._
 import java.io.File
 
 import ammonite.ops.Path
@@ -13,7 +14,7 @@ case class ItTest(
     hash: String,
     config: String = "",
     commands: Seq[Command] = Command.default,
-    rewrites: Seq[Rewrite] = Rewrite.defaultRewrites,
+    rewrites: Seq[ScalafixRewrite] = Rewrite.defaultRewrites,
     addCoursier: Boolean = true
 ) {
   def repoName: String = repo match {


### PR DESCRIPTION
Rewrite now accepts a type parameter. Why?

- Principle of least power, if you don't need semantic information,
  don't require it.
- Rewrite requirements are documented in the type.
- Possible to construct RewriteCtx from scala.meta.Mirror.
- Paves to way to contribute Rewrite upstream to scala.meta