### PR TITLE
Fix #200, override injected scalacOptions.

### DIFF
--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -27,19 +27,33 @@ object ScalafixPlugin extends AutoPlugin {
   import autoImport._
   private val scalafixVersion = _root_.scalafix.Versions.version
 
+  // override injected settings by other sbt plugins.
+  private val leaveMeAlone = Seq(
+    skip in publish := true,
+    publishLocal := {},
+    publish := {},
+    test := {},
+    sources := Nil,
+    scalacOptions := Nil,
+    javaOptions := Nil,
+    libraryDependencies := Nil,
+    publishArtifact := false,
+    publishMavenStyle := false
+  )
+
   private val scalafixStub =
     Project(id = s"scalafix-stub", base = file(s"project/scalafix/stub"))
       .settings(
+        leaveMeAlone,
         description :=
-          """Project to host scalafix-cli, which is executed to run rewrites.""".stripMargin,
-        publishLocal := {},
-        publish := {},
-        publishArtifact := false,
-        publishMavenStyle := false, // necessary to support intransitive dependencies.
+          """Project to fetch jars for ch.epfl.scala:scalafix-cli_2.11, since there
+            |is no nice api in sbt to get jars for a ModuleId outside of
+            |a project. Please upvote https://github.com/sbt/sbt/issues/2879 to
+            |make this hack unnecessary.""".stripMargin,
         scalaVersion := Versions.scala212,
-        libraryDependencies := Nil, // remove injected dependencies from random sbt plugins.
-        libraryDependencies +=
+        libraryDependencies := Seq(
           "ch.epfl.scala" % "scalafix-cli" % scalafixVersion cross CrossVersion.full
+        )
       )
 
   override def extraProjects: Seq[Project] = Seq(scalafixStub)

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/test
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/test
@@ -1,5 +1,7 @@
 # compile should not affect scalafix
 > compile
+# This should not fail, see https://github.com/scalacenter/scalafix/issues/200
+> scalafix-stub/compile
 > scalafix
 > check
 


### PR DESCRIPTION
This error was caused by a bad interplay between sbt-scalahost and
sbt-scalafix.
- sbt-scalahost injects stuff into both scalacOptions and
  libraryDependencies.  In scalacOptions, we call update.value, which
  relies on the existence of dependencies in libraryDependencies.
- sbt-scalafix creates a a synthetic project "scalafix-stub" to fetch
  jars for scalafix-cli and sets the libraryDependencies to empty list
  but leaves scalacOptions unchanged. scalafix-stub/compile
  triggers scalafix-stub/scalacOptions which triggers
  update.value to return an empty list.

This commit sets scalacOptions of scalafix-sbt to empty list, overriding
the injected scalacOptions by sbt-scalahost.