### PR TITLE
Move patch operations into RewriteCtx, fixes #193.

### DIFF
--- a/readme/ImplementingRewrites.scalatex
+++ b/readme/ImplementingRewrites.scalatex
@@ -102,7 +102,7 @@
       on parsed abstract syntax tree nodes. The public API for patch
       operations is available in PatchOps.scala
 
-      @hl.ref(wd/"scalafix-core"/"shared"/"src"/"main"/"scala"/"scalafix"/"patch"/"PatchOps.scala", start = "class SyntacticPatch")
+      @hl.ref(wd/"scalafix-core"/"shared"/"src"/"main"/"scala"/"scalafix"/"patch"/"PatchOps.scala", start = "trait SyntacticPatch")
 
       Some things are typically easier to do on the token level and other
       things are easier to do on the tree level.

--- a/readme/ImplementingRewrites.scalatex
+++ b/readme/ImplementingRewrites.scalatex
@@ -102,7 +102,7 @@
       on parsed abstract syntax tree nodes. The public API for patch
       operations is available in PatchOps.scala
 
-      @hl.ref(wd/"scalafix-core"/"shared"/"src"/"main"/"scala"/"scalafix"/"patch"/"PatchOps.scala", start = "trait SyntacticPatch")
+      @hl.ref(wd/"scalafix-core"/"shared"/"src"/"main"/"scala"/"scalafix"/"patch"/"PatchOps.scala", start = "trait PatchOps")
 
       Some things are typically easier to do on the token level and other
       things are easier to do on the tree level.

