### PR TITLE
Add NoUnusedImports semantic rewrite

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/rewrite/NoUnusedImports.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/NoUnusedImports.scala
@@ -1,0 +1,54 @@
+package scalafix
+package rewrite
+
+import scala.meta._
+import scala.annotation.tailrec
+
+case class NoUnusedImports(mirror: Mirror) extends SemanticRewrite(mirror) {
+
+  @tailrec
+  private[this] def removeTrailingWhitespacesOrSemi(
+      ctx: RewriteCtx,
+      t: Token,
+      patch: Patch = Patch.empty): Patch = {
+    val nextToken = ctx.tokenList.next(t)
+    if (nextToken.is[Token.LF] || nextToken.is[Token.Semicolon]) {
+      patch + ctx.removeToken(nextToken)
+    } else if (nextToken.is[Token.Space] || nextToken.is[Token.Tab]) {
+      removeTrailingWhitespacesOrSemi(ctx,
+                                      nextToken,
+                                      patch + ctx.removeToken(nextToken))
+    } else {
+      patch
+    }
+  }
+
+  @tailrec
+  private[this] def removeLeadingWhitespaces(
+      ctx: RewriteCtx,
+      t: Token,
+      patch: Patch = Patch.empty): Patch = {
+    val prevToken = ctx.tokenList.prev(t)
+    if (prevToken.is[Token.Space] || prevToken.is[Token.Tab]) {
+      removeLeadingWhitespaces(ctx,
+                               prevToken,
+                               patch + ctx.removeToken(prevToken))
+    } else {
+      patch
+    }
+  }
+
+  override def rewrite(ctx: RewriteCtx): Patch = {
+    val patches = mirror.database.messages.collect {
+      case Message(Anchor(_, start, end), _, "Unused import") =>
+        val toRemove =
+          ctx.tokens.dropWhile(_.start < start).takeWhile(_.end <= end)
+
+        val removeImport = toRemove.map(ctx.removeToken).asPatch
+        removeImport +
+          removeLeadingWhitespaces(ctx, toRemove.head) +
+          removeTrailingWhitespacesOrSemi(ctx, toRemove.last)
+    }
+    patches.asPatch
+  }
+}

--- a/scalafix-core/src/main/scala/scalafix/rewrite/ScalafixRewrites.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/ScalafixRewrites.scala
@@ -12,7 +12,8 @@ object ScalafixRewrites {
     ScalaJsRewrites.DemandJSGlobal(mirror),
 //    ExplicitImplicit(mirror), // Unsupported for now
     Xor2Either(mirror),
-    NoAutoTupling(mirror)
+    NoAutoTupling(mirror),
+    NoUnusedImports(mirror)
   )
   def all(mirror: Mirror): List[Rewrite] =
     syntax ++ semantic(mirror)

--- a/scalafix-tests/src/test/resources/checkSyntax/NoUnusedImports.source
+++ b/scalafix-tests/src/test/resources/checkSyntax/NoUnusedImports.source
@@ -1,0 +1,44 @@
+rewrites = [NoUnusedImports]
+<<< remove unused imports
+object imp {
+  import scala.collection.mutable.Set
+  import scala.collection.mutable.ListBuffer
+  import java.util._
+
+  val l = ListBuffer.empty[Int]
+}
+>>>
+object imp {
+  import scala.collection.mutable.ListBuffer
+
+  val l = ListBuffer.empty[Int]
+}
+
+<<< funky formatting
+object imp {
+  import scala.collection.mutable.Set    ; import scala.collection.mutable.ListBuffer
+  import scala.util.Success; import java.util.Date
+  import scala.util.Try
+
+  val d = new Date
+}
+>>>
+object imp {
+ import java.util.Date
+
+  val d = new Date
+}
+
+<<< selective import
+object imp {
+  import scala.collection.mutable.{ Set, ListBuffer }
+
+  val l = ListBuffer.empty[Int]
+}
+>>>
+object imp {
+  import scala.collection.mutable.{ ListBuffer }
+
+  val l = ListBuffer.empty[Int]
+}
+


### PR DESCRIPTION
This a stab at #126, following the idea of parsing compiler messages.

However, this strategy falls short when trying to fix selective imports.

Here's a failing test case

```scala
import scala.collection.mutable.{ Set, ListBuffer }
val l = ListBuffer.empty[Int]
```
The expected result would be

```scala
import scala.collection.mutable.{ ListBuffer }
val l = ListBuffer.empty[Int]
```

but it's actually

```scala
val l = ListBuffer.empty[Int]
```

which of course doesn't compile.

The reason is that the positions in the compiler message are not precise in case of unused members of a selective import and just point to the whole import statement, making it impossible to discriminate which member is used and which isn't.

/cc @jvican @olafurpg 