### PR TITLE
Add dependency on sbthost-runtime.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -196,6 +196,7 @@ lazy val cli = project
     mainClass in assembly := Some("scalafix.cli.Cli"),
     assemblyJarName in assembly := "scalafix.jar",
     libraryDependencies ++= Seq(
+      "org.scalameta" %% "sbthost-runtime" % "0.2.0",
       "com.github.alexarchambault" %% "case-app" % "1.1.3",
       "com.martiansoftware" % "nailgun-server" % "0.9.1"
     )


### PR DESCRIPTION
This library is necessary to patch broken .semanticdb files produced in
2.10.6.