### PR TITLE
Add tests for scalafix-diff

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -175,7 +175,7 @@ lazy val diff = crossProject
   .jsSettings(
     npmDependencies in Compile += "diff" -> "3.2.0"
   )
-  .enablePlugins(ScalaJSBundlerPlugin)
+  .jsConfigure(_.enablePlugins(ScalaJSBundlerPlugin))
 lazy val diffJS = diff.js
 lazy val diffJVM = diff.jvm
 

--- a/scalafix-diff/js/src/main/scala/scalafix/diff/DiffUtils.scala
+++ b/scalafix-diff/js/src/main/scala/scalafix/diff/DiffUtils.scala
@@ -33,12 +33,11 @@ object DiffUtils {
     def trimHeader(line: String) =
       if (line.startsWith("+++") || line.startsWith("---")) line.trim else line
 
-    def removeNewlineDiff(diffLines: Array[String]) =
+    def removeNewlineDiff(diffLines: Iterator[String]) =
       diffLines.filterNot(_ == "\\ No newline at end of file")
 
     removeNewlineDiff(
-      diff
-        .split("\n")
+      diff.lines
         .drop(1) // remove ==== separator
         .map(trimHeader) // remove whitespaces at the end of headers
     ).mkString("\n")

--- a/scalafix-diff/js/src/main/scala/scalafix/diff/DiffUtils.scala
+++ b/scalafix-diff/js/src/main/scala/scalafix/diff/DiffUtils.scala
@@ -29,12 +29,18 @@ object DiffUtils {
       "",
       "",
       js.Dynamic.literal("context" -> contextSize))
+
     def trimHeader(line: String) =
       if (line.startsWith("+++") || line.startsWith("---")) line.trim else line
-    diff
-      .split("\n")
-      .drop(1) // remove ==== separator
-      .map(trimHeader) // remove whitespaces at the end of headers
-      .mkString("\n")
+
+    def removeNewlineDiff(diffLines: Array[String]) =
+      diffLines.filterNot(_ == "\\ No newline at end of file")
+
+    removeNewlineDiff(
+      diff
+        .split("\n")
+        .drop(1) // remove ==== separator
+        .map(trimHeader) // remove whitespaces at the end of headers
+    ).mkString("\n")
   }
 }

--- a/scalafix-diff/js/src/main/scala/scalafix/diff/DiffUtils.scala
+++ b/scalafix-diff/js/src/main/scala/scalafix/diff/DiffUtils.scala
@@ -10,8 +10,8 @@ object JSDiff extends js.Object {
                           newFileName: String,
                           oldStr: String,
                           newStr: String,
-                          oldHeader: Option[String],
-                          newHeader: Option[String],
+                          oldHeader: String,
+                          newHeader: String,
                           options: js.Dynamic): String = js.native
 }
 
@@ -26,9 +26,14 @@ object DiffUtils {
       revisedFileName,
       originalLines.mkString("\n"),
       revisedLines.mkString("\n"),
-      None,
-      None,
+      "",
+      "",
       js.Dynamic.literal("context" -> contextSize))
-    diff.split("\n").drop(1).mkString("\n")
+    def trimHeader(line: String) =
+      if (line.startsWith("+++") || line.startsWith("---")) line.trim else line
+    diff.split("\n")
+      .drop(1)          // remove ==== separator
+      .map(trimHeader) // remove whitespaces at the end of headers
+      .mkString("\n")
   }
 }

--- a/scalafix-diff/js/src/main/scala/scalafix/diff/DiffUtils.scala
+++ b/scalafix-diff/js/src/main/scala/scalafix/diff/DiffUtils.scala
@@ -31,8 +31,9 @@ object DiffUtils {
       js.Dynamic.literal("context" -> contextSize))
     def trimHeader(line: String) =
       if (line.startsWith("+++") || line.startsWith("---")) line.trim else line
-    diff.split("\n")
-      .drop(1)          // remove ==== separator
+    diff
+      .split("\n")
+      .drop(1) // remove ==== separator
       .map(trimHeader) // remove whitespaces at the end of headers
       .mkString("\n")
   }

