### PR TITLE
WIP: Disable Xml Rewrite in pattern position

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/rewrite/RemoveXmlLiterals.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/RemoveXmlLiterals.scala
@@ -20,7 +20,7 @@ case object RemoveXmlLiterals extends Rewrite {
     object Xml {
       def unapply(tree: Tree): Option[Seq[Lit]] =
         tree match {
-          case Pat.Xml(parts, _) => Some(parts)
+          //case Pat.Xml(parts, _) => Some(parts) // Not stable
           case Term.Xml(parts, _) => Some(parts)
           case _ => None
         }


### PR DESCRIPTION
We first need to fix scalameta/scalameta/issues/870 and figure out how to rewrite:
```scala
e match { case <a>{_*}</a> => }
```