### PR TITLE
Support dynamic loading of rewrites from uri.

### DIFF
--- a/core/src/main/scala/scalafix/rewrite/Rewrite.scala
+++ b/core/src/main/scala/scalafix/rewrite/Rewrite.scala
@@ -16,6 +16,9 @@ abstract class Rewrite[-A](implicit sourceName: sourcecode.Name) {
   def name: String = sourceName.value
   override def toString: String = name
   def rewrite[B <: A](ctx: RewriteCtx[B]): Seq[Patch]
+
+  def andThen[B <: A](other: Rewrite[B]): Rewrite[B] =
+    Rewrite(ctx => this.rewrite(ctx) ++ other.rewrite(ctx))
 }
 
 object Rewrite {

--- a/core/src/main/scala/scalafix/rewrite/RewriteCtx.scala
+++ b/core/src/main/scala/scalafix/rewrite/RewriteCtx.scala
@@ -25,10 +25,14 @@ class RewriteCtx[+A](implicit val tree: Tree,
 
 object RewriteCtx {
 
-  /** Constructor for a syntactic rewrite. */
+  /** Constructor for a syntactic rewrite.
+    *
+    * Syntactic rewrite ctx is RewriteCtx[Null] because it is a subtype of any
+    * other rewritectx.
+    */
   def apply(tree: Tree,
-            config: ScalafixConfig = ScalafixConfig()): RewriteCtx[None.type] =
-    apply(tree, config, None)
+            config: ScalafixConfig = ScalafixConfig()): RewriteCtx[Null] =
+    apply(tree, config, null)
 
   /** Constructor for a generic rewrite. */
   def apply[T](tree: Tree, config: ScalafixConfig, mirror: T): RewriteCtx[T] =

--- a/core/src/main/scala/scalafix/util/FileOps.scala
+++ b/core/src/main/scala/scalafix/util/FileOps.scala
@@ -4,6 +4,8 @@ import java.io.BufferedReader
 import java.io.File
 import java.io.FileReader
 import java.io.PrintWriter
+import java.net.URI
+import java.net.URL
 
 object FileOps {
 
@@ -26,12 +28,16 @@ object FileOps {
     }
   }
 
+  def readURL(url: URL): String = {
+    scala.io.Source.fromURL(url)("UTF-8").getLines().mkString("\n")
+  }
+
   /**
     * Reads file from file system or from http url.
     */
   def readFile(filename: String): String = {
     if (filename matches "https?://.*") {
-      scala.io.Source.fromURL(filename)("UTF-8").getLines().mkString("\n")
+      readURL(new URL(filename))
     } else {
       readFile(new File(filename))
     }

--- a/core/src/main/scala/scalafix/util/Replacer.scala
+++ b/core/src/main/scala/scalafix/util/Replacer.scala
@@ -71,10 +71,10 @@ object Renamer {
       implicit ctx: RewriteCtx[T]): Seq[TokenPatch] = {
     object MatchingRename {
       def unapply(arg: Name): Option[(Token, Name)] =
-        renames.find(_.from eq arg).map { rename =>
-          val tok = arg.tokens(ctx.config.dialect).head
-          tok -> rename.to
-        }
+        for {
+          rename <- renames.find(_.from eq arg)
+          tok <- arg.tokens.headOption
+        } yield tok -> rename.to
     }
     ctx.tree.collect {
       case MatchingRename(tok, to) =>

--- a/core/src/main/scala/scalafix/util/RewriteInstrumentation.scala
+++ b/core/src/main/scala/scalafix/util/RewriteInstrumentation.scala
@@ -1,0 +1,49 @@
+package scalafix.util
+
+import scala.meta._
+import scala.collection.immutable.Seq
+import scalafix.util.TreeExtractors._
+
+object RewriteInstrumentation {
+
+  // removes syntax that is not supported by toolbox
+  private def simplify(tree: Tree): Tree = tree.transform {
+    // packages are not supported by toolbox.
+    case Source(Seq(Pkg(ref, stats))) => Source(q"import $ref._" +: stats)
+    case Source(stats) =>
+      Source(stats.flatMap {
+        case Import(is) => is.map(i => Import(Seq(i)))
+        case x => Seq(x)
+      })
+  }
+
+  def instrument(code: String): String = {
+    code.parse[Source] match {
+      case parsers.Parsed.Success(ast) =>
+        val rewriteName: Seq[String] = ast.collect {
+          case Defn.Object(_,
+                           name,
+                           Template(_, ctor"Rewrite[$_]" :: _, _, _)) =>
+            name.value
+          case Defn.Val(_, Pat.Var.Term(name) :: Nil, _, q"Rewrite[$_]($_)")
+                `:WithParent:` (_: Template)
+                `:WithParent:` Defn.Object(_, parentName, _) =>
+            s"$parentName.$name"
+        }
+        rewriteName match {
+          case Nil =>
+            sys.error(s"Found no rewrite in code! \n $code")
+          case _ =>
+            val folded = rewriteName.tail.foldLeft(rewriteName.head)(
+              _ + ".andThen(" + _ + ")")
+            val transformed = simplify(ast)
+            s"""
+               |${transformed.syntax}
+               |
+               |$folded
+               |""".stripMargin
+        }
+      case _ => code
+    }
+  }
+}

--- a/core/src/main/scala/scalafix/util/ScalafixToolbox.scala
+++ b/core/src/main/scala/scalafix/util/ScalafixToolbox.scala
@@ -1,0 +1,28 @@
+package scalafix.util
+
+import scala.collection.immutable.Seq
+import scala.collection.mutable
+import scala.util.control.NonFatal
+import scalafix.rewrite.Rewrite
+import scalafix.util.TreeExtractors._
+
+object ScalafixToolbox {
+  import scala.reflect.runtime.universe._
+  import scala.tools.reflect.ToolBox
+  private val tb = runtimeMirror(getClass.getClassLoader).mkToolBox()
+  private val rewriteCache: mutable.WeakHashMap[String, Any] =
+    mutable.WeakHashMap.empty
+
+  def getRewrite[T](code: String): Either[Throwable, Rewrite[T]] =
+    try {
+      Right(
+        compile(RewriteInstrumentation.instrument(code))
+          .asInstanceOf[Rewrite[T]])
+    } catch {
+      case NonFatal(e) => Left(e)
+    }
+
+  private def compile(code: String): Any = {
+    rewriteCache.getOrElseUpdate(code, tb.eval(tb.parse(code)))
+  }
+}

--- a/rewrites/MyRewrite.scala
+++ b/rewrites/MyRewrite.scala
@@ -1,0 +1,25 @@
+package foo.bar {
+
+import scalafix._
+import scalafix.rewrite._
+import scalafix.util._
+import scalafix.util.TreePatch._
+import scala.collection.immutable.Seq
+import scala.meta._
+
+case object MyRewrite extends Rewrite[Any] {
+  def rewrite[T](ctx: RewriteCtx[T]): Seq[Patch] = {
+    ctx.tree.collect {
+      case n: scala.meta.Name => Rename(n, Term.Name(n.syntax + "1"))
+    }
+  }
+}
+
+case object MyRewrite2 extends Rewrite[Any] {
+  def rewrite[T](ctx: RewriteCtx[T]): Seq[Patch] = {
+    Seq(
+      AddGlobalImport(importer"scala.collection.immutable.Seq")
+    )
+  }
+}
+}

--- a/rewrites/MyRewrite2.scala
+++ b/rewrites/MyRewrite2.scala
@@ -1,0 +1,21 @@
+import scalafix._
+import scalafix.rewrite._
+import scalafix.util._
+import scalafix.util.TreePatch._
+import scala.collection.immutable.Seq
+import scala.meta._
+import scalafix.config.ScalafixConfig
+
+object Rewrites {
+  val myRewrite = Rewrite[Any] { ctx =>
+    ctx.tree.collect {
+      case n: scala.meta.Name => Rename(n, Term.Name(n.syntax + "1"))
+    }
+  }
+
+  val myRewrite2 = Rewrite[Any] { ctx =>
+    Seq(
+      AddGlobalImport(importer"scala.collection.immutable.Seq")
+    )
+  }
+}

--- a/scalafix-nsc/src/test/resources/checkSyntax/FileRewrite.source
+++ b/scalafix-nsc/src/test/resources/checkSyntax/FileRewrite.source
@@ -1,0 +1,9 @@
+rewrites = [
+  "file:rewrites/MyRewrite.scala"
+]
+<<< NOWRAP basic
+object Name
+>>>
+import scala.collection.immutable.Seq
+object Name1
+

--- a/scalafix-nsc/src/test/resources/checkSyntax/FileRewrite2.source
+++ b/scalafix-nsc/src/test/resources/checkSyntax/FileRewrite2.source
@@ -1,0 +1,9 @@
+rewrites = [
+  "file:rewrites/MyRewrite2.scala"
+]
+<<< NOWRAP basic
+object Name
+>>>
+import scala.collection.immutable.Seq
+object Name1
+

--- a/scalafix-nsc/src/test/resources/checkSyntax/FqnRewrite.source
+++ b/scalafix-nsc/src/test/resources/checkSyntax/FqnRewrite.source
@@ -1,5 +1,5 @@
 rewrites = [
-  _root_.scalafix.test.FqnRewrite
+  "scala:scalafix.test.FqnRewrite"
 ]
 <<< NOWRAP add import
 import scala._

--- a/scalafix-nsc/src/test/resources/checkSyntax/UrlRewrite.source
+++ b/scalafix-nsc/src/test/resources/checkSyntax/UrlRewrite.source
@@ -1,0 +1,7 @@
+rewrites = [
+  "https://gist.githubusercontent.com/olafurpg/2a4b1ee14c831fb7cab556b4b471c976/raw/e42891cd705eed6b1411b92a71f9f4f4a399a4f1/MyRewrite.scala"
+]
+<<< NOWRAP basic
+object Name
+>>>
+object Name1

--- a/scalafix-nsc/src/test/scala/scalafix/SemanticTests.scala
+++ b/scalafix-nsc/src/test/scala/scalafix/SemanticTests.scala
@@ -19,8 +19,10 @@ import scalafix.config.ScalafixConfig
 import scalafix.nsc.ScalafixNscPlugin
 import scalafix.rewrite.ExplicitImplicit
 import scalafix.rewrite.Rewrite
+import scalafix.rewrite.RewriteCtx
 import scalafix.rewrite.ScalafixRewrite
 import scalafix.util.DiffAssertions
+import scalafix.util.ScalafixToolbox
 import scalafix.util.logger
 
 import java.io.File
@@ -215,3 +217,4 @@ class SemanticTests extends FunSuite with DiffAssertions { self =>
     }
   }
 }
+


### PR DESCRIPTION
This commit adds support to load rewrites using different protocols

- `file:path/to/rewrite.scala`
- `https://github.com/...`
- `scala:fully.qualified.Name`

In the future, we can add support for other protocols like `scastie:snippet-hash`.

We use the scala.reflect toolbox to compile and load rewrites from code.
We instrument the code to make it compile with scala.reflect Toolbox.