### PR TITLE
Add support for --classpath=auto.

### DIFF
--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -16,7 +16,7 @@ set-up-ssh() {
   ssh-add ${DEPLOY_KEY_FILE}
 }
 
-if [[ "$TRAVIS_BRANCH" == "master" && "$PUBLISH" == "true" ]]; then
+if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" = "false" && "$PUBLISH" == "true" ]]; then
   git log | head -n 20
   echo "Running publish from $(pwd)"
   set-up-ssh

--- a/scalafix-cli/src/test/scala/scalafix/cli/AutoClasspathSuite.scala
+++ b/scalafix-cli/src/test/scala/scalafix/cli/AutoClasspathSuite.scala
@@ -1,0 +1,24 @@
+package scalafix.cli
+
+import java.io.File
+import scala.meta.io.AbsolutePath
+import scala.meta.io.Classpath
+import org.scalatest.FunSuite
+
+class AutoClasspathSuite extends FunSuite {
+  test("--classpath=auto") {
+    val tmp = File.createTempFile("foo", "bar")
+    assert(tmp.delete())
+    val target = tmp.toPath.resolve("target")
+    val target2 = tmp.toPath.resolve("bar")
+    val semanticdb = target.resolve("META-INF").resolve("semanticdb")
+    val semanticdb2 = target2.resolve("META-INF").resolve("semanticdb")
+    val fakesemanticdb = tmp.toPath.resolve("blah").resolve("META-INF")
+    assert(semanticdb.toFile.mkdirs())
+    assert(semanticdb2.toFile.mkdirs())
+    assert(fakesemanticdb.toFile.mkdirs())
+    val obtained = CliRunner.autoClasspath(AbsolutePath(tmp))
+    val expected = Classpath(List(target, target2).map(AbsolutePath.apply))
+    assert(obtained.shallow.toSet == expected.shallow.toSet)
+  }
+}

--- a/scalafix-cli/src/test/scala/scalafix/cli/CliTest.scala
+++ b/scalafix-cli/src/test/scala/scalafix/cli/CliTest.scala
@@ -8,6 +8,8 @@ import scalafix.util.FileOps
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.PrintStream
+import java.nio.file.Paths
+import scala.meta.io.AbsolutePath
 import scalafix.cli.CliCommand.RunScalafix
 import caseapp.core.WithHelp
 import org.scalatest.FunSuite
@@ -138,7 +140,7 @@ class CliTest extends FunSuite with DiffAssertions {
 
   test("--sourceroot --classpath") {
     assert(Cli.parse(List("--sourceroot", "foo.scala")).isError)
-    assert(Cli.parse(List("--classpath", "foo")).isError)
+    assert(Cli.parse(List("--classpath", "auto")).isError)
     // NOTE: This assertion should fail by default, but scalafix-cli % Test
     // depends on testkit, which has scalahost-nsc as a dependency.
     assert(

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRewriteSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRewriteSuite.scala
@@ -2,7 +2,6 @@ package scalafix
 package testkit
 
 import scala.meta._
-import org.scalameta.logger
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FunSuite
 


### PR DESCRIPTION
This setting will automatically find directories containing .semanticdb
files. This might be useful for example to run scalafix-cli from an sbt
multi-module build outside of an sbt session.