### PR TITLE
Add NoAutotupling semantic rewrite

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/rewrite/NoAutoTupling.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/NoAutoTupling.scala
@@ -2,11 +2,8 @@ package scalafix
 package rewrite
 
 import scala.meta._
-import scala.meta.contrib._
 import scalafix.syntax._
-import scala.meta.semantic.v1.Signature
-
-import org.scalameta.logger
+import scala.meta.semantic.Signature
 
 case class NoAutoTupling(mirror: Mirror) extends SemanticRewrite(mirror) {
 

--- a/scalafix-core/src/main/scala/scalafix/rewrite/NoAutoTupling.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/NoAutoTupling.scala
@@ -1,0 +1,51 @@
+package scalafix
+package rewrite
+
+import scala.meta._
+import scala.meta.contrib._
+import scalafix.syntax._
+import scala.meta.semantic.v1.Signature
+
+import org.scalameta.logger
+
+case class NoAutoTupling(mirror: Mirror) extends SemanticRewrite(mirror) {
+
+  private[this] val singleTuplePattern = "^Lscala\\/Tuple\\d{1,2}$".r.pattern
+
+  private[this] def addWrappingParens(ctx: RewriteCtx,
+                                      args: Seq[Term.Arg]): Patch =
+    Seq(
+      ctx.addLeft(args.head.tokens.last, "("),
+      ctx.addRight(args.last.tokens.last, ")")
+    ).asPatch
+
+  override def rewrite(ctx: RewriteCtx): Patch = {
+    ctx.tree.collect {
+      case x @ q"$fun(...$argss)"
+          if argss.length > 0 && fun.isInstanceOf[Ref] =>
+        mirror
+          .symbol(fun.asInstanceOf[Ref])
+          .toOption
+          .collect {
+            case Symbol.Global(_, Signature.Method(_, jvmSignature)) =>
+              jvmSignature.stripPrefix("(").takeWhile(_ != ')').split(';')
+          }
+          .map { argListSignatures =>
+            argListSignatures
+              .zip(argss)
+              .foldLeft(Seq.empty[Patch]) {
+                case (patches, (argListSignature, args)) =>
+                  if (singleTuplePattern
+                        .matcher(argListSignature)
+                        .matches && args.length > 1) {
+                    patches :+ addWrappingParens(ctx, args)
+                  } else {
+                    patches
+                  }
+              }
+              .asPatch
+          }
+          .getOrElse(Patch.empty)
+    }.asPatch
+  }
+}

--- a/scalafix-core/src/main/scala/scalafix/rewrite/NoAutoTupling.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/NoAutoTupling.scala
@@ -12,7 +12,7 @@ case class NoAutoTupling(mirror: Mirror) extends SemanticRewrite(mirror) {
 
   private[this] def addWrappingParens(ctx: RewriteCtx,
                                       args: Seq[Term.Arg]): Patch =
-    ctx.addLeft(args.head.tokens.last, "(") +
+    ctx.addLeft(args.head.tokens.head, "(") +
       ctx.addRight(args.last.tokens.last, ")")
 
   override def rewrite(ctx: RewriteCtx): Patch = {

--- a/scalafix-core/src/main/scala/scalafix/rewrite/ScalafixRewrites.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/ScalafixRewrites.scala
@@ -11,7 +11,8 @@ object ScalafixRewrites {
   def semantic(mirror: Mirror): List[Rewrite] = List(
     ScalaJsRewrites.DemandJSGlobal(mirror),
 //    ExplicitImplicit(mirror), // Unsupported for now
-    Xor2Either(mirror)
+    Xor2Either(mirror),
+    NoAutoTupling(mirror)
   )
   def all(mirror: Mirror): List[Rewrite] =
     syntax ++ semantic(mirror)

--- a/scalafix-tests/src/test/resources/checkSyntax/NoAutoTupling.source
+++ b/scalafix-tests/src/test/resources/checkSyntax/NoAutoTupling.source
@@ -77,3 +77,14 @@ object tup {
   def sum(a: Int, b: (Int, String)): Int = ???
   sum(1, (2, "foo"))
 }
+
+<<< auto-tupling with lambdas
+object tup {
+  val foo = (a: (Int, Boolean)) => a
+  foo(2, true)
+}
+>>>
+object tup {
+  val foo = (a: (Int, Boolean)) => a
+  foo((2, true))
+}

--- a/scalafix-tests/src/test/resources/checkSyntax/NoAutoTupling.source
+++ b/scalafix-tests/src/test/resources/checkSyntax/NoAutoTupling.source
@@ -77,7 +77,7 @@ object tup {
   sum(1, (2, "foo"))
 }
 
-<<< auto-tupling with lambdas
+<<< SKIP auto-tupling with lambdas
 object tup {
   val foo = (a: (Int, Boolean)) => a
   foo(2, true)
@@ -86,4 +86,15 @@ object tup {
 object tup {
   val foo = (a: (Int, Boolean)) => a
   foo((2, true))
+}
+
+<<< SKIP auto-tupling with curried methods
+object tup {
+  def foo: (((Int, String)) => ((String, List[Int])) => Int) = a => b => a._1
+  foo(1 + 2, "foo")("bar", 1 :: 2 :: Nil)
+}
+>>>
+object tup {
+  def foo: (((Int, String)) => ((String, List[Int])) => Int) = a => b => a._1
+  foo((1 + 2, "foo"))(("bar", 1 :: 2 :: Nil))
 }

--- a/scalafix-tests/src/test/resources/checkSyntax/NoAutoTupling.source
+++ b/scalafix-tests/src/test/resources/checkSyntax/NoAutoTupling.source
@@ -40,7 +40,6 @@ object tup {
   def fooo(t: (Int, Int))(s: (String, String)): Int = ???
   fooo((1, 2))(("a", "b"))
 
-
   def baar(t: (Boolean, Int, String))(s: (Boolean, String))(k: (Int, String)): String = ???
   baar((true, 1, "foo"))((false, "42"))((42, "foo"))
 }

--- a/scalafix-tests/src/test/resources/checkSyntax/NoAutoTupling.source
+++ b/scalafix-tests/src/test/resources/checkSyntax/NoAutoTupling.source
@@ -1,0 +1,79 @@
+rewrites = [NoAutoTupling]
+<<< add explicit tuple
+object tup {
+  def fooo(t: (Int, Int)): Int = ???
+  fooo(1, 2)
+}
+>>>
+object tup {
+  def fooo(t: (Int, Int)): Int = ???
+  fooo((1, 2))
+}
+
+<<< multiple parameter lists, all auto-tupled
+object tup {
+  def fooo(t: (Int, Int))(s: (String, String)): Int = ???
+  fooo(1, 2)("a", "b")
+
+  def baar(t: (Boolean, Int, String))(s: (Boolean, String))(k: (Int, String)): String = ???
+  baar(true, 1, "foo")(false, "42")(42, "foo")
+}
+>>>
+object tup {
+  def fooo(t: (Int, Int))(s: (String, String)): Int = ???
+  fooo((1, 2))(("a", "b"))
+
+  def baar(t: (Boolean, Int, String))(s: (Boolean, String))(k: (Int, String)): String = ???
+  baar((true, 1, "foo"))((false, "42"))((42, "foo"))
+}
+
+<<< multiple parameter lists, some auto-tupled
+object tup {
+  def fooo(t: (Int, Int))(s: (String, String)): Int = ???
+  fooo((1, 2))("a", "b")
+
+  def baar(t: (Boolean, Int, String))(s: (Boolean, String))(k: (Int, String)): String = ???
+  baar(true, 1, "foo")((false, "42"))(42, "foo")
+}
+>>>
+object tup {
+  def fooo(t: (Int, Int))(s: (String, String)): Int = ???
+  fooo((1, 2))(("a", "b"))
+
+
+  def baar(t: (Boolean, Int, String))(s: (Boolean, String))(k: (Int, String)): String = ???
+  baar((true, 1, "foo"))((false, "42"))((42, "foo"))
+}
+
+<<< already tupled calls stay the same
+object tup {
+  def fooo(t: (Int, Int)): Int = ???
+  fooo((1, 2))
+}
+>>>
+object tup {
+  def fooo(t: (Int, Int)): Int = ???
+  fooo((1, 2))
+}
+
+<<< methods not involving tuples stay the same
+object tup {
+  def sum(a: Int, b: Int): Int = ???
+  sum(1, 2)
+}
+>>>
+object tup {
+  def sum(a: Int, b: Int): Int = ???
+  sum(1, 2)
+}
+
+<<< methods with tuples, but not single parameter
+object tup {
+  def sum(a: Int, b: (Int, String)): Int = ???
+  sum(1, (2, "foo"))
+}
+>>>
+object tup {
+  def sum(a: Int, b: (Int, String)): Int = ???
+  sum(1, (2, "foo"))
+}

--- a/scalafix-tests/src/test/resources/checkSyntax/NoAutoTupling.source
+++ b/scalafix-tests/src/test/resources/checkSyntax/NoAutoTupling.source
@@ -2,12 +2,12 @@ rewrites = [NoAutoTupling]
 <<< add explicit tuple
 object tup {
   def fooo(t: (Int, Int)): Int = ???
-  fooo(1, 2)
+  fooo(1 + 1, 2)
 }
 >>>
 object tup {
   def fooo(t: (Int, Int)): Int = ???
-  fooo((1, 2))
+  fooo((1 + 1, 2))
 }
 
 <<< multiple parameter lists, all auto-tupled


### PR DESCRIPTION
This is a first attempt at #66.

Trivial cases work fine, but it fails with multiple parameter lists since the tree is matched multiple times by `q"$fun(..$argss)"`.

E.g. when traversing the tree of `foo(1, 2)("a", "b")`, the pattern `q"$fun(..$argss)` matches

```scala
foo(1, 2)
```

and 

```scala
foo(1, 2)("a", "b")
```

so we end up with

```scala
foo(((1, 2)))(("a", "b"))
```

@olafurpg any hint to solve this?