### PR TITLE
Add ExplicitUnit rewrite

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/rewrite/ExplicitUnit.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/ExplicitUnit.scala
@@ -1,0 +1,13 @@
+package scalafix
+package rewrite
+
+import scala.meta._
+
+case object ExplicitUnit extends Rewrite {
+  override def rewrite(ctx: RewriteCtx): Patch = {
+    ctx.tree.collect {
+      case t: Decl.Def if t.decltpe.tokens.isEmpty =>
+        ctx.addRight(t.tokens.last, s": Unit")
+    }.asPatch
+  }
+}

--- a/scalafix-core/src/main/scala/scalafix/rewrite/ScalafixRewrites.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/ScalafixRewrites.scala
@@ -5,7 +5,8 @@ import scala.meta._
 object ScalafixRewrites {
   val syntax: List[Rewrite] = List(
     ProcedureSyntax,
-    VolatileLazyVal
+    VolatileLazyVal,
+    ExplicitUnit
   )
   def semantic(mirror: Mirror): List[Rewrite] = List(
     ScalaJsRewrites.DemandJSGlobal(mirror),

--- a/scalafix-tests/src/test/resources/checkSyntax/ExplicitUnit.source
+++ b/scalafix-tests/src/test/resources/checkSyntax/ExplicitUnit.source
@@ -1,0 +1,49 @@
+rewrites = [ExplicitUnit]
+<<< def inside a trait
+trait A {
+  def x
+}
+>>>
+trait A {
+  def x: Unit
+}
+<<< def inside an abstract class
+abstract class A {
+  def x
+}
+>>>
+abstract class A {
+  def x: Unit
+}
+<<< def with comment
+trait B {
+  def x /* comment */
+}
+>>>
+trait B {
+  def x: Unit /* comment */
+}
+<<< def with empty params
+trait C {
+  def x()
+}
+>>>
+trait C {
+  def x(): Unit
+}
+<<< def with params
+trait D {
+  def x(a: String, b: Boolean)
+}
+>>>
+trait D {
+  def x(a: String, b: Boolean): Unit
+}
+<<< def with return type
+trait E {
+  def x: String // don't touch this
+}
+>>>
+trait E {
+  def x: String // don't touch this
+}


### PR DESCRIPTION
Closes #58 

It adds an explicit `Unit` return type to `def` declarations without a return type.

Example:

```diff
trait A {
-  def x
+  def x: Unit
}
```