### PR TITLE
fix missing double quotations in scalafix-testkit doc

### DIFF
--- a/readme/Testkit.scalatex
+++ b/readme/Testkit.scalatex
@@ -32,7 +32,7 @@
     @hl.scala
       // project/plugins.sbt
       addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
-      addSbtPlugin("org.scalameta" % "sbt-scalahost" % @V.scalameta)
+      addSbtPlugin("org.scalameta" % "sbt-scalahost" % "@V.scalameta")
       // build.sbt
       lazy val testsInput = project.in(file("scalafix/input"))
       lazy val testsExpectedOutput = project.in(file("scalafix/output"))


### PR DESCRIPTION
Currently the doc says:

```
addSbtPlugin("org.scalameta" % "sbt-scalahost" % 1.8.0)
```

This misses double quotations in version.

At open source spree at Copenhagen, I find this :)