--- a/scalafix-core/shared/src/main/scala/scalafix/package.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/package.scala
@@ -17,15 +17,6 @@ package object scalafix {
   type Patch = patch.Patch
   val Patch = patch.Patch
 
-  implicit class XtensionMirrorRewriteCtx(val ctx: RewriteCtx)(
-      implicit val mirror: Mirror)
-      extends SemanticPatchOps(ctx, mirror) {
-    def semanticOps: SemanticPatchOps = this
-  }
-  implicit class XtensionRewriteCtx(val ctx: RewriteCtx)
-      extends SyntacticPatchOps(ctx) {
-    def semanticOps: SyntacticPatchOps = this
-  }
   implicit class XtensionSeqPatch(patches: Iterable[Patch]) {
     def asPatch: Patch = Patch.fromIterable(patches)
   }

--- a/scalafix-core/shared/src/main/scala/scalafix/package.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/package.scala
@@ -1,6 +1,4 @@
 import scala.meta._
-import scalafix.patch.SemanticPatchOps
-import scalafix.patch.SyntacticPatchOps
 
 package object scalafix {
 

--- a/scalafix-core/shared/src/main/scala/scalafix/patch/ImportPatchOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/patch/ImportPatchOps.scala
@@ -102,7 +102,7 @@ object ImportPatchOps {
       val trailingComma =
         if (hadLeadingComma) List(Patch.empty)
         else removeFirstComma(ctx.tokenList.trailing(tokens.last))
-      PatchOps.removeTokens(tokens) ++ trailingComma ++ leadingComma
+      ctx.removeTokens(tokens) ++ trailingComma ++ leadingComma
     }
 
     val leadingNewlines = isRemovedImport.map { i =>

--- a/scalafix-core/shared/src/main/scala/scalafix/patch/PatchOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/patch/PatchOps.scala
@@ -5,12 +5,8 @@ package patch
 import scala.meta._
 import org.scalameta.FileLine
 
-object PatchOps {
-  def removeTokens(tokens: Tokens): Patch =
-    tokens.foldLeft(Patch.empty)(_ + TokenPatch.Remove(_))
-}
-
-trait SyntacticPatchOps {
+trait PatchOps {
+  // Syntactic patch ops.
   def removeImportee(importee: Importee): Patch
   def replaceToken(token: Token, toReplace: String): Patch
   def removeTokens(tokens: Tokens): Patch
@@ -18,9 +14,8 @@ trait SyntacticPatchOps {
   def rename(from: Name, to: Name)(implicit fileLine: FileLine): Patch
   def addRight(tok: Token, toAdd: String): Patch
   def addLeft(tok: Token, toAdd: String): Patch
-}
 
-trait SemanticPatchOps {
+  // Semantic patch ops.
   def removeGlobalImport(symbol: Symbol)(implicit mirror: Mirror): Patch
   def addGlobalImport(importer: Importer)(implicit mirror: Mirror): Patch
   def replace(from: Symbol,

--- a/scalafix-core/shared/src/main/scala/scalafix/rewrite/RewriteCtx.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/rewrite/RewriteCtx.scala
@@ -1,6 +1,6 @@
 package scalafix
 package rewrite
-import scala.meta.Tree
+import scala.meta._
 import scala.meta.contrib.AssociatedComments
 import scala.meta.inputs.Input
 import scala.meta.io.AbsolutePath
@@ -8,13 +8,22 @@ import scala.meta.tokens.Tokens
 import scalafix.syntax._
 import scalafix.config.ScalafixConfig
 import scalafix.config.ScalafixReporter
+import scalafix.patch.PatchOps
+import scalafix.patch.SemanticPatchOps
+import scalafix.patch.SyntacticPatchOps
+import scalafix.patch.TokenPatch.Add
+import scalafix.patch.TreePatch
+import scalafix.patch.TreePatch._
 import scalafix.util.MatchingParens
 import scalafix.util.TokenList
+import org.scalameta.FileLine
 import org.scalameta.logger
 
 /** Bundle of useful things when implementing [[Rewrite]]. */
-case class RewriteCtx(tree: Tree, config: ScalafixConfig) {
-  def syntax =
+case class RewriteCtx(tree: Tree, config: ScalafixConfig)
+    extends SyntacticPatchOps
+    with SemanticPatchOps { ctx =>
+  def syntax: String =
     s"""${tree.input.syntax}
        |${logger.revealWhitespace(tree.syntax.take(100))}""".stripMargin
   override def toString: String = syntax
@@ -24,4 +33,33 @@ case class RewriteCtx(tree: Tree, config: ScalafixConfig) {
   lazy val matching: MatchingParens = MatchingParens(tokens)
   lazy val comments: AssociatedComments = AssociatedComments(tokens)
   val reporter: ScalafixReporter = config.reporter
+
+  // Syntactic patch ops.
+  def removeImportee(importee: Importee): Patch =
+    TreePatch.RemoveImportee(importee)
+  def replaceToken(token: Token, toReplace: String): Patch =
+    Add(token, "", toReplace, keepTok = false)
+  def removeTokens(tokens: Tokens): Patch = PatchOps.removeTokens(tokens)
+  def removeToken(token: Token): Patch = Add(token, "", "", keepTok = false)
+  def rename(from: Name, to: Name)(implicit fileLine: FileLine): Patch =
+    ctx
+      .toks(from)
+      .headOption
+      .fold(Patch.empty)(tok => Add(tok, "", to.value, keepTok = false))
+  def addRight(tok: Token, toAdd: String): Patch = Add(tok, "", toAdd)
+  def addLeft(tok: Token, toAdd: String): Patch = Add(tok, toAdd, "")
+
+  // Semantic patch ops.
+  def removeGlobalImport(symbol: Symbol)(implicit mirror: Mirror): Patch =
+    RemoveGlobalImport(symbol)
+  def addGlobalImport(importer: Importer)(implicit mirror: Mirror): Patch =
+    AddGlobalImport(importer)
+  def replace(from: Symbol,
+              to: Term.Ref,
+              additionalImports: List[Importer] = Nil,
+              normalized: Boolean = true)(implicit mirror: Mirror): Patch =
+    Replace(from, to, additionalImports, normalized)
+  def renameSymbol(from: Symbol, to: Name, normalize: Boolean = false)(
+      implicit mirror: Mirror): Patch =
+    RenameSymbol(from, to, normalize)
 }


### PR DESCRIPTION
This avoid the need for extension methods. The implementations of the
patch operations are now abstract to make it easier to read.