### PR TITLE
Update docs on how to implement rewrites

### DIFF
--- a/readme/Faq.scalatex
+++ b/readme/Faq.scalatex
@@ -1,5 +1,6 @@
 @import Main._
 @import scalafix.Readme._
+@import scalafix.{Versions => V}
 
 @sect{FAQ / Troubleshooting}
 
@@ -16,3 +17,21 @@
     You might be using an old version of sbt.
     sbt-scalafix requires sbt 0.13.13 or higher.
 
+  @sect{Scalafix doesn't do anything}
+    @ul
+      @li
+        Make sure that you are running at least one rewrite.
+      @li
+        Make sure that you are using a supported Scala version: @V.supportedScalaVersions.mkString(", ")
+      @li
+        It could be that sbt-scalafix failed to enable the @sect.ref{Scalahost} compiler plugin.
+        You can check if Scalahost is enabled in sbt with @code{show myproject/scalacOptions}.
+        If it does not contains an option @code{-Xplugin:/path/to/scalahost.jar},
+        then Scalahost is not enabled.
+        See @lnk("here", "http://scalameta.org/tutorial/#Installation")
+        for how to manually install scalahost and verify that
+        @code{.semanticdb} files are created.
+
+  @sect{RemoveUnusedImports does not remove unused imports}
+    Make sure that you followed the instructions in @sect.ref{RemoveUnusedImports}
+    regarding scalac options.

--- a/readme/ImplementingRewrites.scalatex
+++ b/readme/ImplementingRewrites.scalatex
@@ -51,6 +51,21 @@
       have some unit tests and be documented so that other people can help maintain
       the rewrite.
 
+  @sect{scalacenter/scalafix.g8}
+    @p
+      Run the following commands to generate a skeleton project
+
+      @hl.scala
+        // by convention, --rewrite= should match the Github repo name.
+        // this makes it possible for users to run `scalafix github:org/reponame/v1.0`
+        sbt new scalacenter/scalafix.g8 --rewrite "reponame" --version=v1.0
+        cd reponame/scalafix
+        sbt tests/test
+    @p
+      Note that the @code{scalafix} directory is a self-contained sbt build
+      and can be put into the root directory of your repo.
+      The tests are written using @sect.ref{scalafix-testkit}.
+
   @sect{Example rewrites}
     The Scalafix repository contains several example rewrites and tests,
     see @lnk("here", "https://github.com/scalacenter/scalafix/tree/master/scalafix-core/src/main/scala/scalafix/rewrite").
@@ -159,13 +174,17 @@
     @p
       You have implemented a rewrite, you have tests, it works,
       and now you want to share it with the world. Congrats!
-      There are several ways to share a rewrite:
+      There are several ways to share a rewrite if the rewrite is contained in
+      a single file and uses no external dependencies,
       @ul
         @li
-          If the rewrite is contained in a single file, then you can create a gist
-          and tell users to use the @sect.ref{http:} protocol,
-          @code{scalafix --rewrites https://gist....}.
+          If you used @sect.ref{scalacenter/scalafix.g8} to build your project,
+          push your rewrite to github and tell users to run
+          @code{scalafix github:org/$reponame/$version}.
         @li
-          If your rewrite uses a custom library @code{foo}, then it's a bit tricky
-          to share it. See @issue(201) for more updates.
-        @li
+          otherwise, tell users to use the @sect.ref{http:} protocol,
+          @code{scalafix --rewrites https://gist....} where the url
+          points to the plaintext contents of your rewrite.
+
+      If your rewrite uses a custom library @code{foo}, then it's a bit tricky
+      to share it. See @issue(201) for more updates.

--- a/readme/ImplementingRewrites.scalatex
+++ b/readme/ImplementingRewrites.scalatex
@@ -1,0 +1,171 @@
+@import Main._
+@import scalafix.Readme._
+@import scalafix.rewrite._
+@import scalafix.{Versions => V}
+@import scalafix.cli.Cli
+
+@sect{Creating your own rewrite}
+  @p
+    It is possible to implement custom rewrites with Scalafix.
+    Depending on what your rewrite does, it may be a lot of work or very
+    little work. Don't hestitate to get an estimate on @gitter for
+    how complicated it would be to implement your rewrite.
+
+  @sect{Before you begin}
+    Before you dive right into the code of your rewrite, it might be
+    good to answer the following questions first.
+
+    @sect{What diff do you want to make?}
+      Scalafix is a tool to automatically produce diffs.
+      Before implementing a rewrite, it's good to manually migrate/refactor a
+      few examples first. Manually refactoring code is helpful
+      to estimate how complicated the rewrite is.
+
+    @sect{Is the expected output unambiguous?}
+      Does the rewrite require manual intervention or do you always know what
+      output the rewrite should produce? Scalafix currently does not yet support
+      interactive refactoring. However, Scalafix has support for configuration,
+      which makes it possible to leave some choice to the user on how the rewrite
+      should behave.
+
+    @sect{Who will use your rewrite?}
+      The target audience/users of your rewrite can impact the implementation the
+      rewrite. If you are the only end-user of the rewrite, then you can maybe
+      take shortcuts and worry less about rare corner cases that may be easier to fix
+      manually. If your rewrite is intended to be used by the entire Scala
+      community, then you might want to be more careful with corner cases.
+
+    @sect{What code will your rewrite fix?}
+      Is your rewrite specific to a particular codebase? Or is the rewrite intended
+      to be used on codebases that you don't have access to? If your rewrite is
+      specific to one codebase, then it's easier to validate if your rewrite
+      is ready. You may not even need tests, since your codebase is your only test.
+      If your rewrite is intended to be used in any random codebase, you may
+      want to have tests and put more effort into handling corner cases.
+      In general, the smaller the target domain of your rewrite, the easier it
+      is to implement a rewrite.
+
+    @sect{How often will your rewrite run?}
+      Are you writing a one-off migration script or will your rewrite run on
+      every pull request? A rewrite that runs on every pull request should ideally
+      have some unit tests and be documented so that other people can help maintain
+      the rewrite.
+
+  @sect{Example rewrites}
+    The Scalafix repository contains several example rewrites and tests,
+    see @lnk("here", "https://github.com/scalacenter/scalafix/tree/master/scalafix-core/src/main/scala/scalafix/rewrite").
+    These examples may serve as inspiration for your rewrite.
+
+  @sect{Vocabulary}
+    The following sections explain useful vocabulary when working with Scalafix.
+
+    @sect{Rewrite}
+      A rewrite is a small program/function that can produce diffs.
+      To implement a rewrite, you extend the
+      @lnk("Rewrite", "https://github.com/scalacenter/scalafix/blob/master/scalafix-core/src/main/scala/scalafix/rewrite/Rewrite.scala")
+      class.
+      To run a rewrite, users execute @code{scalafix --rewrites MyRewrite}.
+      Multiple rewrites can be composed into a single rewrite.
+      For example, the migration for Dotty may involve @sect.ref{ProcedureSyntax},
+      @sect.ref{ExplicitUnit}, @sect.ref{DottyVarArgPattern}, @sect.ref{ExplicitReturnTypes}
+      and a few other rewrites. It is possible to combine all of those rewrites
+      into a single @code{Dotty} rewrite so users can run
+      @code{scalafix --rewrites Dotty}.
+
+    @sect{RewriteCtx}
+      A rewrite context contains data structures and utilities to rewrite a single
+      source file. For example, the rewrite context contains the parsed @sect.ref{Tree},
+      @sect.ref{Tokens}, lookup tables for matching parentheses and more.
+
+    @sect{Patch}
+      A "Patch" is a data structure that describes how to produce a diff.
+      Two patches can combined into a single patch with the @code{+} operator.
+      A patch can also be empty. Patches can either be low-level "token patches",
+      that operate on the token level or high-level "tree patches" that operate
+      on parsed abstract syntax tree nodes. The public API for patch
+      operations is available in PatchOps.scala
+
+      @hl.ref(wd/"scalafix-core"/"src"/"main"/"scala"/"scalafix"/"patch"/"PatchOps.scala", start = "class SyntacticPatch")
+
+      Some things are typically easier to do on the token level and other
+      things are easier to do on the tree level.
+      The Patch API is constantly evolving and we regularly add more
+      utility methods to accomplish common tasks.
+      If you experience that it's difficult to implement something that
+      seems simple then don't hesitate to ask on @gitter.
+
+    @sect{Scalameta}
+      Scalafix uses @lnk("Scalameta", "http://scalameta.org/") to implement
+      rewrites.
+      Scalameta is a clean-room implementation of a metaprogramming toolkit for Scala.
+      This means it's not necessary to have experience with Scala compiler internals
+      to implement Scalafix rewrites.
+      In fact, Scalafix doesn't even depend on the Scala compiler.
+      Since Scalafix is not tied so a single compiler, this means that Scalafix
+      rewrites in theory can work with any Scala compiler, including @dotty and
+      IntelliJ Scala Plugin.
+
+    @sect{Scalahost}
+      Scalahost is a compiler plugin for Scala 2.x in the @sect.ref{Scalameta} project
+      that collects information to build a @sect.ref{Mirror}.
+      For more information about Scalahost, see
+      the @lnk("Scalameta documentation", "http://scalameta.org/tutorial/#Scalahost").
+
+    @sect{Token}
+      A token is for example an identifier @code{println}, a delimiter @code{[} @code{)},
+      or a whitespace character like space or newline.
+      In the context of Scalafix, a @code{Token} means the data structure
+      @code{scala.meta.Token}.
+      See @lnk("Scalameta tutorial", "http://scalameta.org/tutorial/#Tokens")
+      for more details.
+      See @lnk("Wikipedia", "https://en.wikipedia.org/wiki/Lexical_analysis#Token")
+      for a more general definition.
+
+    @sect{Tokens}
+      @code{Tokens} is a list of @sect.ref{Token}.
+      See @lnk("Scalameta tutorial", "http://scalameta.org/tutorial/#Tokens")
+
+    @sect{Tree}
+      A @code{Tree} is a parsed abstract syntax tree.
+      In the context of Scalafix, a @code{Tree} means the data structure
+      @code{scala.meta.Tree}.
+      See @lnk("Scalameta tutorial", "http://scalameta.org/tutorial/#Trees")
+      for more details.
+      See @lnk("Wikipedia", "https://en.wikipedia.org/wiki/Abstract_syntax_tree")
+      for a more general definition.
+
+    @sect{Syntactic}
+      A @sect.ref{Rewrite} is "syntactic" when it does not require information
+      from type-checking such as resolved names (@code{println} => @code{scala.Predef.println}),
+      types or terms, or inferred implicit arguments.
+      A syntactic rewrite can use @sect.ref{Tokens} and @sect.ref{Tree}, but
+      not @sect.ref{Mirror}.
+
+    @sect{Semantic}
+      A @sect.ref{Rewrite} is "semantic" if it requires information from the compiler
+      such as types, symbols and reported compiler messages.
+      A semantic rewrite can use a @sect.ref{Mirror}.
+
+    @sect{Mirror}
+       A mirror is a Scalameta concept that encapsulates a compilation context, providing
+       capabilities to perform semantic operations for @sect.ref{Semantic} rewrites.
+       To learn more about mirrors and its associated concepts (Symbol,
+       Denotation, ...), see the
+       @lnk("Scalameta tutorial", "http://scalameta.org/tutorial/#Mirror").
+
+  @scalatex.Testkit()
+
+  @sect{Sharing your rewrite}
+    @p
+      You have implemented a rewrite, you have tests, it works,
+      and now you want to share it with the world. Congrats!
+      There are several ways to share a rewrite:
+      @ul
+        @li
+          If the rewrite is contained in a single file, then you can create a gist
+          and tell users to use the @sect.ref{http:} protocol,
+          @code{scalafix --rewrites https://gist....}.
+        @li
+          If your rewrite uses a custom library @code{foo}, then it's a bit tricky
+          to share it. See @issue(201) for more updates.
+        @li

--- a/readme/ImplementingRewrites.scalatex
+++ b/readme/ImplementingRewrites.scalatex
@@ -56,7 +56,7 @@
       Run the following commands to generate a skeleton project
 
       @hl.scala
-        // by convention, --rewrite= should match the Github repo name.
+        // by convention, --rewrite= should match the GitHub repo name.
         // this makes it possible for users to run `scalafix github:org/reponame/v1.0`
         sbt new scalacenter/scalafix.g8 --rewrite "reponame" --version=v1.0
         cd reponame/scalafix
@@ -186,5 +186,5 @@
           @code{scalafix --rewrites https://gist....} where the url
           points to the plaintext contents of your rewrite.
 
-      If your rewrite uses a custom library @code{foo}, then it's a bit tricky
+      If your rewrite uses a custom library, then it's a bit tricky
       to share it. See @issue(201) for more updates.

--- a/readme/Readme.scalatex
+++ b/readme/Readme.scalatex
@@ -6,7 +6,7 @@
   @scalatex.Installation()
   @scalatex.Configuration()
   @scalatex.Rewrites()
-  @scalatex.Testkit()
+  @scalatex.ImplementingRewrites()
   @scalatex.Faq()
   @scalatex.Changelog()
 @scalatex.Footer()

--- a/readme/Testkit.scalatex
+++ b/readme/Testkit.scalatex
@@ -10,17 +10,8 @@
     semantic scalafix rewrites.
 
   @p
-    @b{Note.} Scalafix-testkit is a new module under active development
-    will be included in the next 0.4 release. The following instructions
-    may be incomplete. For any questions, don't hesitate to ask on @gitter
-
-
-  @p
-    To use scalafix-testkit
-
-    @hl.scala
-      @bintrayRepo
-      libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % "@V.stable" % Test cross CrossVersion.full
+    Note. This section may be incomplete, in case of any questions
+    don't hestitate to ask on @gitter.
 
   @p
     The following instructions assume you are using sbt.
@@ -41,8 +32,7 @@
         .in(file("scalafix/tests"))
         .settings(
           libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % "@V.stable" % Test cross CrossVersion.full,
-           buildInfoPackage := "scalafix.tests",
-           buildInfoObject := "BuildInfo",
+           buildInfoPackage := "myproject.scalafix.tests",
            buildInfoKeys := Seq[BuildInfoKey](
              "inputSourceroot" ->
                sourceDirectory.in(testsInput, Compile).value,
@@ -76,11 +66,11 @@
 
     Specify scalafix configuration inside comment at top of file like this.
 
-    @hl.ref(wd/"scalafix-tests"/"input"/"src"/"main"/"scala"/"test"/"VolatileLazyVal.scala")
+    @hl.ref(wd/"scalafix-tests"/"input"/"src"/"main"/"scala"/"test"/"ExplicitUnit.scala")
 
     And then testkit checks if rewritten codes match the one in output.
 
-    @hl.ref(wd/"scalafix-tests"/"output"/"src"/"main"/"scala"/"test"/"VolatileLazyVal.scala")
+    @hl.ref(wd/"scalafix-tests"/"output"/"src"/"main"/"scala"/"test"/"ExplicitUnit.scala")
 
   @p
     For a full working example, see the

--- a/readme/Testkit.scalatex
+++ b/readme/Testkit.scalatex
@@ -10,8 +10,9 @@
     semantic scalafix rewrites.
 
   @p
-    Note. This section may be incomplete, in case of any questions
-    don't hestitate to ask on @gitter.
+    Note. You may prefer to use the @sect.ref{scalacenter/scalafix.g8} template
+    to generate the following boilerplate.
+    In case of any problems, don't hestitate to ask on @gitter.
 
   @p
     The following instructions assume you are using sbt.

--- a/readme/src/main/scala/scalafix/Readme.scala
+++ b/readme/src/main/scala/scalafix/Readme.scala
@@ -16,7 +16,6 @@ object Readme {
       """<a href="https://gitter.im/scalacenter/scalafix?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge"><img src="https://camo.githubusercontent.com/382ebf95f5b4df9275ac203229928db8c8fd5c50/68747470733a2f2f6261646765732e6769747465722e696d2f6f6c6166757270672f7363616c61666d742e737667" alt="Join the chat at https://gitter.im/scalacenter/scalafix" data-canonical-src="https://badges.gitter.im/scalacenter/scalafix.svg" style="max-width:100%;"></a>""")
   def bintrayRepo =
     """resolvers += Resolver.bintrayRepo("scalameta", "maven")"""
-
   def github: String = "https://github.com"
   def repo: String = "https://github.com/scalacenter/scalafix"
   def metaRepo: String = "https://github.com/scalameta/scalameta"

--- a/scalafix-reflect/src/main/scala/scalafix/reflect/ScalafixCompilerDecoder.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/reflect/ScalafixCompilerDecoder.scala
@@ -41,24 +41,24 @@ object ScalafixCompilerDecoder {
     private[this] val GitHubShorthandWithSha =
       """github:([^\/]+)\/([^\/]+)\/([^\/]+)\?sha=(.+)""".r
 
-    private[this] def normalizedPackageName(repoName: String): String = {
-      val packageName = repoName.replaceAll("[^a-zA-Z0-9]", "_").toLowerCase
-      if (packageName.headOption.map(_.isDigit) == Some(true)) {
-        s"_$packageName"
-      } else {
-        packageName
-      }
-    }
+    private[this] val alphanumerical = "[^a-zA-Z0-9]"
+
+    // approximates the "format=Camel" formatter in giter8.
+    // http://www.foundweekends.org/giter8/Combined+Pages.html#Formatting+template+fields
+    private[this] def CamelCase(string: String): String =
+      string.split(alphanumerical).map(_.capitalize).mkString
+
+    // approximates the "format=Snake" formatter in giter8.
+    private[this] def SnakeCase(string: String): String =
+      string.split(alphanumerical).map(_.toLowerCase).mkString("_")
 
     private[this] def expandGitHubURL(org: String,
                                       repo: String,
                                       version: String,
                                       sha: String): URL = {
-      val normVersion = version.replaceAll("[^\\d]", "_")
-      val packageName = normalizedPackageName(repo)
-      val fileName = s"${packageName.capitalize}_$normVersion.scala"
+      val fileName = s"${CamelCase(repo)}_${SnakeCase(version)}.scala"
       new URL(
-        s"https://github.com/$org/$repo/blob/$sha/scalafix-rewrites/src/main/scala/$packageName/scalafix/$fileName")
+        s"https://github.com/$org/$repo/blob/$sha/scalafix/rewrites/src/main/scala/fix/$fileName")
     }
 
     def unapply(arg: Conf.Str): Option[URL] = arg.value match {

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/GitHubUrlRewriteSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/GitHubUrlRewriteSuite.scala
@@ -5,7 +5,7 @@ import scalafix.reflect.ScalafixCompilerDecoder.GitHubUrlRewrite
 import metaconfig.Conf
 import org.scalatest.FunSuite
 
-class GithubUrlRewriteSuite extends FunSuite {
+class GitHubUrlRewriteSuite extends FunSuite {
   def check(original: String, expected: String): Unit = {
     test(original) {
       Conf.Str(original) match {

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/GitHubUrlRewriteSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/GitHubUrlRewriteSuite.scala
@@ -2,37 +2,42 @@ package scalafix
 package tests
 
 import scalafix.reflect.ScalafixCompilerDecoder.GitHubUrlRewrite
-
-import org.scalatest.{FunSuiteLike, Matchers}
 import metaconfig.Conf
+import org.scalatest.FunSuite
 
-class GitHubUrlRewriteSuite extends FunSuiteLike with Matchers {
-  test("it expands a GitHub shorthand with a default sha") {
-    Conf.Str("github:someorg/somerepo/1.2.3") match {
-      case GitHubUrlRewrite(url) =>
-        url.toString shouldBe "https://github.com/someorg/somerepo/blob/master/scalafix-rewrites/src/main/scala/somerepo/scalafix/Somerepo_1_2_3.scala"
+class GithubUrlRewriteSuite extends FunSuite {
+  def check(original: String, expected: String): Unit = {
+    test(original) {
+      Conf.Str(original) match {
+        case GitHubUrlRewrite(obtained) =>
+          assert(obtained.toString == expected)
+      }
     }
   }
 
-  test("it expands a GitHub shorthand with a specific sha") {
-    Conf.Str("github:someorg/somerepo/1.2.3?sha=master~1") match {
-      case GitHubUrlRewrite(url) =>
-        url.toString shouldBe "https://github.com/someorg/somerepo/blob/master~1/scalafix-rewrites/src/main/scala/somerepo/scalafix/Somerepo_1_2_3.scala"
-    }
-  }
-
-  test("it replaces invalid characters in package name and file name with _") {
-    Conf.Str("github:someorg/some-repo/1.2.3") match {
-      case GitHubUrlRewrite(url) =>
-        url.toString shouldBe "https://github.com/someorg/some-repo/blob/master/scalafix-rewrites/src/main/scala/some_repo/scalafix/Some_repo_1_2_3.scala"
-    }
-  }
-
-  test(
-    "it adds an underscore to the package name and to the file name if the repo name begins with a digit") {
-    Conf.Str("github:someorg/42some-repo/1.2.3") match {
-      case GitHubUrlRewrite(url) =>
-        url.toString shouldBe "https://github.com/someorg/42some-repo/blob/master/scalafix-rewrites/src/main/scala/_42some_repo/scalafix/_42some_repo_1_2_3.scala"
-    }
-  }
+  check(
+    "github:someorg/somerepo/1.2.3",
+    "https://github.com/someorg/somerepo/blob/master/scalafix/rewrites/" +
+      "src/main/scala/fix/Somerepo_1_2_3.scala"
+  )
+  check(
+    "github:someorg/somerepo/1.2.3?sha=master~1",
+    "https://github.com/someorg/somerepo/blob/master~1/scalafix/rewrites/" +
+      "src/main/scala/fix/Somerepo_1_2_3.scala"
+  )
+  check(
+    "github:someorg/some-repo/1.2.3",
+    "https://github.com/someorg/some-repo/blob/master/scalafix/rewrites/" +
+      "src/main/scala/fix/SomeRepo_1_2_3.scala"
+  )
+  check(
+    "github:someorg/42some-repo/1.2.3",
+    "https://github.com/someorg/42some-repo/blob/master/scalafix/rewrites/" +
+      // NOTE: identifiers can't start with numbers like 42. However,
+      // giter8 doesn't support adding a prefix in case the first character
+      // is a number: http://www.foundweekends.org/giter8/Combined+Pages.html#Formatting+template+fields
+      // The rewrite inside the file can still be renamed to _42SomeRepo
+      // without problem.
+      "src/main/scala/fix/42someRepo_1_2_3.scala"
+  )
 }


### PR DESCRIPTION
While writing the docs, I realized that there's a lot of boilerplate needed to setup a build correctly. I created https://github.com/scalacenter/scalafix.g8 and updated the `github:` protocol to make the two match.