### PR TITLE
Add SBT test that demonstrates problem with ooimports

### DIFF
--- a/core/src/main/scala/scalafix/config/ScalafixConfig.scala
+++ b/core/src/main/scala/scalafix/config/ScalafixConfig.scala
@@ -41,7 +41,9 @@ object ScalafixConfig {
   }
 
   def fromFile(file: File): Either[Throwable, ScalafixConfig] =
-    fromString(FileOps.readFile(file))
+    fromString(FileOps.readFile(file)).left.map { th =>
+      new IllegalArgumentException(s"Error reading configuration from ${file.getAbsolutePath}:\n  ${th.getMessage}", th)
+    }
 
   def fromString(str: String): Either[Throwable, ScalafixConfig] =
     Hocon2Class.gimmeClass[ScalafixConfig](str, default.reader, None)

--- a/scalafix-nsc/src/test/resources/checkSyntax/OrganizeImportsRemoveUnused.source
+++ b/scalafix-nsc/src/test/resources/checkSyntax/OrganizeImportsRemoveUnused.source
@@ -144,3 +144,8 @@ import scalafix.test._
 import scalafix.test.Generic
 import shapeless._
 object A { val x = Generic[Int]; new Used }
+<<< remove unused java import in trivial example
+import java.util.UUID
+object Test
+>>>
+object Test

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/oimports-basic/build.sbt
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/oimports-basic/build.sbt
@@ -1,0 +1,16 @@
+scalaVersion := "2.12.1"
+
+scalafixConfig in ThisBuild := Some(file("myscalafix.conf"))
+
+TaskKey[Unit]("check") := {
+  val assertContentMatches: ((String, String) => Boolean) =
+    ScalafixTestUtility.assertContentMatches(streams.value) _
+  val expected = "object Test"
+
+  assert(
+    assertContentMatches(
+      "src/main/scala/Test.scala",
+      expected
+    )
+  )
+}

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/oimports-basic/myscalafix.conf
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/oimports-basic/myscalafix.conf
@@ -1,0 +1,4 @@
+rewrites = []
+imports.organize = true
+imports.removeUnused = true
+imports.expandRelative = false

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/oimports-basic/project/ScalafixTestUtility.scala
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/oimports-basic/project/ScalafixTestUtility.scala
@@ -1,0 +1,1 @@
+../../../../test-project-template/project/ScalafixTestUtility.scala

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/oimports-basic/project/build.properties
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/oimports-basic/project/build.properties
@@ -1,0 +1,1 @@
+../../../../test-project-template/project/build.properties

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/oimports-basic/project/plugins.sbt
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/oimports-basic/project/plugins.sbt
@@ -1,0 +1,1 @@
+../../../../test-project-template/project/plugins.sbt

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/oimports-basic/src/main/scala/Test.scala
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/oimports-basic/src/main/scala/Test.scala
@@ -1,0 +1,3 @@
+import java.util.UUID
+
+object Test

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/oimports-basic/test
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/oimports-basic/test
@@ -1,0 +1,5 @@
+# compile should not affect scalafix
+> compile
+> scalafix
+> check
+


### PR DESCRIPTION
Organize imports seems not to remove unused imports when used from the SBT plugin, as demonstrated by the added SBT test. Interestingly, an analogous test case for scalafix-nsc, that also comes with this commit, passes flawlessly.

My suspicion is that the "hijacking" performed by scalafix-nsc does not work so well in the context of the SBT plugin.