### PR TITLE
Lazily compute mirror so auto-detect --syntactic.

### DIFF
--- a/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
+++ b/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
@@ -14,27 +14,26 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.function.UnaryOperator
 import java.util.regex.Pattern
 import java.util.regex.PatternSyntaxException
-import java.util.stream.Collectors
 import scala.meta._
 import scala.meta.inputs.Input
 import scala.meta.internal.inputs._
 import scala.meta.internal.io.PlatformFileIO
 import scala.meta.internal.semantic.vfs
 import scala.meta.io.AbsolutePath
-import scala.util.Success
 import scala.util.Try
 import scala.util.control.NonFatal
 import scalafix.cli.termdisplay.TermDisplay
 import scalafix.config.Class2Hocon
 import scalafix.config.FilterMatcher
+import scalafix.config.LazyMirror
+import scalafix.config.MetaconfigPendingUpstream
 import scalafix.config.PrintStreamReporter
+import scalafix.config.RewriteKind
 import scalafix.config.ScalafixConfig
 import scalafix.config.ScalafixReporter
 import scalafix.reflect.ScalafixCompilerDecoder
 import scalafix.reflect.ScalafixToolbox
-import scalafix.rewrite.ScalafixRewrites
 import scalafix.syntax._
-import difflib.DiffUtils
 import metaconfig.Configured.NotOk
 import metaconfig.Configured.Ok
 import metaconfig._
