### PR TITLE
Make RewriteCtx covariant and Rewrite contravariant.

### DIFF
--- a/cli/src/main/scala/scalafix/cli/ArgParserImplicits.scala
+++ b/cli/src/main/scala/scalafix/cli/ArgParserImplicits.scala
@@ -2,6 +2,7 @@ package scalafix.cli
 
 import scalafix.rewrite.Rewrite
 import scalafix.rewrite.ScalafixRewrite
+import scalafix.rewrite.ScalafixRewrites
 
 import java.io.InputStream
 import java.io.PrintStream
@@ -12,10 +13,10 @@ object ArgParserImplicits {
 
   implicit val rewriteRead: ArgParser[ScalafixRewrite] =
     ArgParser.instance[ScalafixRewrite] { str =>
-      Rewrite.name2rewrite.get(str) match {
+      ScalafixRewrites.name2rewrite.get(str) match {
         case Some(x) => Right(x)
         case _ =>
-          val availableKeys = Rewrite.name2rewrite.keys.mkString(", ")
+          val availableKeys = ScalafixRewrites.name2rewrite.keys.mkString(", ")
           Left(s"invalid input $str, must be one of $availableKeys")
       }
     }

--- a/cli/src/main/scala/scalafix/cli/Cli.scala
+++ b/cli/src/main/scala/scalafix/cli/Cli.scala
@@ -17,6 +17,7 @@ import scala.util.control.NonFatal
 import scalafix.Fixed
 import scalafix.cli.termdisplay.TermDisplay
 import scalafix.rewrite.ScalafixRewrite
+import scalafix.rewrite.ScalafixRewrites
 
 import caseapp._
 import caseapp.core.Messages
@@ -35,8 +36,8 @@ case class CommonOptions(
 @ProgName("scalafix")
 case class ScalafixOptions(
     @HelpMessage(
-      s"Rules to run, one of: ${Rewrite.allRewrites.mkString(", ")}"
-    ) rewrites: List[ScalafixRewrite] = Rewrite.syntaxRewrites.toList,
+      s"Rules to run, one of: ${ScalafixRewrites.all.mkString(", ")}"
+    ) rewrites: List[ScalafixRewrite] = ScalafixRewrites.syntax.toList,
     @Hidden @HelpMessage(
       "Files to fix. Runs on all *.scala files if given a directory."
     ) @ExtraName("f") files: List[String] = List.empty[String],

--- a/core/src/main/scala/scalafix/ScalafixConfig.scala
+++ b/core/src/main/scala/scalafix/ScalafixConfig.scala
@@ -5,9 +5,8 @@ import scala.meta._
 import scala.meta.dialects.Scala211
 import scala.meta.parsers.Parse
 import scala.util.control.NonFatal
-import scalafix.rewrite.Rewrite
-import scalafix.rewrite.ScalafixCtx
 import scalafix.rewrite.ScalafixRewrite
+import scalafix.rewrite.ScalafixRewrites
 import scalafix.syntax._
 
 import java.io.File
@@ -33,7 +32,7 @@ object ImportsConfig {
   def default: ImportsConfig = ImportsConfig()
 }
 case class ScalafixConfig(
-    rewrites: Seq[ScalafixRewrite] = Rewrite.defaultRewrites,
+    rewrites: Seq[ScalafixRewrite] = ScalafixRewrites.default,
     parser: Parse[_ <: Tree] = Parse.parseSource,
     imports: ImportsConfig = ImportsConfig(),
     fatalWarning: Boolean = true,
@@ -85,16 +84,15 @@ object ScalafixConfig {
 
   def fromNames(names: List[String]): Either[String, Seq[ScalafixRewrite]] =
     names match {
-      case "all" :: Nil => Right(Rewrite.allRewrites)
+      case "all" :: Nil => Right(ScalafixRewrites.all)
       case _ =>
         val invalidNames =
-          names.filterNot(Rewrite.name2rewrite.contains)
+          names.filterNot(ScalafixRewrites.name2rewrite.contains)
         if (invalidNames.nonEmpty) {
-          Left(
-            s"Invalid rewrite rule: ${invalidNames.mkString(",")}. " +
-              s"Valid rules are: ${Rewrite.name2rewrite.keys.mkString(",")}")
+          Left(s"Invalid rewrite rule: ${invalidNames.mkString(",")}. " +
+            s"Valid rules are: ${ScalafixRewrites.name2rewrite.keys.mkString(",")}")
         } else {
-          Right(names.map(Rewrite.name2rewrite))
+          Right(names.map(ScalafixRewrites.name2rewrite))
         }
     }
 }

--- a/core/src/main/scala/scalafix/rewrite/ExplicitImplicit.scala
+++ b/core/src/main/scala/scalafix/rewrite/ExplicitImplicit.scala
@@ -15,7 +15,7 @@ case object ExplicitImplicit extends Rewrite[ScalafixMirror] {
     case m.Term.ApplyType(m.Term.Name("implicitly"), _) => true
     case _ => false
   }
-  override def rewrite(ctx: ScalafixCtx): Seq[Patch] = {
+  override def rewrite[T <: ScalafixMirror](ctx: RewriteCtx[T]): Seq[Patch] = {
     import scala.meta._
     import ctx._
     def fix(defn: Defn, body: Term): Seq[Patch] = {

--- a/core/src/main/scala/scalafix/rewrite/ProcedureSyntax.scala
+++ b/core/src/main/scala/scalafix/rewrite/ProcedureSyntax.scala
@@ -10,8 +10,8 @@ import scalafix.util.Patch
 import scala.collection.immutable.Seq
 import scalafix.util.TokenPatch
 
-class ProcedureSyntax[T]() extends Rewrite[T] {
-  override def rewrite(ctx: RewriteCtx[T]): Seq[Patch] = {
+case object ProcedureSyntax extends Rewrite[Any] {
+  override def rewrite[T](ctx: RewriteCtx[T]): Seq[Patch] = {
     import ctx.tokenList._
     val patches: Seq[Patch] = ctx.tree.collect {
       case t: Defn.Def
@@ -33,9 +33,4 @@ class ProcedureSyntax[T]() extends Rewrite[T] {
     }
     patches
   }
-}
-
-object ProcedureSyntax {
-  val default: ScalafixRewrite = apply()
-  def apply[T](): Rewrite[T] = new ProcedureSyntax[T]()
 }

--- a/core/src/main/scala/scalafix/rewrite/ScalafixRewrites.scala
+++ b/core/src/main/scala/scalafix/rewrite/ScalafixRewrites.scala
@@ -1,0 +1,20 @@
+package scalafix.rewrite
+
+import scala.collection.immutable.Seq
+
+object ScalafixRewrites {
+  val syntax: Seq[SyntaxRewrite] = Seq(
+    ProcedureSyntax,
+    VolatileLazyVal
+  )
+  val semantic: Seq[ScalafixRewrite] = Seq(
+    ExplicitImplicit,
+    Xor2Either
+  )
+  val all: Seq[ScalafixRewrite] = syntax ++ semantic
+  val default: Seq[ScalafixRewrite] =
+    all.filterNot(_ == VolatileLazyVal)
+  val name2rewrite: Map[String, ScalafixRewrite] =
+    all.map(x => x.name -> x).toMap
+
+}

--- a/core/src/main/scala/scalafix/rewrite/VolatileLazyVal.scala
+++ b/core/src/main/scala/scalafix/rewrite/VolatileLazyVal.scala
@@ -5,7 +5,7 @@ import scalafix.util.Patch
 import scala.collection.immutable.Seq
 import scalafix.util.TokenPatch
 
-class VolatileLazyVal[T]() extends Rewrite[T] {
+case object VolatileLazyVal extends Rewrite[Any] {
   private object NonVolatileLazyVal {
     def unapply(defn: Defn.Val): Option[Token] = {
       defn.mods.collectFirst {
@@ -16,15 +16,10 @@ class VolatileLazyVal[T]() extends Rewrite[T] {
       }
     }.flatten
   }
-  override def rewrite(ctx: RewriteCtx[T]): Seq[Patch] = {
+  override def rewrite[T](ctx: RewriteCtx[T]): Seq[Patch] = {
     ctx.tree.collect {
       case NonVolatileLazyVal(tok) =>
         TokenPatch.AddLeft(tok, s"@volatile ")
     }
   }
-}
-
-object VolatileLazyVal {
-  val default: ScalafixRewrite = apply[ScalafixMirror]()
-  def apply[T](): VolatileLazyVal[T] = new VolatileLazyVal[T]()
 }

--- a/core/src/main/scala/scalafix/rewrite/Xor2Either.scala
+++ b/core/src/main/scala/scalafix/rewrite/Xor2Either.scala
@@ -11,7 +11,7 @@ import scalafix.util.TreePatch._
 import scalafix.util.logger
 
 case object Xor2Either extends Rewrite[ScalafixMirror] {
-  override def rewrite(ctx: ScalafixCtx): Seq[Patch] = {
+  override def rewrite[T <: ScalafixMirror](ctx: RewriteCtx[T]): Seq[Patch] = {
     import ctx._
     tree.collectFirst {
       case t: Term.Name

--- a/core/src/main/scala/scalafix/rewrite/package.scala
+++ b/core/src/main/scala/scalafix/rewrite/package.scala
@@ -1,6 +1,14 @@
 package scalafix
 
+import scala.collection.immutable.Seq
+import scalafix.util.Patch
+
 package object rewrite {
   type ScalafixRewrite = Rewrite[ScalafixMirror]
+  val ScalafixRewrite: (RewriteCtx[ScalafixMirror] => Seq[Patch]) => Rewrite[
+    ScalafixMirror] =
+    Rewrite.apply[ScalafixMirror]
   type ScalafixCtx = RewriteCtx[ScalafixMirror]
+  type SyntaxRewrite = Rewrite[Any]
+  type SyntaxCtx = RewriteCtx[None.type]
 }

--- a/core/src/main/scala/scalafix/util/TokenList.scala
+++ b/core/src/main/scala/scalafix/util/TokenList.scala
@@ -3,6 +3,7 @@ package scalafix.util
 import scala.meta.tokens.Token
 import scala.meta.tokens.Tokens
 
+/** Helper to traverse tokens as a doubly linked list.  */
 class TokenList(tokens: Tokens) {
   private[this] val tok2idx = {
     val map = Map.newBuilder[Token, Int]

--- a/scalafix-nsc/src/test/scala/scalafix/rewrite/ErrorSuite.scala
+++ b/scalafix-nsc/src/test/scala/scalafix/rewrite/ErrorSuite.scala
@@ -4,7 +4,7 @@ import scalafix.Failure
 import scalafix.Fixed
 import scalafix.Scalafix
 
-class ErrorSuite extends RewriteSuite(ProcedureSyntax()) {
+class ErrorSuite extends RewriteSuite(ProcedureSyntax) {
 
   test("on parse error") {
     val Fixed.Failed(err: Failure.ParseError) = Scalafix.fix("object A {")

--- a/scalafix-tests/src/test/scala/scalafix/tests/ItTest.scala
+++ b/scalafix-tests/src/test/scala/scalafix/tests/ItTest.scala
@@ -2,6 +2,7 @@ package scalafix.tests
 
 import scalafix.rewrite.Rewrite
 import scalafix.rewrite.ScalafixRewrite
+import scalafix.rewrite.ScalafixRewrites
 
 import ammonite.ops._
 import java.io.File
@@ -14,7 +15,7 @@ case class ItTest(
     hash: String,
     config: String = "",
     commands: Seq[Command] = Command.default,
-    rewrites: Seq[ScalafixRewrite] = Rewrite.defaultRewrites,
+    rewrites: Seq[ScalafixRewrite] = ScalafixRewrites.default,
     addCoursier: Boolean = true
 ) {
   def repoName: String = repo match {


### PR DESCRIPTION
This change gives the following nice properties

RewriteCtx[ScalafixMirror] <: RewriteCtx[Mirror]
Rewrite[ScalafixMirror] <: RewriteCtx[Any]

This also allows rewrites to be defined as case objects extending
Rewrite[A] where A is the least powerful api needed for this rewrite.