### PR TITLE
Set the exit code when running in a nailgun context

### DIFF
--- a/cli/src/main/scala/scalafix/cli/Cli.scala
+++ b/cli/src/main/scala/scalafix/cli/Cli.scala
@@ -281,14 +281,16 @@ object Cli {
   }
 
   def nailMain(nGContext: NGContext): Unit = {
-    runMain(
-      nGContext.getArgs,
-      CommonOptions(
-        workingDirectory = nGContext.getWorkingDirectory,
-        out = nGContext.out,
-        in = nGContext.in,
-        err = nGContext.err
+    val code =
+      runMain(
+        nGContext.getArgs,
+        CommonOptions(
+          workingDirectory = nGContext.getWorkingDirectory,
+          out = nGContext.out,
+          in = nGContext.in,
+          err = nGContext.err
+        )
       )
-    )
+    nGContext.exit(code)
   }
 }


### PR DESCRIPTION
It turns out that one of the underlying reasons for #104 was that pants executes tools in a nailgun context, and in that case the exit code was being discarded.