@@ -44,7 +43,6 @@ sealed abstract case class CliRunner(
     sourceroot: AbsolutePath,
     cli: ScalafixOptions,
     config: ScalafixConfig,
-    database: Option[Database],
     rewrite: Rewrite,
     inputs: Seq[FixFile],
     replacePath: AbsolutePath => AbsolutePath
@@ -86,8 +84,7 @@ sealed abstract case class CliRunner(
   // creation of the .semanticdb file. Without this check, we risk overwriting
   // the latest changes written by the user.
   private def isUpToDate(input: FixFile): Boolean =
-    if (database.isEmpty) true
-    else if (!input.toIO.exists() && cli.outTo.nonEmpty) true
+    if (!input.toIO.exists() && cli.outTo.nonEmpty) true
     else {
       input.mirror match {
         case Some(Input.LabeledString(_, contents)) =>
@@ -165,27 +162,14 @@ object CliRunner {
   def fromOptions(options: ScalafixOptions): Configured[CliRunner] = {
     val builder = new CliRunner.Builder(options)
     for {
-      database <- builder.resolvedMirror
-      sourceroot <- builder.resolvedSourceroot
       rewrite <- builder.resolvedRewrite
       replace <- builder.resolvedPathReplace
       inputs <- builder.fixFilesWithMirror
       config <- builder.resolvedConfig
     } yield {
       if (options.verbose) {
-        val entries = database.map(_.entries.length).getOrElse(0)
-        val inputsNames = inputs
-          .map(
-            _.original.path.syntax
-              .stripPrefix(options.common.workingDirectory + "/"))
-          .mkString(", ")
         options.common.err.println(
-          s"""|Files to fix (${inputs.length}):
-              |$inputsNames
-              |Database entires count: $entries
-              |Database head:
-              |${database.toString.take(1000)}
-              |Config:
+          s"""|Config:
               |${Class2Hocon(config)}
               |Rewrite:
               |$rewrite
@@ -193,10 +177,9 @@ object CliRunner {
         )
       }
       new CliRunner(
-        sourceroot = sourceroot,
+        sourceroot = builder.resolvedSourceroot,
         cli = options,
         config = config,
-        database = database,
         rewrite = rewrite,
         replacePath = replace,
         inputs = inputs
@@ -236,75 +219,64 @@ object CliRunner {
 
     implicit val workingDirectory: AbsolutePath = common.workingPath
 
-    val resolvedClasspath: Option[Configured[Classpath]] =
-      if (autoMirror) {
-        val cp = autoClasspath(common.workingPath)
-        if (verbose) {
-          common.err.println(s"Automatic classpath=$cp")
-        }
-        if (cp.shallow.nonEmpty) Some(Ok(cp))
-        else {
-          val msg =
-            """Unable to automatically detect .semanticdb files to run semantic rewrites. Possible workarounds:
-              |- re-compile sources with the scalahost compiler plugin enabled.
-              |- pass in the --syntactic flag to run only syntactic rewrites.
-              |- explicitly pass in --classpath and --sourceroot to run semantic rewrites.""".stripMargin
-          Some(ConfError.msg(msg).notOk)
-        }
-      } else {
-        classpath.map { x =>
-          val paths = x.split(File.pathSeparator).map { path =>
+    def resolveClasspath: Configured[Classpath] =
+      classpath match {
+        case Some(cp) =>
+          val paths = cp.split(File.pathSeparator).map { path =>
             AbsolutePath.fromString(path)(common.workingPath)
           }
           Ok(Classpath(paths))
+        case None =>
+          val cp = autoClasspath(common.workingPath)
+          if (verbose) {
+            common.err.println(s"Automatic classpath=$cp")
+          }
+          if (cp.shallow.nonEmpty) Ok(cp)
+          else {
+            val msg =
+              """Unable to automatically detect .semanticdb files to run semantic rewrites. Possible workarounds:
+                |- re-compile sources with the scalahost compiler plugin enabled.
+                |- explicitly pass in --classpath and --sourceroot to run semantic rewrites.""".stripMargin
+            ConfError.msg(msg).notOk
+          }
+      }
+
+    val resolvedSourceroot: AbsolutePath =
+      sourceroot
+        .map(AbsolutePath.fromString(_))
+        .getOrElse(common.workingPath)
+
+    // We don't know yet if we need to compute the database or not.
+    // If all the rewrites are syntactic, we never need to compute the mirror.
+    // If a single rewrite is semantic, then we need to compute the database.
+    private var cachedDatabase = Option.empty[Configured[Database]]
+    private def hasDatabase = cachedDatabase.isDefined
+    private def computeAndCacheDatabase(): Option[Database] = {
+      val result: Configured[Database] = cachedDatabase.getOrElse {
+        try {
+          resolveClasspath.map { classpath =>
+            val db = Database.load(classpath, Sourcepath(resolvedSourceroot))
+            if (verbose) {
+              common.err.println(
+                s"Loaded database with ${db.entries.length} entries.")
+            }
+            db
+          }
+        } catch {
+          case NonFatal(e) =>
+            ConfError.exception(e, common.stackVerbosity).notOk
         }
       }
-
-    val autoSourceroot: Option[AbsolutePath] =
-      if (autoMirror) resolvedClasspath.map(_ => common.workingPath)
-      else {
-        sourceroot
-          .map(AbsolutePath.fromString(_))
-          .orElse(Some(common.workingPath))
+      if (cachedDatabase.isEmpty) {
+        cachedDatabase = Some(result)
       }
-
-    // Database
-    private val resolvedDatabase: Configured[Database] =
-      (resolvedClasspath, autoSourceroot) match {
-        case (Some(Ok(cp)), sp) =>
-          val tryMirror = for {
-            mirror <- Try {
-              val sourcepath = sp.map(Sourcepath.apply)
-              val mirror =
-                vfs.Database.load(cp).toSchema.toMeta(sourcepath)
-              mirror
-            }
-          } yield mirror
-          tryMirror match {
-            case Success(x) => Ok(x)
-            case scala.util.Failure(e) => ConfError.msg(e.toString).notOk
-          }
-        case (Some(err @ NotOk(_)), _) => err
-        case (None, _) =>
-          Ok(ScalafixRewrites.emptyDatabase)
-      }
-    val resolvedMirror: Configured[Option[Database]] =
-      resolvedDatabase.map { x =>
-        if (x == ScalafixRewrites.emptyDatabase) None
-        else Some(x)
-      }
-    val resolvedMirrorSourceroot: Configured[AbsolutePath] =
-      autoSourceroot match {
-        case None => ConfError.msg("--sourceroot is required").notOk
-        case Some(path) => Ok(path)
-      }
-    val resolvedSourceroot: Configured[AbsolutePath] =
-      resolvedMirror.flatMap {
-        // Use mirror sourceroot if Mirror.nonEmpty
-        case Some(_) => resolvedMirrorSourceroot
-        // Use working directory if running syntactic rewrites.
-        case None => Ok(common.workingPath)
-      }
+      result.toEither.toOption
+    }
+    private def resolveDatabase(kind: RewriteKind): Option[Database] = {
+      if (kind.isSyntactic) None
+      else computeAndCacheDatabase()
+    }
+    private val lazyMirror: LazyMirror = resolveDatabase
 
     // expands a single file into a list of files.
     def expand(matcher: FilterMatcher)(path: AbsolutePath): Seq[FixFile] = {
@@ -356,27 +328,6 @@ object CliRunner {
       paths.toVector.flatMap(expand(pathMatcher))
     }
 
-    val mirrorInputs: Configured[Map[AbsolutePath, Input.LabeledString]] =
-      for {
-        sourceroot <- resolvedSourceroot
-        database <- resolvedDatabase
-      } yield {
-        val inputsByAbsolutePath = database.entries.collect {
-          case (input @ Input.LabeledString(path, _), _) =>
-            sourceroot.resolve(path) -> input
-        }
-        inputsByAbsolutePath.toMap
-      }
-
-    val fixFilesWithMirror: Configured[Seq[FixFile]] = for {
-      fromMirror <- mirrorInputs
-      files <- fixFiles
-    } yield {
-      files.map { file =>
-        file.copy(mirror = fromMirror.get(file.original.path))
-      }
-    }
-
     val resolvedConfigInput: Configured[Input] =
       (config, configStr) match {
         case (Some(x), Some(y)) =>
@@ -401,36 +352,24 @@ object CliRunner {
     //  - --config-str or --config
     //  - .scalafix.conf in working directory
     //  - ScalafixConfig.default
-    val resolvedRewriteAndConfig: Configured[(Rewrite, ScalafixConfig)] =
+    val resolvedRewriteAndConfig: Configured[(Rewrite, ScalafixConfig)] = {
+      val decoder = ScalafixCompilerDecoder.fromMirror(lazyMirror)
       for {
-        mirror <- resolvedMirror
-        decoder = ScalafixCompilerDecoder.fromMirrorOption(mirror)
-        cliArgRewrite <- rewrites
-          .foldLeft(ScalafixToolbox.emptyRewrite) {
-            case (rewrite, next) =>
-              rewrite
-                .product(decoder.read(Conf.Str(next)))
-                .map { case (a, b) => a.andThen(b) }
-          }
-        inputs <- fixFilesWithMirror
+        inputs <- fixFiles
         configuration <- {
-          if (inputs.isEmpty) {
-            Ok(Rewrite.empty -> ScalafixConfig.default)
-          } else {
+          if (inputs.isEmpty) Ok(Rewrite.empty -> ScalafixConfig.default)
+          else {
             resolvedConfigInput.flatMap(input =>
-              ScalafixConfig.fromInput(input, mirror)(decoder))
+              ScalafixConfig.fromInput(input, lazyMirror, rewrites)(decoder))
           }
         }
+      } yield {
         // TODO(olafur) implement withFilter on Configured
-        (configRewrite, scalafixConfig) = configuration
-        finalConfig = scalafixConfig.copy(
-          reporter = scalafixConfig.reporter match {
-            case r: PrintStreamReporter => r.copy(outStream = common.err)
-            case _ => ScalafixReporter.default.copy(outStream = common.err)
-          }
-        )
-        finalRewrite = cliArgRewrite.andThen(configRewrite)
-      } yield finalRewrite -> finalConfig
+        val (finalRewrite, scalafixConfig) = configuration
+        val finalConfig = scalafixConfig.withOut(common.err)
+        finalRewrite -> finalConfig
+      }
+    }
     val resolvedRewrite: Configured[Rewrite] =
       resolvedRewriteAndConfig.map(_._1)
     val resolvedConfig: Configured[ScalafixConfig] =
@@ -448,5 +387,28 @@ object CliRunner {
       case e: PatternSyntaxException =>
         ConfError.msg(s"Invalid regex '$outFrom'! ${e.getMessage}").notOk
     }
+
+    val mirrorInputs: Configured[Map[AbsolutePath, Input.LabeledString]] =
+      for {
+        _ <- resolvedRewrite // force evaluation of rewrite.
+        database <- cachedDatabase.getOrElse(Ok(Database(Nil)))
+      } yield {
+        val inputsByAbsolutePath = database.entries.collect {
+          case (input @ Input.LabeledString(path, _), _) =>
+            resolvedSourceroot.resolve(path) -> input
+        }
+        inputsByAbsolutePath.toMap
+      }
+
+    val fixFilesWithMirror: Configured[Seq[FixFile]] = for {
+      fromMirror <- mirrorInputs
+      files <- fixFiles
+    } yield {
+      files.map { file =>
+        val labeled = fromMirror.get(file.original.path)
+        file.copy(mirror = labeled)
+      }
+    }
+
   }
 }

--- a/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
+++ b/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
@@ -32,12 +32,10 @@ import scalafix.config.RewriteKind
 import scalafix.config.ScalafixConfig
 import scalafix.config.ScalafixReporter
 import scalafix.reflect.ScalafixCompilerDecoder
-import scalafix.reflect.ScalafixToolbox
 import scalafix.syntax._
 import metaconfig.Configured.NotOk
 import metaconfig.Configured.Ok
 import metaconfig._
-import org.scalameta.logger
 
 sealed abstract case class CliRunner(
     sourceroot: AbsolutePath,
@@ -270,7 +268,7 @@ object CliRunner {
       if (cachedDatabase.isEmpty) {
         cachedDatabase = Some(result)
       }
-      result.toEither.toOption
+      result.toEither.right.toOption
     }
     private def resolveDatabase(kind: RewriteKind): Option[Database] = {
       if (kind.isSyntactic) None

--- a/scalafix-cli/src/main/scala/scalafix/cli/ScalafixOptions.scala
+++ b/scalafix-cli/src/main/scala/scalafix/cli/ScalafixOptions.scala
@@ -63,8 +63,6 @@ case class ScalafixOptions(
     )
     @ValueDescription("entry1.jar:entry2.jar:target/scala-2.12/classes")
     classpath: Option[String] = None,
-    @HelpMessage("""don't automatically look for semanticdb files.""")
-    syntactic: Boolean = false,
     @HelpMessage(
       s"""Rewrite rules to run.""".stripMargin
     )
@@ -129,8 +127,4 @@ case class ScalafixOptions(
       """Print out zsh completion file for scalafix. To install:
         |          scalafix --zsh > /usr/local/share/zsh/site-functions/_scalafix""".stripMargin)
     zsh: Boolean = false
-) {
-  def autoMirror: Boolean = {
-    !syntactic && classpath.isEmpty && sourceroot.isEmpty
-  }
-}
+)

--- a/scalafix-cli/src/test/scala/scalafix/cli/CliTest.scala
+++ b/scalafix-cli/src/test/scala/scalafix/cli/CliTest.scala
@@ -35,7 +35,7 @@ trait ScalafixCliTest extends FunSuite with DiffAssertions {
     workingDirectory = cwd.toString
   )
 
-  val default = ScalafixOptions(syntactic = true, common = devNull)
+  val default = ScalafixOptions(common = devNull)
 
 }
 
@@ -161,7 +161,6 @@ class CliTest extends ScalafixCliTest {
     FileOps.writeFile(file, "object a { implicit val x = ??? }")
     val code = Cli.runOn(
       default.copy(rewrites = List(ExplicitReturnTypes.toString),
-                   syntactic = true,
                    files = List(file.getAbsolutePath),
                    common = devNull))
     assert(code == ExitStatus.InvalidCommandLineOption)

--- a/scalafix-core/src/main/scala/scalafix/config/RewriteKind.scala
+++ b/scalafix-core/src/main/scala/scalafix/config/RewriteKind.scala
@@ -1,0 +1,13 @@
+package scalafix.config
+
+// Boolean enum, either Syntactic or Semantic.
+sealed trait RewriteKind {
+  def isSyntactic: Boolean = this == RewriteKind.Syntactic
+}
+
+object RewriteKind {
+  def apply(syntactic: Boolean): RewriteKind =
+    if (syntactic) Syntactic else Semantic
+  case object Syntactic extends RewriteKind
+  case object Semantic extends RewriteKind
+}

--- a/scalafix-core/src/main/scala/scalafix/config/package.scala
+++ b/scalafix-core/src/main/scala/scalafix/config/package.scala
@@ -2,7 +2,17 @@ package scalafix
 
 import scala.meta.Tree
 import scala.meta.parsers.Parse
+import scala.meta.semantic.Database
+import scala.meta.semantic.Mirror
 
 package object config extends ScalafixMetaconfigReaders {
   type MetaParser = Parse[_ <: Tree]
+  // The challenge when loading a rewrite is that 1) if it's semantic it needs a
+  // mirror constructor argument and 2) we don't know upfront if it's semantic.
+  // For example, to know if a classloaded rewrites is semantic or syntactic
+  // we have to test against it's Class[_]. For default rewrites, the interface
+  // to detect if a rewrite is semantic is different.
+  // LazyMirror allows us to delay the computation of a mirror right up until
+  // the moment we instantiate the rewrite.
+  type LazyMirror = RewriteKind => Option[Database]
 }

--- a/scalafix-core/src/main/scala/scalafix/patch/Patch.scala
+++ b/scalafix-core/src/main/scala/scalafix/patch/Patch.scala
@@ -166,8 +166,7 @@ object Patch {
     })
     val importPatches =
       patches.collect { case e: ImportPatch => e } ++
-        replacePatches.collect { case e: ImportPatch => e } ++
-        ctx.config.patches.all.collect { case e: ImportPatch => e }
+        replacePatches.collect { case e: ImportPatch => e }
     val importTokenPatches = {
       val result = ImportPatchOps.superNaiveImportPatchToTokenPatchConverter(
         ctx,

--- a/scalafix-core/src/main/scala/scalafix/patch/Replacer.scala
+++ b/scalafix-core/src/main/scala/scalafix/patch/Replacer.scala
@@ -49,12 +49,7 @@ object Replacer {
   def toTokenPatches(ast: Tree, replacements: Seq[Replace])(
       implicit ctx: RewriteCtx,
       mirror: Mirror): Seq[Patch] = {
-    new Replacer().toTokenPatches(
-      ast,
-      replacements ++ ctx.config.patches.all.collect {
-        case r: Replace => r
-      }
-    )
+    new Replacer().toTokenPatches(ast, replacements)
   }
 }
 

--- a/scalafix-core/src/main/scala/scalafix/rewrite/RemoveUnusedImports.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/RemoveUnusedImports.scala
@@ -5,7 +5,7 @@ import scala.meta._
 import scalafix.syntax._
 import org.scalameta.logger
 
-case class RemoveUnusedImports(mirror: Mirror)
+case class RemoveUnusedImports(mirror: Database)
     extends SemanticRewrite(mirror) {
   private val unusedImports = mirror.database.messages.toIterator.collect {
     case Message(pos, _, "Unused import") =>

--- a/scalafix-core/src/main/scala/scalafix/rewrite/ScalafixRewrites.scala
+++ b/scalafix-core/src/main/scala/scalafix/rewrite/ScalafixRewrites.scala
@@ -11,18 +11,18 @@ object ScalafixRewrites {
     NoValInForComprehension,
     DottyVarArgPattern
   )
-  def semantic(mirror: Mirror): List[Rewrite] = List(
+  def semantic(mirror: Database): List[Rewrite] = List(
     ExplicitReturnTypes(mirror),
     RemoveUnusedImports(mirror),
     Xor2Either(mirror),
     NoAutoTupling(mirror),
     NoExtendsApp(mirror)
   )
-  def all(mirror: Mirror): List[Rewrite] =
+  def all(mirror: Database): List[Rewrite] =
     syntax ++ semantic(mirror)
-  def default(mirror: Mirror): List[Rewrite] =
+  def default(mirror: Database): List[Rewrite] =
     all(mirror).filterNot(Set(VolatileLazyVal, Xor2Either))
-  def name2rewrite(mirror: Mirror): Map[String, Rewrite] =
+  def name2rewrite(mirror: Database): Map[String, Rewrite] =
     all(mirror).map(x => x.name -> x).toMap
   lazy val syntaxName2rewrite: Map[String, Rewrite] =
     syntax.map(x => x.name -> x).toMap

--- a/scalafix-core/src/main/scala/scalafix/syntax/package.scala
+++ b/scalafix-core/src/main/scala/scalafix/syntax/package.scala
@@ -21,6 +21,8 @@ import scala.meta.internal.scalafix.ScalafixScalametaHacks
 import scalafix.patch.TokenPatch
 import scalafix.util.TreeOps
 import scalafix.util.Whitespace
+import metaconfig.ConfDecoder
+import metaconfig.Configured
 
 package object syntax {
 

--- a/scalafix-reflect/src/main/scala/scalafix/reflect/ScalafixCompilerDecoder.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/reflect/ScalafixCompilerDecoder.scala
@@ -14,15 +14,16 @@ import metaconfig.Configured.NotOk
 import metaconfig.Configured.Ok
 
 object ScalafixCompilerDecoder {
-  def syntactic: ConfDecoder[Rewrite] = fromMirrorOption(None)
-  def semantic(mirror: Mirror): ConfDecoder[Rewrite] =
-    fromMirrorOption(Some(mirror))
-  def fromMirrorOption(mirror: Option[Mirror]): ConfDecoder[Rewrite] =
+  def syntactic: ConfDecoder[Rewrite] =
+    fromMirror(_ => None)
+  def semantic(mirror: Database): ConfDecoder[Rewrite] =
+    fromMirror(_ => Some(mirror))
+  def fromMirror(mirror: LazyMirror): ConfDecoder[Rewrite] =
     rewriteConfDecoder(
       MetaconfigPendingUpstream.orElse(baseCompilerDecoder(mirror),
-                                       baseRewriteDecoders(mirror)),
-      mirror)
-  def baseCompilerDecoder(mirror: Option[Mirror]): ConfDecoder[Rewrite] =
+                                       baseRewriteDecoders(mirror))
+    )
+  def baseCompilerDecoder(mirror: LazyMirror): ConfDecoder[Rewrite] =
     ConfDecoder.instance[Rewrite] {
       case FromSourceRewrite(rewrite) =>
         rewrite match {

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/DiffTest.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/DiffTest.scala
@@ -34,10 +34,10 @@ object DiffTest {
           .collectFirst {
             case Token.Comment(comment) =>
               val decoder =
-                ScalafixCompilerDecoder.fromMirrorOption(Some(mirror))
+                ScalafixCompilerDecoder.fromMirror(_ => Some(mirror))
               ScalafixConfig
                 .fromInput(Input.LabeledString(label, stripPrefix(comment)),
-                           Some(mirror))(decoder)
+                           _ => Some(mirror))(decoder)
                 .get
           }
           .getOrElse(throw new TestFailedException(

--- a/scalafix-tests/integration/src/it/scala/scalafix/tests/URLConfiguration.scala
+++ b/scalafix-tests/integration/src/it/scala/scalafix/tests/URLConfiguration.scala
@@ -14,7 +14,7 @@ class URLConfiguration extends FunSuite {
     val mirror = Some(Database(Nil))
     val obtained =
       ScalafixCompilerDecoder
-        .fromMirrorOption(mirror)
+        .fromMirror(mirror)
         .read(Conf.Str(url))
     assert(obtained.get.name.contains("Rewrite2"))
   }


### PR DESCRIPTION
This commit refactors how mirrors are loaded in the cli. Before, mirrors
were eagerly loaded depending on whether --syntactic was passed or not.
This meant is was annoying to run syntactic rewrites, or you loaded
the semanticdb even if you didn't need it. After this commit, the cli
will only try to load the mirror if it's requested by a semantic
rewrite. This fix works for default rewrites along with
classloaded/compiled rewrites.

The most important change in this commit was to change `Option[Mirror]`
into `type LazyMirror = RewriteKind => Option[Mirror]`. This allowed
us to delay the computation of the mirror up to the point where we
needed to load the first semantic rewrite.

Along the way, I had to refactor a lot of things on the side, which
caused the large diff. The side changes are mostly

- Consolidate how cli arg --rewrites and .scalafix.conf rewrites are loaded
- Remove --syntactic since it's no longer used.
- Use Database instead of Mirror everywhere.
- Refactor validation logic inside CliRunner.Builder.
- More polished --verbose logging statements.