### PR TITLE
Handle auto-tupling on functions

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/rewrite/NoAutoTupling.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/NoAutoTupling.scala
@@ -15,32 +15,68 @@ case class NoAutoTupling(mirror: Mirror) extends SemanticRewrite(mirror) {
     ctx.addLeft(args.head.tokens.head, "(") +
       ctx.addRight(args.last.tokens.last, ")")
 
+  private[this] def fixMethods(ctx: RewriteCtx,
+                               jvmSignature: String,
+                               argss: Seq[Seq[Term.Arg]],
+                               fixed: mutable.Set[Seq[Term.Arg]]): Patch = {
+    val argListSignatures =
+      jvmSignature.stripPrefix("(").takeWhile(_ != ')').split(';')
+    argListSignatures
+      .zip(argss)
+      .foldLeft(Patch.empty) {
+        case (patches, (argListSignature, args)) =>
+          if (!fixed(args) && singleTuplePattern
+                .matcher(argListSignature)
+                .matches && args.length > 1) {
+            fixed += args // dirty hack, see explanation above
+            patches + addWrappingParens(ctx, args)
+          } else {
+            patches
+          }
+      }
+  }
+
+  private[this] def fixFunctions(ctx: RewriteCtx,
+                                 symbol: Symbol,
+                                 argss: Seq[Seq[Term.Arg]],
+                                 fixed: mutable.Set[Seq[Term.Arg]],
+                                 mirror: Mirror): Patch =
+    mirror.database.denotations
+      .get(symbol)
+      .map { denot =>
+        val argListSignatures =
+          denot.info.split("=>").map(_.trim).toList.dropRight(1)
+        argListSignatures
+          .zip(argss)
+          .foldLeft(Patch.empty) {
+            case (patches, (argListSignature, args)) =>
+              if (!fixed(args) && argListSignature.startsWith("((") && argListSignature
+                    .endsWith("))")
+                  && args.length > 1) {
+                fixed += args
+                patches + addWrappingParens(ctx, args)
+              } else {
+                patches
+              }
+          }
+      }
+      .asPatch
+
   override def rewrite(ctx: RewriteCtx): Patch = {
     // "hack" to avoid fixing an argument list more than once due
     // to recursive matching of multiple parameters lists.
     val fixed = mutable.Set.empty[Seq[Term.Arg]]
     ctx.tree.collect {
       case q"${fun: Term.Ref}(...$argss)" if argss.nonEmpty =>
-        fun.symbolOpt
-          .collect {
-            case Symbol.Global(_, Signature.Method(_, jvmSignature)) =>
-              val argListSignatures =
-                jvmSignature.stripPrefix("(").takeWhile(_ != ')').split(';')
-              argListSignatures
-                .zip(argss)
-                .foldLeft(Patch.empty) {
-                  case (patches, (argListSignature, args)) =>
-                    if (!fixed(args) && singleTuplePattern
-                          .matcher(argListSignature)
-                          .matches && args.length > 1) {
-                      fixed += args // dirty hack, see explanation above
-                      patches + addWrappingParens(ctx, args)
-                    } else {
-                      patches
-                    }
-                }
-          }
-          .getOrElse(Patch.empty)
+        fun.symbolOpt.collect {
+          case s @ Symbol.Global(_, Signature.Method(_, jvmSignature)) =>
+            fixMethods(ctx, jvmSignature, argss, fixed) +
+              fixFunctions(ctx, s, argss, fixed, mirror)
+
+          case s @ Symbol.Global(_, Signature.Term(x))
+              if mirror.database.denotations.get(s).isDefined =>
+            fixFunctions(ctx, s, argss, fixed, mirror)
+        }.asPatch
     }.asPatch
   }
 }

--- a/scalafix-tests/input/src/main/scala/test/NoAutoTupling.scala
+++ b/scalafix-tests/input/src/main/scala/test/NoAutoTupling.scala
@@ -42,16 +42,16 @@ class NoAutoTupling {
     def sum(a: Int, b: (Int, String)): Int = ???
     sum(1, (2, "foo"))
   }
