### PR TITLE
Disable Xml Rewrite in pattern position

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -221,7 +221,7 @@ lazy val testkit = project
 
 lazy val testsDeps = List(
   // integration property tests
-  "org.renucci"        %% "scala-xml-quote"    % "0.1.3",
+  "org.renucci"        %% "scala-xml-quote"    % "0.1.4",
   "org.typelevel"      %% "catalysts-platform" % "0.0.5",
   "com.typesafe.slick" %% "slick"              % "3.2.0-M2",
   "com.chuusai"        %% "shapeless"          % "2.3.2",

--- a/scalafix-tests/input/src/main/scala/test/RemoveXmlLiterals.scala
+++ b/scalafix-tests/input/src/main/scala/test/RemoveXmlLiterals.scala
@@ -45,28 +45,20 @@ class RemoveXmlLiterals {
   }
 
   object I {
-    <div>{{</div>
+    val a = <div>{{</div>
+    val b = <div>}}</div>
+    // <div b="{{"/> >>> xml"""<div b="{{"/>"""
   }
 
-//  <<< SKIP protect curly brace 2
-//  object J {
-//      <div b="{{"/>
-//  }
-//  >>>
-//  import scala.xml.quote._
-//  object J {
-//    xml"""<div b="{{"/>"""
-//  }
-
-  object K {
+  object J {
     <a>{1}{2}</a>
   }
 
-  object L {
+  object K {
     null match { case <a></a> => }
   }
 
-  object M {
+  object L {
     null match { case <a>{_*}</a> => }
   }
 

--- a/scalafix-tests/input/src/main/scala/test/RemoveXmlLiterals.scala
+++ b/scalafix-tests/input/src/main/scala/test/RemoveXmlLiterals.scala
@@ -48,12 +48,26 @@ class RemoveXmlLiterals {
     <div>{{</div>
   }
 
-  object J {
-    <div b="{{"/>
-  }
+//  <<< SKIP protect curly brace 2
+//  object J {
+//      <div b="{{"/>
+//  }
+//  >>>
+//  import scala.xml.quote._
+//  object J {
+//    xml"""<div b="{{"/>"""
+//  }
 
   object K {
     <a>{1}{2}</a>
+  }
+
+  object L {
+    null match { case <a></a> => }
+  }
+
+  object M {
+    null match { case <a>{_*}</a> => }
   }
 
 }

--- a/scalafix-tests/output/src/main/scala/test/RemoveXmlLiterals.scala
+++ b/scalafix-tests/output/src/main/scala/test/RemoveXmlLiterals.scala
@@ -46,12 +46,26 @@ class RemoveXmlLiterals {
     xml"<div>{</div>"
   }
 
-  object J {
-    xml"""<div b="{"/>"""
-  }
+  //  <<< SKIP protect curly brace 2
+  //  object J {
+  //      <div b="{{"/>
+  //  }
+  //  >>>
+  //  import scala.xml.quote._
+  //  object J {
+  //    xml"""<div b="{{"/>"""
+  //  }
 
   object K {
     xml"<a>${1}${2}</a>"
+  }
+
+  object L {
+    null match { case <a></a> => }
+  }
+
+  object M {
+    null match { case <a>{_*}</a> => }
   }
 
 }

--- a/scalafix-tests/output/src/main/scala/test/RemoveXmlLiterals.scala
+++ b/scalafix-tests/output/src/main/scala/test/RemoveXmlLiterals.scala
@@ -43,28 +43,20 @@ class RemoveXmlLiterals {
   }
 
   object I {
-    xml"<div>{</div>"
+    val a = xml"<div>{</div>"
+    val b = xml"<div>}</div>"
+    // <div b="{{"/> >>> xml"""<div b="{{"/>"""
   }
 
-  //  <<< SKIP protect curly brace 2
-  //  object J {
-  //      <div b="{{"/>
-  //  }
-  //  >>>
-  //  import scala.xml.quote._
-  //  object J {
-  //    xml"""<div b="{{"/>"""
-  //  }
-
-  object K {
+  object J {
     xml"<a>${1}${2}</a>"
   }
 
-  object L {
+  object K {
     null match { case <a></a> => }
   }
 
-  object M {
+  object L {
     null match { case <a>{_*}</a> => }
   }
 


### PR DESCRIPTION
We need to figure out how to rewrite:
```scala
e match { case <a>{_*}</a> => }
```