### PR TITLE
Add GitHub shorthand for URL rewrites

### DIFF
--- a/scalafix-tests/src/test/scala/scalafix/tests/GitHubUrlRewriteSuite.scala
+++ b/scalafix-tests/src/test/scala/scalafix/tests/GitHubUrlRewriteSuite.scala
@@ -1,0 +1,23 @@
+package scalafix
+package tests
+
+import scalafix.reflect.ScalafixCompilerDecoder.GitHubUrlRewrite
+
+import org.scalatest.{FunSuiteLike, Matchers}
+import metaconfig.Conf
+
+class GitHubUrlRewriteSuite extends FunSuiteLike with Matchers {
+  test("it expands a GitHub shorthand with a default sha") {
+    Conf.Str("github:someorg/somerepo/1.2.3") match {
+      case GitHubUrlRewrite(url) =>
+        url.toString shouldBe "https://github.com/someorg/somerepo/blob/master/scalafix-rewrites/src/main/scala/somerepo/scalafix/Somerepo_1_2_3.scala"
+    }
+  }
+
+  test("it expands a GitHub shorthand with a specific sha") {
+    Conf.Str("github:someorg/somerepo/1.2.3?sha=master~1") match {
+      case GitHubUrlRewrite(url) =>
+        url.toString shouldBe "https://github.com/someorg/somerepo/blob/master~1/scalafix-rewrites/src/main/scala/somerepo/scalafix/Somerepo_1_2_3.scala"
+    }
+  }
+}


### PR DESCRIPTION
Closes #125 

First working draft. I've setup some integration tests but they fail because the file referenced is not there. Not sure whether these tests make sense, or whether we should just unit test the shorthand expansion. Anyway, the `FileNotFound` exception shows a correct value, so 🎉.

@olafurpg take a look and let me know what you think!