### PR TITLE
Clean up cli.

### DIFF
--- a/cli/src/main/scala/scalafix/cli/ExitStatus.scala
+++ b/cli/src/main/scala/scalafix/cli/ExitStatus.scala
@@ -1,0 +1,24 @@
+package scalafix.cli
+
+case class ExitStatus(code: Int, name: String) {
+  override def toString: String = s"$name=$code"
+}
+
+object ExitStatus {
+  def apply(n: Int)(implicit name: sourcecode.Name) =
+    new ExitStatus(n, name.value)
+  val Ok: ExitStatus = apply(0)
+  val UnexpectedError: ExitStatus = apply(1)
+  val ParseError: ExitStatus = apply(2)
+  val ScalafixError: ExitStatus = apply(3)
+
+  def all: Seq[ExitStatus] = Seq(
+    Ok,
+    UnexpectedError,
+    ParseError,
+    ScalafixError
+  )
+
+  def merge(code1: ExitStatus, code2: ExitStatus): ExitStatus =
+    if (code1 == Ok) code2 else code1
+}

--- a/core/src/main/scala/scalafix/Failure.scala
+++ b/core/src/main/scala/scalafix/Failure.scala
@@ -4,7 +4,7 @@ import scala.meta.inputs.Position
 import scalafix.rewrite.Rewrite
 import scalafix.rewrite.ScalafixRewrites
 
-class Failure(e: Throwable) extends Exception(e.getMessage)
+class Failure(val ex: Throwable) extends Exception(ex.getMessage)
 
 object Failure {
   case class ParseError(pos: Position, message: String, exception: Throwable)
@@ -14,4 +14,12 @@ object Failure {
         s"Unknown rewrite '$name', expected one of ${ScalafixRewrites.name2rewrite.keys
           .mkString(", ")}"))
   case class Unexpected(e: Throwable) extends Failure(e)
+  case class MissingSemanticApi(operation: String)
+      extends Failure(
+        new UnsupportedOperationException(
+          s"Operation '$operation' requires the semantic api. " +
+            "This may indicate a configuration or build integration error. " +
+            "See sbt-scalahost, sbt-scalafix or scala.meta.Mirror for instructions on " +
+            "how to setup a semantic api."
+        ))
 }


### PR DESCRIPTION
- Return proper exit codes on failure: parse/scalafix/unexpected error.
- Document exit code in --help.
- Clearer instruction on missing semantic api.
- Return Fixed.Failed on scalafix errors instead of throwing unexpected errors.

Fixes #104