### PR TITLE
Fix #158, fix ExplicitReturnType for non-implicits

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/config/ExplicitReturnTypesConfig.scala
+++ b/scalafix-core/src/main/scala/scalafix/config/ExplicitReturnTypesConfig.scala
@@ -5,7 +5,8 @@ import metaconfig._
 @DeriveConfDecoder
 case class ExplicitReturnTypesConfig(
     memberKind: Seq[MemberKind] = Nil,
-    memberVisibility: Seq[MemberVisibility] = Nil
+    memberVisibility: Seq[MemberVisibility] = Nil,
+    skipSimpleDefinitions: Boolean = true
 )
 
 sealed trait MemberVisibility

--- a/scalafix-core/src/main/scala/scalafix/rewrite/ExplicitReturnTypes.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/ExplicitReturnTypes.scala
@@ -27,17 +27,17 @@ case class ExplicitReturnTypes(mirror: Mirror)
     case Defn.Def(_, name, _, _, _, _) => name
   }
 
-  def visibility(mod:Mod):Option[MemberVisibility] = Option(mod).flatMap{
-    case _:Mod.Private => Some(MemberVisibility.Private)
-    case _:Mod.Protected => Some(MemberVisibility.Protected)
+  def visibility(mod: Mod): Option[MemberVisibility] = Option(mod).flatMap {
+    case _: Mod.Private => Some(MemberVisibility.Private)
+    case _: Mod.Protected => Some(MemberVisibility.Protected)
     case _ => None
   }
 
-  def kind(defn:Defn):Option[MemberKind] = Option(defn).flatMap{
-    case _:Defn.Val => Some(MemberKind.Val)
-    case _:Defn.Def => Some(MemberKind.Def)
-    case _:Defn.Var => Some(MemberKind.Var)
-    case _          => None
+  def kind(defn: Defn): Option[MemberKind] = Option(defn).flatMap {
+    case _: Defn.Val => Some(MemberKind.Val)
+    case _: Defn.Def => Some(MemberKind.Def)
+    case _: Defn.Var => Some(MemberKind.Var)
+    case _ => None
   }
 
   def parseDenotationInfo(denot: Denotation): Option[Type] = {
@@ -48,10 +48,12 @@ case class ExplicitReturnTypes(mirror: Mirror)
         throw new UnsupportedOperationException(
           s"Can't parse type for denotation $denot, denot.info=${denot.info}")
       }
-    if(denot.isVal || denot.isDef)
+    if (denot.isVal || denot.isDef)
       base.parse[Type].toOption
     else
-      base.parse[Stat].toOption.flatMap{_.collect{case Term.Ascribe(_,typ) => typ}.headOption}
+      base.parse[Stat].toOption.flatMap {
+        _.collect { case Term.Ascribe(_, typ) => typ }.headOption
+      }
   }
 
   def defnType(defn: Defn): Option[Type] =
@@ -76,27 +78,28 @@ case class ExplicitReturnTypes(mirror: Mirror)
         replace <- lhsTokens.reverseIterator.find(x =>
           !x.is[Token.Equals] && !x.is[Whitespace])
         typ <- defnType(defn)
-      } yield {
-        ctx.addRight(replace, s": ${typ.treeSyntax}")
-      }
+      } yield ctx.addRight(replace, s": ${typ.treeSyntax}")
     }.to[Seq]
 
-    def checkModsScope(mods:Seq[Mod]):Boolean =
-      ctx.config.explicitReturnTypes.memberVisibility.contains(mods.flatMap(visibility).headOption.getOrElse(Public))
-    def checkDefnScope(defn:Defn):Boolean =
+    def checkModsScope(mods: Seq[Mod]): Boolean =
+      ctx.config.explicitReturnTypes.memberVisibility
+        .contains(mods.flatMap(visibility).headOption.getOrElse(Public))
+    def checkDefnScope(defn: Defn): Boolean =
       kind(defn).exists(ctx.config.explicitReturnTypes.memberKind.contains)
 
     tree
       .collect {
         case t @ Defn.Val(mods, _, None, body)
-          if  t.hasMod(mod"implicit") && !isImplicitly(body)
-            || !t.hasMod(mod"implicit") && checkDefnScope(t) && checkModsScope(mods) =>
+            if t.hasMod(mod"implicit") && !isImplicitly(body)
+              || !t.hasMod(mod"implicit") && checkDefnScope(t) && checkModsScope(
+                mods) =>
           fix(t, body)
         case t @ Defn.Var(mods, _, None, Some(body))
-          if checkDefnScope(t) && checkModsScope(mods) =>
+            if checkDefnScope(t) && checkModsScope(mods) =>
           fix(t, body)
         case t @ Defn.Def(mods, _, _, _, None, body)
-          if t.hasMod(mod"implicit") || checkDefnScope(t) && checkModsScope(mods) =>
+            if t.hasMod(mod"implicit") || checkDefnScope(t) && checkModsScope(
+              mods) =>
           fix(t, body)
       }
       .flatten

