### PR TITLE
Safer derivation of package name from repo name

### DIFF
--- a/scalafix-reflect/src/main/scala/scalafix/reflect/ScalafixCompilerDecoder.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/reflect/ScalafixCompilerDecoder.scala
@@ -55,8 +55,8 @@ object ScalafixCompilerDecoder {
                                       version: String,
                                       sha: String): URL = {
       val normVersion = version.replaceAll("[^\\d]", "_")
-      val fileName = s"${repo.toLowerCase.capitalize}_$normVersion.scala"
       val packageName = normalizedPackageName(repo)
+      val fileName = s"${packageName.capitalize}_$normVersion.scala"
       new URL(
         s"https://github.com/$org/$repo/blob/$sha/scalafix-rewrites/src/main/scala/$packageName/scalafix/$fileName")
     }

--- a/scalafix-reflect/src/main/scala/scalafix/reflect/ScalafixCompilerDecoder.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/reflect/ScalafixCompilerDecoder.scala
@@ -41,14 +41,24 @@ object ScalafixCompilerDecoder {
     private[this] val GitHubShorthandWithSha =
       """github:([^\/]+)\/([^\/]+)\/([^\/]+)\?sha=(.+)""".r
 
+    private[this] def normalizedPackageName(repoName: String): String = {
+      val packageName = repoName.replaceAll("[^a-zA-Z0-9]", "_")
+      if (packageName.headOption.map(_.isDigit) == Some(true)) {
+        s"_$packageName"
+      } else {
+        packageName
+      }
+    }
+
     private[this] def expandGitHubURL(org: String,
                                       repo: String,
                                       version: String,
                                       sha: String): URL = {
       val normVersion = version.replaceAll("[^\\d]", "_")
       val fileName = s"${repo.toLowerCase.capitalize}_$normVersion.scala"
+      val packageName = normalizedPackageName(repo)
       new URL(
-        s"https://github.com/$org/$repo/blob/$sha/scalafix-rewrites/src/main/scala/$repo/scalafix/$fileName")
+        s"https://github.com/$org/$repo/blob/$sha/scalafix-rewrites/src/main/scala/$packageName/scalafix/$fileName")
     }
 
     def unapply(arg: Conf.Str): Option[URL] = arg.value match {

--- a/scalafix-reflect/src/main/scala/scalafix/reflect/ScalafixCompilerDecoder.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/reflect/ScalafixCompilerDecoder.scala
@@ -42,7 +42,7 @@ object ScalafixCompilerDecoder {
       """github:([^\/]+)\/([^\/]+)\/([^\/]+)\?sha=(.+)""".r
 
     private[this] def normalizedPackageName(repoName: String): String = {
-      val packageName = repoName.replaceAll("[^a-zA-Z0-9]", "_")
+      val packageName = repoName.replaceAll("[^a-zA-Z0-9]", "_").toLowerCase
       if (packageName.headOption.map(_.isDigit) == Some(true)) {
         s"_$packageName"
       } else {

--- a/scalafix-tests/src/test/scala/scalafix/tests/GitHubUrlRewriteSuite.scala
+++ b/scalafix-tests/src/test/scala/scalafix/tests/GitHubUrlRewriteSuite.scala
@@ -21,18 +21,18 @@ class GitHubUrlRewriteSuite extends FunSuiteLike with Matchers {
     }
   }
 
-  test("it replaces invalid characters in package name with _") {
+  test("it replaces invalid characters in package name and file name with _") {
     Conf.Str("github:someorg/some-repo/1.2.3") match {
       case GitHubUrlRewrite(url) =>
-        url.toString shouldBe "https://github.com/someorg/some-repo/blob/master/scalafix-rewrites/src/main/scala/some_repo/scalafix/Some-repo_1_2_3.scala"
+        url.toString shouldBe "https://github.com/someorg/some-repo/blob/master/scalafix-rewrites/src/main/scala/some_repo/scalafix/Some_repo_1_2_3.scala"
     }
   }
 
   test(
-    "it adds an underscore to the package name if the repo name begins with a digit") {
+    "it adds an underscore to the package name and to the file name if the repo name begins with a digit") {
     Conf.Str("github:someorg/42some-repo/1.2.3") match {
       case GitHubUrlRewrite(url) =>
-        url.toString shouldBe "https://github.com/someorg/42some-repo/blob/master/scalafix-rewrites/src/main/scala/_42some_repo/scalafix/42some-repo_1_2_3.scala"
+        url.toString shouldBe "https://github.com/someorg/42some-repo/blob/master/scalafix-rewrites/src/main/scala/_42some_repo/scalafix/_42some_repo_1_2_3.scala"
     }
   }
 }

--- a/scalafix-tests/src/test/scala/scalafix/tests/GitHubUrlRewriteSuite.scala
+++ b/scalafix-tests/src/test/scala/scalafix/tests/GitHubUrlRewriteSuite.scala
@@ -20,4 +20,19 @@ class GitHubUrlRewriteSuite extends FunSuiteLike with Matchers {
         url.toString shouldBe "https://github.com/someorg/somerepo/blob/master~1/scalafix-rewrites/src/main/scala/somerepo/scalafix/Somerepo_1_2_3.scala"
     }
   }
+
+  test("it replaces invalid characters in package name with _") {
+    Conf.Str("github:someorg/some-repo/1.2.3") match {
+      case GitHubUrlRewrite(url) =>
+        url.toString shouldBe "https://github.com/someorg/some-repo/blob/master/scalafix-rewrites/src/main/scala/some_repo/scalafix/Some-repo_1_2_3.scala"
+    }
+  }
+
+  test(
+    "it adds an underscore to the package name if the repo name begins with a digit") {
+    Conf.Str("github:someorg/42some-repo/1.2.3") match {
+      case GitHubUrlRewrite(url) =>
+        url.toString shouldBe "https://github.com/someorg/42some-repo/blob/master/scalafix-rewrites/src/main/scala/_42some_repo/scalafix/42some-repo_1_2_3.scala"
+    }
+  }
 }


### PR DESCRIPTION
Closes #131 and also handles the case in which a repo name starts with a digit.

See unit tests, but in short

`some-repo` => `some_repo`

`42some-repo` => `_42some_repo`

Ugly but consistent (naming is hard)