--- a/scalafix-diff/jvm/src/main/scala/scalafix/diff/DiffUtils.scala
+++ b/scalafix-diff/jvm/src/main/scala/scalafix/diff/DiffUtils.scala
@@ -1,5 +1,6 @@
 package scalafix.diff
 
+import difflib.{ DiffUtils => DU }
 import scala.collection.JavaConverters._
 
 object DiffUtils {
@@ -8,9 +9,8 @@ object DiffUtils {
                   originalLines: List[String],
                   revisedLines: List[String],
                   contextSize: Int): String = {
-    val patch = difflib.DiffUtils
-      .diff(originalLines.toSeq.asJava, revisedLines.toSeq.asJava)
-    val diff = difflib.DiffUtils.generateUnifiedDiff(
+    val patch = DU.diff(originalLines.toSeq.asJava, revisedLines.toSeq.asJava)
+    val diff = DU.generateUnifiedDiff(
       originalFileName,
       revisedFileName,
       originalLines.toSeq.asJava,

--- a/scalafix-diff/jvm/src/main/scala/scalafix/diff/DiffUtils.scala
+++ b/scalafix-diff/jvm/src/main/scala/scalafix/diff/DiffUtils.scala
@@ -1,6 +1,6 @@
 package scalafix.diff
 
-import difflib.{ DiffUtils => DU }
+import difflib.{DiffUtils => DU}
 import scala.collection.JavaConverters._
 
 object DiffUtils {
@@ -10,12 +10,11 @@ object DiffUtils {
                   revisedLines: List[String],
                   contextSize: Int): String = {
     val patch = DU.diff(originalLines.toSeq.asJava, revisedLines.toSeq.asJava)
-    val diff = DU.generateUnifiedDiff(
-      originalFileName,
-      revisedFileName,
-      originalLines.toSeq.asJava,
-      patch,
-      contextSize)
+    val diff = DU.generateUnifiedDiff(originalFileName,
+                                      revisedFileName,
+                                      originalLines.toSeq.asJava,
+                                      patch,
+                                      contextSize)
     diff.asScala.mkString("\n")
   }
 }

--- a/scalafix-diff/shared/src/test/scala/scalafix/DiffUtilsSpec.scala
+++ b/scalafix-diff/shared/src/test/scala/scalafix/DiffUtilsSpec.scala
@@ -1,0 +1,51 @@
+package scalafix.diff
+
+import org.scalatest.FunSuite
+
+class DiffUtilsSpec extends FunSuite {
+
+  val originalFileName = "SomeFile.scala"
+  val revisedFileName = "SomeFileRenamed.scala"
+  val originalLines =
+    s"""|object Foo {
+        |  const x = Map(
+        |    'a -> "a",
+        |    'b -> "b",
+        |    'c -> "c"
+        |  )
+        |}""".stripMargin.split("\n").toList
+  val revisedLines =
+    s"""|object Foo {
+        |  const y = Map(
+        |    'd -> "d",
+        |    'a -> "a",
+        |    'b -> "b",
+        |    'c -> "c",
+        |    'e -> "e"
+        |  )
+        |}""".stripMargin.split("\n").toList
+
+  val contextSize = 4
+
+  val expectedDiff =
+    s"""|--- SomeFile.scala
+        |+++ SomeFileRenamed.scala
+        |@@ -1,7 +1,9 @@
+        | object Foo {
+        |-  const x = Map(
+        |+  const y = Map(
+        |+    'd -> "d",
+        |     'a -> "a",
+        |     'b -> "b",
+        |-    'c -> "c"
+        |+    'c -> "c",
+        |+    'e -> "e"
+        |   )
+        | }""".stripMargin
+
+  test("unifiedDiff") {
+    val actualDiff = DiffUtils.unifiedDiff(originalFileName, revisedFileName, originalLines, revisedLines, contextSize)
+    assert(actualDiff == expectedDiff)
+  }
+
+}

--- a/scalafix-diff/shared/src/test/scala/scalafix/DiffUtilsSpec.scala
+++ b/scalafix-diff/shared/src/test/scala/scalafix/DiffUtilsSpec.scala
@@ -8,32 +8,43 @@ class DiffUtilsTest extends FunSuite {
   val revisedFileName = "SomeFileRenamed.scala"
   val originalLines =
     s"""|object Foo {
-        |  const x = Map(
+        |  val a = "foo"
+        |  val b = 42
+        |  case class Bar(x: Boolean)
+        |  val x = Map(
         |    'a -> "a",
         |    'b -> "b",
         |    'c -> "c"
         |  )
+        |  val c = 1 + 1
+        |  val d = true
         |}""".stripMargin.split("\n").toList
   val revisedLines =
     s"""|object Foo {
-        |  const y = Map(
+        |  val a = "foo"
+        |  val b = 42
+        |  case class Bar(x: Boolean)
+        |  val y = Map(
         |    'd -> "d",
         |    'a -> "a",
         |    'b -> "b",
         |    'c -> "c",
         |    'e -> "e"
         |  )
+        |  val c = 1 + 1
+        |  val d = true
         |}""".stripMargin.split("\n").toList
 
-  val contextSize = 4
+  val contextSize = 2
 
   val expectedDiff =
     s"""|--- SomeFile.scala
         |+++ SomeFileRenamed.scala
-        |@@ -1,7 +1,9 @@
-        | object Foo {
-        |-  const x = Map(
-        |+  const y = Map(
+        |@@ -3,8 +3,10 @@
+        |   val b = 42
+        |   case class Bar(x: Boolean)
+        |-  val x = Map(
+        |+  val y = Map(
         |+    'd -> "d",
         |     'a -> "a",
         |     'b -> "b",
@@ -41,7 +52,7 @@ class DiffUtilsTest extends FunSuite {
         |+    'c -> "c",
         |+    'e -> "e"
         |   )
-        | }""".stripMargin
+        |   val c = 1 + 1""".stripMargin
 
   test("unifiedDiff") {
     val actualDiff = DiffUtils.unifiedDiff(originalFileName,

--- a/scalafix-diff/shared/src/test/scala/scalafix/DiffUtilsSpec.scala
+++ b/scalafix-diff/shared/src/test/scala/scalafix/DiffUtilsSpec.scala
@@ -44,7 +44,11 @@ class DiffUtilsSpec extends FunSuite {
         | }""".stripMargin
 
   test("unifiedDiff") {
-    val actualDiff = DiffUtils.unifiedDiff(originalFileName, revisedFileName, originalLines, revisedLines, contextSize)
+    val actualDiff = DiffUtils.unifiedDiff(originalFileName,
+                                           revisedFileName,
+                                           originalLines,
+                                           revisedLines,
+                                           contextSize)
     assert(actualDiff == expectedDiff)
   }
 

--- a/scalafix-diff/shared/src/test/scala/scalafix/DiffUtilsSpec.scala
+++ b/scalafix-diff/shared/src/test/scala/scalafix/DiffUtilsSpec.scala
@@ -2,7 +2,7 @@ package scalafix.diff
 
 import org.scalatest.FunSuite
 
-class DiffUtilsSpec extends FunSuite {
+class DiffUtilsTest extends FunSuite {
 
   val originalFileName = "SomeFile.scala"
   val revisedFileName = "SomeFileRenamed.scala"


### PR DESCRIPTION
This adds a basic test for `DiffUtils.unifiedDiff` to ensure the output is consistent between JS and JVM implementations.

I found some discrepancies, namely:

- [x] the JS library also accepts a String to append to the header after the file name. Despite passing an empty String a `\t` was still appended, so I manually trimmed it.

- [x] the JS library starts the output with a line made of `===`. I dropped it.

- [ ] the JS library appends a `\ No newline at end of file` to the diff, whereas the Java library doesn't. I'm not sure of who's right and how to work around this. @olafurpg any idea in merit?