### PR TITLE
Generate tab completions for sbt, fixes #172.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -222,18 +222,6 @@ lazy val `scalafix-sbt` = project
           "; very scalafix-sbt/scripted"
       )(state.value)
     },
-    // install the tab completion for sbt-scalafix.
-    compile.in(Compile) :=
-      compile
-        .in(Compile)
-        .dependsOn(runMain.in(cli, Compile).toTask {
-          // poor man's source generator.
-          val out =
-            file("scalafix-sbt") / "src" / "main" / "scala" /
-              "scalafix" / "internal" / "sbt" / "ScalafixCompletions.scala"
-          s" scalafix.cli.Cli --no-sys-exit --sbt ${out.getAbsolutePath}"
-        })
-        .value,
     addSbtPlugin(scalahostSbt),
     scalaVersion := scala210,
     crossScalaVersions := Seq(scala210),

--- a/build.sbt
+++ b/build.sbt
@@ -222,6 +222,18 @@ lazy val `scalafix-sbt` = project
           "; very scalafix-sbt/scripted"
       )(state.value)
     },
+    // install the tab completion for sbt-scalafix.
+    compileInputs.in(Compile, compile) :=
+      compileInputs
+        .in(Compile, compile)
+        .dependsOn(runMain.in(cli, Compile).toTask {
+          // poor man's source generator.
+          val out =
+            file("scalafix-sbt") / "src" / "main" / "scala" /
+              "scalafix" / "internal" / "sbt" / "ScalafixCompletions.scala"
+          s" scalafix.cli.Cli --no-sys-exit --sbt ${out.getAbsolutePath}"
+        })
+        .value,
     addSbtPlugin(scalahostSbt),
     scalaVersion := scala210,
     crossScalaVersions := Seq(scala210),

--- a/build.sbt
+++ b/build.sbt
@@ -223,9 +223,9 @@ lazy val `scalafix-sbt` = project
       )(state.value)
     },
     // install the tab completion for sbt-scalafix.
-    compileInputs.in(Compile, compile) :=
-      compileInputs
-        .in(Compile, compile)
+    compile.in(Compile) :=
+      compile
+        .in(Compile)
         .dependsOn(runMain.in(cli, Compile).toTask {
           // poor man's source generator.
           val out =

--- a/scalafix-cli/src/main/scala/scalafix/internal/cli/ScalafixOptions.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/cli/ScalafixOptions.scala
@@ -125,5 +125,10 @@ case class ScalafixOptions(
     @HelpMessage(
       """Print out zsh completion file for scalafix. To install:
         |          scalafix --zsh > /usr/local/share/zsh/site-functions/_scalafix""".stripMargin)
-    zsh: Boolean = false
+    zsh: Boolean = false,
+    @HelpMessage(
+      """Print out sbt completion parser to argument.""".stripMargin)
+    @ValueDescription("scalafix-sbt/src/main/scala/Completions.scala")
+    @Hidden
+    sbt: Option[String] = None
 )

--- a/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
@@ -1,0 +1,26 @@
+package scalafix.internal.sbt
+
+import sbt.complete.DefaultParsers._
+import sbt.complete.Parser
+
+object ScalafixCompletions {
+  val names = List(
+    "NoValInForComprehension",
+    "RemoveXmlLiterals",
+    "VolatileLazyVal",
+    "ProcedureSyntax",
+    "ExplicitUnit",
+    "DottyVarArgPattern",
+    "ExplicitReturnTypes",
+    "RemoveUnusedImports",
+    "Xor2Either",
+    "NoAutoTupling",
+    "NoExtendsApp"
+  )
+  val parser = {
+    val rewrite: Parser[String] =
+      names.map(literal).reduceLeft(_ | _)
+    (token(Space) ~> token(rewrite)).* <~ SpaceClass.*
+  }
+}
+

--- a/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
@@ -23,4 +23,3 @@ object ScalafixCompletions {
     (token(Space) ~> token(rewrite)).* <~ SpaceClass.*
   }
 }
-

--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -13,6 +13,7 @@ import sbt.inc.Analysis
 import sbt.plugins.JvmPlugin
 import scala.meta.scalahost.sbt.ScalahostSbtPlugin
 import scalafix.internal.sbt.CliWrapperPlugin
+import scalafix.internal.sbt.ScalafixCompletions
 
 object ScalafixPlugin extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
@@ -78,7 +79,7 @@ object ScalafixPlugin extends AutoPlugin {
     val log = streams.value.log
     scalahostCompile.value // trigger compilation
     val classpath = scalahostClasspath.value.asPath
-    val inputArgs = Def.spaceDelimited("<rewrite>").parsed
+    val inputArgs: Seq[String] = ScalafixCompletions.parser.parsed
     val directoriesToFix: Seq[String] =
       scalafixUnmanagedSources.value.flatMap(_.collect {
         case p if p.exists() => p.getAbsolutePath


### PR DESCRIPTION
This solution is kind of a hack. We statically generate the parser by
invoking scalafix-cli on every compilation of scalafix-sbt.
The benefit of this approach is that tab completions are always
generated in the same way in scalafix-cli.