### PR TITLE
Replace ScalafixMirror with Mirror where possible.

### DIFF
--- a/core/src/main/scala/scalafix/Scalafix.scala
+++ b/core/src/main/scala/scalafix/Scalafix.scala
@@ -8,6 +8,7 @@ import scalafix.config.ScalafixConfig
 import scalafix.rewrite.RewriteCtx
 import scalafix.rewrite.ScalafixCtx
 import scalafix.rewrite.ScalafixMirror
+import scalafix.util.CanOrganizeImports
 import scalafix.util.Patch
 
 object Scalafix {
@@ -24,13 +25,13 @@ object Scalafix {
   def fix(ast: Tree,
           config: ScalafixConfig,
           semanticApi: Option[ScalafixMirror]): Fixed = {
-    val tokens = ast.tokens
     implicit val ctx: ScalafixCtx = RewriteCtx(
       ast,
       config,
       semanticApi.getOrElse(ScalafixMirror.empty(config.dialect)))
     val patches = config.rewrites.flatMap(_.rewrite(ctx))
-    Fixed.Success(Patch.apply(ast, patches))
+    Fixed.Success(
+      Patch.apply(ast, patches)(CanOrganizeImports.ScalafixMirror, ctx))
   }
 
   def fix(code: Input, config: ScalafixConfig): Fixed = {

--- a/core/src/main/scala/scalafix/rewrite/package.scala
+++ b/core/src/main/scala/scalafix/rewrite/package.scala
@@ -11,4 +11,5 @@ package object rewrite {
   type ScalafixCtx = RewriteCtx[ScalafixMirror]
   type SyntaxRewrite = Rewrite[Any]
   type SyntaxCtx = RewriteCtx[None.type]
+  type AnyCtx = RewriteCtx[Any]
 }

--- a/core/src/main/scala/scalafix/util/CanOrganizeImports.scala
+++ b/core/src/main/scala/scalafix/util/CanOrganizeImports.scala
@@ -1,0 +1,41 @@
+package scalafix.util
+
+import scala.meta._
+import scalafix.syntax._
+import scalafix.rewrite.ScalafixMirror
+
+object CanOrganizeImports {
+  // Not implicit to avoid implicit ambiguity
+  val ScalafixMirror: CanOrganizeImports[ScalafixMirror] =
+    new CanOrganizeImports[ScalafixMirror] {
+      override def toOrganizeImportsMirror(
+          e: ScalafixMirror): OrganizeImportsMirror =
+        new OrganizeImportsMirror {
+          override def fullyQualifiedName(ref: Ref): Option[Ref] = e.fqn(ref)
+          override def isUnused(importee: Importee): Boolean =
+            e.isUnusedImport(importee)
+        }
+    }
+
+  implicit val ScalaMetaMirrorCanOrganizeImports: CanOrganizeImports[Mirror] =
+    new CanOrganizeImports[Mirror] {
+      override def toOrganizeImportsMirror(e: Mirror): OrganizeImportsMirror =
+        new OrganizeImportsMirror {
+          override def fullyQualifiedName(ref: Ref): Option[Ref] =
+            for {
+              sym <- e.symbol(ref).toOption
+              name <- sym.to[Ref].toOption
+              strippedRoot = name.transform {
+                case q"_root_.$nme" => nme
+              }
+              if strippedRoot.is[Ref]
+            } yield strippedRoot.asInstanceOf[Ref]
+          // scala.meta.Miror does not support isUnusedImport
+          override def isUnused(importee: Importee): Boolean = false
+        }
+    }
+}
+
+trait CanOrganizeImports[T] {
+  def toOrganizeImportsMirror(e: T): OrganizeImportsMirror
+}

--- a/core/src/main/scala/scalafix/util/CanonicalImport.scala
+++ b/core/src/main/scala/scalafix/util/CanonicalImport.scala
@@ -3,14 +3,16 @@ package scalafix.util
 import scala.collection.immutable.Seq
 import scala.meta._
 import scala.meta.tokens.Token.Comment
+import scalafix.rewrite.AnyCtx
 import scalafix.rewrite.ScalafixCtx
+import scalafix.rewrite.SyntaxCtx
 
 object CanonicalImport {
   def fromWildcard(ref: Term.Ref,
                    wildcard: Importee.Wildcard,
                    unimports: Seq[Importee.Unimport],
                    renames: Seq[Importee.Rename])(
-      implicit ctx: ScalafixCtx,
+      implicit ctx: AnyCtx,
       ownerImport: Import
   ): CanonicalImport =
     new CanonicalImport(
@@ -24,7 +26,7 @@ object CanonicalImport {
       None
     ) {}
   def fromImportee(ref: Term.Ref, importee: Importee)(
-      implicit ctx: ScalafixCtx,
+      implicit ctx: AnyCtx,
       ownerImport: Import
   ): CanonicalImport =
     new CanonicalImport(
@@ -53,7 +55,7 @@ sealed case class CanonicalImport(
     leadingComments: Set[Comment],
     trailingComments: Set[Comment],
     fullyQualifiedRef: Option[Term.Ref]
-)(implicit ctx: ScalafixCtx) {
+)(implicit ctx: AnyCtx) {
 
   def isRootImport: Boolean =
     ref.collect {

--- a/core/src/main/scala/scalafix/util/Patch.scala
+++ b/core/src/main/scala/scalafix/util/Patch.scala
@@ -12,6 +12,7 @@ import scalafix.util.TokenPatch.Add
 import scalafix.util.TokenPatch.Remove
 import scalafix.util.TreePatch.Replace
 import scalafix.config._
+import scalafix.rewrite.RewriteCtx
 
 sealed abstract class Patch
 abstract class TreePatch extends Patch
@@ -68,8 +69,8 @@ object Patch {
                    |1. $a
                    |2. $b""".stripMargin)
   }
-  def apply(ast: Tree, patches: Seq[Patch])(
-      implicit ctx: ScalafixCtx): String = {
+  def apply[T <: Mirror: CanOrganizeImports](ast: Tree, patches: Seq[Patch])(
+      implicit ctx: RewriteCtx[T]): String = {
     val input = ast.tokens
     val tokenPatches = patches.collect { case e: TokenPatch => e }
     val replacePatches = Replacer.toTokenPatches(ast, patches.collect {

--- a/core/src/main/scala/scalafix/util/Replacer.scala
+++ b/core/src/main/scala/scalafix/util/Replacer.scala
@@ -8,9 +8,10 @@ import scalafix.rewrite.ScalafixCtx
 import scalafix.util.TreePatch.Replace
 import scala.meta.internal.ast.Helpers._
 import scala.util.Try
+import scalafix.rewrite.RewriteCtx
 import scalafix.util.TreePatch.AddGlobalImport
 
-private[this] class Replacer(implicit ctx: ScalafixCtx) {
+private[this] class Replacer(implicit ctx: RewriteCtx[Mirror]) {
   import ctx._
   object `:withSymbol:` {
     def unapply(ref: Ref): Option[(Ref, Symbol)] =
@@ -55,7 +56,7 @@ private[this] class Replacer(implicit ctx: ScalafixCtx) {
 }
 object Replacer {
   def toTokenPatches(ast: Tree, replacements: Seq[Replace])(
-      implicit ctx: ScalafixCtx): Seq[Patch] = {
+      implicit ctx: RewriteCtx[Mirror]): Seq[Patch] = {
     new Replacer().toTokenPatches(
       ast,
       replacements ++ ctx.config.patches.all.collect {


### PR DESCRIPTION
This makes is possible to use OrganizeImports (without remove unused
imports) and Replacer with scala.meta.Mirror instead of ScalafixMirror.