-//  <<< SKIP auto-tupling with lambdas
-//  object tup6 {
-//    val foo = (a: (Int, Boolean)) => a
-//    foo(2, true)
-//  }
-//  <<< SKIP auto-tupling with curried methods
-//  object tup7 {
-//    def foo: (((Int, String)) => ((String, List[Int])) => Int) = a => b => a._1
-//    foo(1 + 2, "foo")("bar", 1 :: 2 :: Nil)
-//  }
+//  <<< auto-tupling with lambdas
+ object tup6 {
+   val foo = (a: (Int, Boolean)) => a
+   foo(2, true)
+ }
+//  <<< auto-tupling with curried methods
+ object tup7 {
+   def foo: (((Int, String)) => ((String, List[Int])) => Int) = a => b => a._1
+   foo(1 + 2, "foo")("bar", 1 :: 2 :: Nil)
+ }
 //  <<< auto-tupling with class constructors
   object tup8 {
     case class Foo(t: (Int, String))(s: (Boolean, List[Int]))

--- a/scalafix-tests/output/src/main/scala/test/NoAutoTupling.scala
+++ b/scalafix-tests/output/src/main/scala/test/NoAutoTupling.scala
@@ -39,16 +39,16 @@ class NoAutoTupling {
     def sum(a: Int, b: (Int, String)): Int = ???
     sum(1, (2, "foo"))
   }
-//  <<< SKIP auto-tupling with lambdas
-//  object tup6 {
-//    val foo = (a: (Int, Boolean)) => a
-//    foo(2, true)
-//  }
-//  <<< SKIP auto-tupling with curried methods
-//  object tup7 {
-//    def foo: (((Int, String)) => ((String, List[Int])) => Int) = a => b => a._1
-//    foo(1 + 2, "foo")("bar", 1 :: 2 :: Nil)
-//  }
+//  <<< auto-tupling with lambdas
+ object tup6 {
+   val foo = (a: (Int, Boolean)) => a
+   foo((2, true))
+ }
+//  <<< auto-tupling with curried methods
+ object tup7 {
+   def foo: (((Int, String)) => ((String, List[Int])) => Int) = a => b => a._1
+   foo((1 + 2, "foo"))(("bar", 1 :: 2 :: Nil))
+ }
 //  <<< auto-tupling with class constructors
   object tup8 {
     case class Foo(t: (Int, String))(s: (Boolean, List[Int]))


### PR DESCRIPTION
Closes #147 

Still WIP, but the previously failing test cases are now green ✅ 

By the way, I just realized that maybe this whole rewrite can be a lot simpler if you use compiler messages.

Here's what scalac emits if the auto-tupling warning is on

```sg
[warn] /Users/gabro/buildo/scalafix/scalafix-tests/input/src/main/scala/test/NoAutoTupling.scala:15: Adapting argument list by creating a 2-tuple: this may not be what you want.
[warn]         signature: tup1.fooo(t: (Int, Int))(s: (String, String)): Int
[warn]   given arguments: 1, 2
[warn]  after adaptation: tup1.fooo((1, 2): (Int, Int))
[warn]     fooo(1, 2)("a", "b")
[warn]         ^
[warn] /Users/gabro/buildo/scalafix/scalafix-tests/input/src/main/scala/test/NoAutoTupling.scala:15: Adapting argument list by creating a 2-tuple: this may not be what you want.
[warn]         signature: tup1.fooo(t: (Int, Int))(s: (String, String)): Int
[warn]   given arguments: "a", "b"
[warn]  after adaptation: tup1.fooo(("a", "b"): (String, String))
[warn]     fooo(1, 2)("a", "b")
[warn]               ^             
```

The carets are conveniently pointing to the positions we need.

However, I think scalameta outputs inconsistent positions similarly to what it used to do for importees.