--- a/scalafix-core/src/main/scala/scalafix/rewrite/ExplicitReturnTypes.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/ExplicitReturnTypes.scala
@@ -50,6 +50,10 @@ case class ExplicitReturnTypes(mirror: Mirror)
     if (denot.isVal || denot.isDef)
       base.parse[Type].toOption
     else
+    /*
+      Currently a symbol of Var points to its setter function.
+      That's why its argument type should be extracted via pattern-match.
+     */
       for {
         stat <- base.parse[Stat].toOption
         typ <- stat.collectFirst { case Term.Ascribe(_, typ) => typ }

--- a/scalafix-core/src/main/scala/scalafix/rewrite/ExplicitReturnTypes.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/ExplicitReturnTypes.scala
@@ -102,8 +102,8 @@ case class ExplicitReturnTypes(mirror: Mirror)
         body.is[Lit] && skipSimpleDefinitions
 
       defn.hasMod(mod"implicit") && !isImplicitly(body) ||
-      !matchesSimpleDefinition() &&
       !defn.hasMod(mod"implicit") &&
+      !matchesSimpleDefinition() &&
       matchesMemberKind() &&
       matchesMemberVisibility()
     }

--- a/scalafix-core/src/main/scala/scalafix/rewrite/ExplicitReturnTypes.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/ExplicitReturnTypes.scala
@@ -54,8 +54,6 @@ case class ExplicitReturnTypes(mirror: Mirror)
       base.parse[Stat].toOption.flatMap{_.collect{case Term.Ascribe(_,typ) => typ}.headOption}
   }
 
