### PR TITLE
Remove unused imports.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -387,6 +387,7 @@ lazy val readme = scalatex
         .dependsOn(run.in(Compile).toTask(" --validate-links"))
         .value
     },
+    scalacOptions ~= (_.filterNot(_ == "-Xlint")),
     test := run.in(Compile).toTask(" --validate-links").value,
     libraryDependencies ++= Seq(
       "com.twitter" %% "util-eval" % "6.42.0"

--- a/scalafix-cli/src/main/scala/scalafix/cli/Cli.scala
+++ b/scalafix-cli/src/main/scala/scalafix/cli/Cli.scala
@@ -2,8 +2,6 @@ package scalafix.cli
 
 import java.nio.file.Path
 import scala.collection.immutable.Seq
-import scala.meta.Database
-import scala.meta.io.AbsolutePath
 import scalafix.cli.CliCommand.PrintAndExit
 import scalafix.cli.CliCommand.RunScalafix
 import scalafix.internal.cli.CommonOptions

--- a/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
+++ b/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
@@ -17,16 +17,12 @@ import java.util.regex.PatternSyntaxException
 import scala.meta._
 import scala.meta.inputs.Input
 import scala.meta.internal.inputs._
-import scala.meta.internal.io.PlatformFileIO
-import scala.meta.internal.semantic.vfs
 import scala.meta.io.AbsolutePath
 import scala.util.Try
 import scala.util.control.NonFatal
 import scalafix.config.Class2Hocon
 import scalafix.config.FilterMatcher
 import scalafix.config.LazyMirror
-import scalafix.config.MetaconfigPendingUpstream
-import scalafix.config.PrintStreamReporter
 import scalafix.config.RewriteKind
 import scalafix.config.ScalafixConfig
 import scalafix.config.ScalafixReporter
@@ -37,7 +33,6 @@ import scalafix.internal.cli.TermDisplay
 import scalafix.internal.cli.WriteMode
 import scalafix.reflect.ScalafixReflect
 import scalafix.syntax._
-import metaconfig.Configured.NotOk
 import metaconfig.Configured.Ok
 import metaconfig._
 

--- a/scalafix-cli/src/main/scala/scalafix/internal/cli/ScalafixOptions.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/cli/ScalafixOptions.scala
@@ -10,11 +10,6 @@ import scalafix.config.ScalafixReporter
 import scalafix.rewrite.ProcedureSyntax
 import scalafix.rewrite.ScalafixRewrites
 import caseapp._
-import metaconfig.Conf
-import metaconfig.ConfError
-import metaconfig.Configured
-import metaconfig.Configured.NotOk
-import metaconfig.Configured.Ok
 
 case class CommonOptions(
     @Hidden workingDirectory: String = System.getProperty("user.dir"),

--- a/scalafix-cli/src/test/scala/scalafix/cli/CliTest.scala
+++ b/scalafix-cli/src/test/scala/scalafix/cli/CliTest.scala
@@ -6,7 +6,6 @@ import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
 import scala.collection.immutable.Seq
-import scala.meta.io.AbsolutePath
 import scalafix.cli.CliCommand.PrintAndExit
 import scalafix.cli.CliCommand.RunScalafix
 import scalafix.internal.cli.CommonOptions

--- a/scalafix-core/shared/src/main/scala/scalafix/config/package.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/config/package.scala
@@ -3,7 +3,6 @@ package scalafix
 import scala.meta.Tree
 import scala.meta.parsers.Parse
 import scala.meta.semantic.Database
-import scala.meta.semantic.Mirror
 
 package object config extends ScalafixMetaconfigReaders {
   type MetaParser = Parse[_ <: Tree]

--- a/scalafix-core/shared/src/main/scala/scalafix/package.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/package.scala
@@ -1,4 +1,4 @@
-import scala.meta._
+
 
 package object scalafix {
 

--- a/scalafix-core/shared/src/main/scala/scalafix/package.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/package.scala
@@ -1,5 +1,3 @@
-
-
 package object scalafix {
 
   type ScalafixConfig = config.ScalafixConfig

--- a/scalafix-core/shared/src/main/scala/scalafix/patch/Patch.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/patch/Patch.scala
@@ -210,8 +210,6 @@ object Patch {
   }
 
   def unifiedDiff(original: Input, revised: Input): String = {
-    import scala.collection.JavaConverters._
-    val originalLines = original.asString.lines.toSeq.asJava
     DiffUtils.unifiedDiff(original.label,
                           revised.label,
                           original.asString.lines.toList,

--- a/scalafix-core/shared/src/main/scala/scalafix/rewrite/RemoveUnusedImports.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/rewrite/RemoveUnusedImports.scala
@@ -3,7 +3,6 @@ package rewrite
 
 import scala.meta._
 import scalafix.syntax._
-import org.scalameta.logger
 
 case class RemoveUnusedImports(mirror: Database)
     extends SemanticRewrite(mirror) {

--- a/scalafix-core/shared/src/main/scala/scalafix/rewrite/RewriteCtx.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/rewrite/RewriteCtx.scala
@@ -2,8 +2,6 @@ package scalafix
 package rewrite
 import scala.meta._
 import scala.meta.contrib.AssociatedComments
-import scala.meta.inputs.Input
-import scala.meta.io.AbsolutePath
 import scala.meta.tokens.Tokens
 import scalafix.syntax._
 import scalafix.config.ScalafixConfig

--- a/scalafix-core/shared/src/main/scala/scalafix/syntax/package.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/syntax/package.scala
@@ -8,21 +8,13 @@ import scala.collection.mutable
 import scala.meta._
 import scala.meta.semantic.Signature
 import scala.meta.semantic.Symbol
-import scala.meta.tokens.Token
 import scala.util.Success
 import scala.util.Try
 import org.scalameta.logger
 import scala.compat.Platform.EOL
-import scala.meta.classifiers.Classifier
 import scala.meta.internal.io.PathIO
-import scala.meta.internal.prettyprinters.TreeSyntax
-import scala.meta.internal.prettyprinters.TreeToString
 import scala.meta.internal.scalafix.ScalafixScalametaHacks
-import scalafix.patch.TokenPatch
 import scalafix.util.TreeOps
-import scalafix.util.Whitespace
-import metaconfig.ConfDecoder
-import metaconfig.Configured
 
 package object syntax {
 

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/DiffTest.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/DiffTest.scala
@@ -14,10 +14,6 @@ case class DiffTest(filename: RelativePath,
                     isSkip: Boolean,
                     isOnly: Boolean) {
   def name: String = filename.toString()
-  private def prefix =
-    if (isOnly) "ONLY "
-    else if (isSkip) "SKIP "
-    else ""
   def originalStr = new String(original.chars)
 }
 

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/IntegrationPropertyTest.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/IntegrationPropertyTest.scala
@@ -17,7 +17,6 @@ abstract class IntegrationPropertyTest(t: ItTest, skip: Boolean = false)
     extends FunSuite
     with TimeLimits {
 
-  private val isCi = sys.props.contains("CI")
   private val maxTime = Span(20, Minutes) // just in case.
 
   val hardClean = true

--- a/scalafix-tests/shared/src/main/scala/cats/implicits.scala
+++ b/scalafix-tests/shared/src/main/scala/cats/implicits.scala
@@ -1,6 +1,5 @@
 package cats
 
-
 package object implicits {
   implicit class EitherOps[A, B](from: Either[A, B]) {
     def map[C](f: B => C): Either[A, C] = ???

--- a/scalafix-tests/shared/src/main/scala/cats/implicits.scala
+++ b/scalafix-tests/shared/src/main/scala/cats/implicits.scala
@@ -1,6 +1,5 @@
 package cats
 
-import scala.language.implicitConversions
 
 package object implicits {
   implicit class EitherOps[A, B](from: Either[A, B]) {

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/ErrorSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/ErrorSuite.scala
@@ -10,7 +10,6 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
 
-
 class ErrorSuite extends SyntacticRewriteSuite(ProcedureSyntax) {
   test("on parse error") {
     intercept[ParseException] {

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/ErrorSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/ErrorSuite.scala
@@ -3,8 +3,6 @@ package tests
 
 import scala.meta._
 import scala.meta.tokens.Token.Ident
-import scalafix.patch.TokenPatch
-import scalafix.patch.TreePatch
 import scalafix.rewrite.ProcedureSyntax
 import scalafix.testkit.SyntacticRewriteSuite
 
@@ -12,7 +10,6 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
 
-import org.scalameta.logger
 
 class ErrorSuite extends SyntacticRewriteSuite(ProcedureSyntax) {
   test("on parse error") {


### PR DESCRIPTION
I've been delaying this commit for too long hoping to fix it with
scalafix. However, it turns out that we can't yet use scalahost in the
scalafix repo because of https://github.com/scalameta/scalameta/issues/979.

I could not get myself to manually remove the imports so I implemented
instead an sbt plugin called sbt-messagehost that collects reported messages
from the compilerReporter in sbt and writes .semanticdb files. Using
messagehost, I was able to run RemoveUnusedImports on the scalafix
codebase. I suspect messagehost may become popular as a lightweight
alternative to scalahost.

I plan to publish messagehost later, it will not be part of the scalafix
repo.