-  def denotations:Seq[(Symbol,Denotation)] = mirror.database.entries.flatMap(_._2.denotations)
-
   def defnType(defn: Defn): Option[Type] =
     for {
       name <- defnName(defn)

--- a/scalafix-core/src/main/scala/scalafix/rewrite/ExplicitReturnTypes.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/ExplicitReturnTypes.scala
@@ -91,15 +91,15 @@ case class ExplicitReturnTypes(mirror: Mirror)
       .collect {
         case t @ Defn.Val(mods, _, None, body)
             if t.hasMod(mod"implicit") && !isImplicitly(body)
-              || !t.hasMod(mod"implicit") && checkDefnScope(t) && checkModsScope(
-                mods) =>
+              || !t.hasMod(mod"implicit")
+                && checkDefnScope(t) && checkModsScope(mods) =>
           fix(t, body)
         case t @ Defn.Var(mods, _, None, Some(body))
             if checkDefnScope(t) && checkModsScope(mods) =>
           fix(t, body)
         case t @ Defn.Def(mods, _, _, _, None, body)
-            if t.hasMod(mod"implicit") || checkDefnScope(t) && checkModsScope(
-              mods) =>
+            if t.hasMod(mod"implicit")
+              || checkDefnScope(t) && checkModsScope(mods) =>
           fix(t, body)
       }
       .flatten

--- a/scalafix-core/src/main/scala/scalafix/rewrite/ExplicitReturnTypes.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/ExplicitReturnTypes.scala
@@ -50,10 +50,10 @@ case class ExplicitReturnTypes(mirror: Mirror)
     if (denot.isVal || denot.isDef)
       base.parse[Type].toOption
     else
-    /*
+      /*
       Currently a symbol of Var points to its setter function.
       That's why its argument type should be extracted via pattern-match.
-     */
+       */
       for {
         stat <- base.parse[Stat].toOption
         typ <- stat.collectFirst { case Term.Ascribe(_, typ) => typ }

--- a/scalafix-core/src/main/scala/scalafix/rewrite/ExplicitReturnTypes.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/ExplicitReturnTypes.scala
@@ -42,8 +42,7 @@ case class ExplicitReturnTypes(mirror: Mirror)
 
   def parseDenotationInfo(denot: Denotation): Option[Type] = {
     val base =
-      if (denot.isVal) denot.info
-      else if(denot.isVar) denot.info.replaceFirst("var ", "")
+      if (denot.isVal || denot.isVar) denot.info
       else if (denot.isDef) denot.info.replaceFirst(".*\\)", "")
       else {
         throw new UnsupportedOperationException(

--- a/scalafix-tests/input/src/main/scala/test/ExplicitReturnTypes.scala
+++ b/scalafix-tests/input/src/main/scala/test/ExplicitReturnTypes.scala
@@ -1,14 +1,14 @@
 /*
 rewrites = ExplicitReturnTypes
-explicitReturnTypes.memberKind = [Def, Var]
+explicitReturnTypes.memberKind = [Val, Def, Var]
 explicitReturnTypes.memberVisibility = [Public, Protected]
  */
 package test
 
 object ExplicitReturnTypes {
-  val a = 1
-  def b() = List
-  var c = true
+  val a = 1 + 2
+  def b() = "a" + "b"
+  var c = 1 == 1
   protected val d = 1.0f
   protected def e(a:Int,b:Double) = a + b
   protected var f = (x: Int) => x + 1

--- a/scalafix-tests/input/src/main/scala/test/ExplicitReturnTypes.scala
+++ b/scalafix-tests/input/src/main/scala/test/ExplicitReturnTypes.scala
@@ -1,9 +1,21 @@
 /*
 rewrites = ExplicitReturnTypes
+explicitReturnTypes.memberKind = [Def, Var]
+explicitReturnTypes.memberVisibility = [Public, Protected]
  */
 package test
 
 object ExplicitReturnTypes {
+  val a = 1
+  def b() = List
+  var c = true
+  protected val d = 1.0f
+  protected def e(a:Int,b:Double) = a + b
+  protected var f = (x: Int) => x + 1
+  private val g = 1
+  private def h(a:Int) = ""
+  private var i = 1
+
   implicit val L = List(1)
   implicit val M = Map(1 -> "STRING")
   implicit def D = 2

--- a/scalafix-tests/input/src/main/scala/test/ExplicitReturnTypes.scala
+++ b/scalafix-tests/input/src/main/scala/test/ExplicitReturnTypes.scala
@@ -16,6 +16,8 @@ object ExplicitReturnTypes {
   private def h(a:Int) = ""
   private var i = 1
 
+  private implicit var j = 1
+
   implicit val L = List(1)
   implicit val M = Map(1 -> "STRING")
   implicit def D = 2

--- a/scalafix-tests/output/src/main/scala/test/ExplicitReturnTypes.scala
+++ b/scalafix-tests/output/src/main/scala/test/ExplicitReturnTypes.scala
@@ -11,6 +11,8 @@ object ExplicitReturnTypes {
   private def h(a:Int) = ""
   private var i = 1
 
+  private implicit var j: Int = 1
+
   implicit val L: List[Int] = List(1)
   implicit val M: scala.collection.immutable.Map[Int, String] = Map(1 -> "STRING")
   implicit def D: Int = 2

--- a/scalafix-tests/output/src/main/scala/test/ExplicitReturnTypes.scala
+++ b/scalafix-tests/output/src/main/scala/test/ExplicitReturnTypes.scala
@@ -1,6 +1,16 @@
 package test
 
 object ExplicitReturnTypes {
+  val a = 1
+  def b(): scala.collection.immutable.List.type = List
+  var c: Boolean = true
+  protected val d = 1.0f
+  protected def e(a:Int,b:Double): Double = a + b
+  protected var f: Int => Int = (x: Int) => x + 1
+  private val g = 1
+  private def h(a:Int) = ""
+  private var i = 1
+
   implicit val L: List[Int] = List(1)
   implicit val M: scala.collection.immutable.Map[Int, String] = Map(1 -> "STRING")
   implicit def D: Int = 2

--- a/scalafix-tests/output/src/main/scala/test/ExplicitReturnTypes.scala
+++ b/scalafix-tests/output/src/main/scala/test/ExplicitReturnTypes.scala
@@ -1,9 +1,9 @@
 package test
 
 object ExplicitReturnTypes {
-  val a = 1
-  def b(): scala.collection.immutable.List.type = List
-  var c: Boolean = true
+  val a: Int = 1 + 2
+  def b(): String = "a" + "b"
+  var c: Boolean = 1 == 1
   protected val d = 1.0f
   protected def e(a:Int,b:Double): Double = a + b
   protected var f: Int => Int = (x: Int) => x + 1


### PR DESCRIPTION
This fixes #158 to add ExplicitReturnType with respecting configuration.

ATM memberKind and memberVisibility configuration supports are implemented in "AND" basis.

For example if you specify `[Val, Def]` for memberKind and `[Protected]` for memberVisibility, only `protected val` and `protected def`s are rewritten.
I believe it should be so, but please feel free to let me know if it's different from what you expect.

And I'm so sorry for making issue reference a bit dirty.