### PR TITLE
Implement crude MoveSymbol patch.

### DIFF
--- a/bin/new-rewrite.sh
+++ b/bin/new-rewrite.sh
@@ -2,6 +2,6 @@
 set -eux
 rewrite=$1
 
-touch scalafix-core/src/main/scala/scalafix/rewrite/${rewrite}.scala
+touch scalafix-core/shared/src/main/scala/scalafix/rewrite/${rewrite}.scala
 touch scalafix-tests/input/src/main/scala/test/${rewrite}.scala
 touch scalafix-tests/output/src/main/scala/test/${rewrite}.scala

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,7 @@
 addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
-resolvers += Resolver.bintrayIvyRepo("scalameta", "sbt-plugins") // only needed for scalatex 0.3.8-pre
-addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.8-pre")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15")
+addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.9")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC6")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
@@ -11,9 +10,11 @@ addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalahost" % Dependencies.scalametaV)
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.2.0")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.17")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.6.0")
+// exclude is a workaround for https://github.com/sbt/sbt-assembly/issues/236#issuecomment-294452474
+addSbtPlugin(
+  "com.eed3si9n" % "sbt-assembly" % "0.14.5" exclude ("org.apache.maven", "maven-plugin-api"))
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.7.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.14")
 
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.17")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC6")
 unmanagedSources.in(Compile) += baseDirectory.value / ".." / "Dependencies.scala"

--- a/scalafix-core/shared/src/main/scala/scalafix/config/MetaconfigPendingUpstream.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/config/MetaconfigPendingUpstream.scala
@@ -1,10 +1,11 @@
 package scalafix.config
 
 import scala.collection.immutable.Seq
-
 import metaconfig.Conf
 import metaconfig.ConfDecoder
+import metaconfig.ConfError
 import metaconfig.Configured
+import metaconfig.Metaconfig
 
 // TODO(olafur) contribute upstream to metaconfig.
 object MetaconfigPendingUpstream {
@@ -12,6 +13,13 @@ object MetaconfigPendingUpstream {
     lst.foldLeft(Configured.Ok(Seq.empty[T]): Configured[Seq[T]]) {
       case (res, configured) =>
         res.product(configured).map { case (a, b) => b +: a }
+    }
+  }
+  def getKey[T](conf: Conf.Obj, path: String, extraNames: String*)(
+      implicit ev: ConfDecoder[T]): Configured[T] = {
+    Metaconfig.getKey(conf, path +: extraNames) match {
+      case Some(value) => ev.read(value)
+      case None => ConfError.missingField(conf, path).notOk
     }
   }
 

--- a/scalafix-core/shared/src/main/scala/scalafix/config/PatchConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/config/PatchConfig.scala
@@ -3,6 +3,7 @@ package scalafix.config
 import scalafix.patch.TreePatch.AddGlobalImport
 import scalafix.patch.TreePatch.Replace
 import scalafix.patch.TreePatch
+import scalafix.patch.TreePatch.MoveSymbol
 import scalafix.patch.TreePatch.RemoveGlobalImport
 import metaconfig._
 
@@ -10,6 +11,7 @@ import metaconfig._
 case class PatchConfig(
     removeGlobalImports: List[RemoveGlobalImport] = Nil,
     addGlobalImports: List[AddGlobalImport] = Nil,
+    moveSymbols: List[MoveSymbol] = Nil,
     replacements: List[Replace] = Nil
 ) {
   def all: Seq[TreePatch] =

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/patch/MoveSymbolOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/patch/MoveSymbolOps.scala
@@ -1,0 +1,86 @@
+package scalafix.internal.patch
+
+import scala.collection.mutable
+import scalafix._, syntax._
+import scala.meta._
+import scalafix.internal.util.SymbolOps.BottomSymbol
+import scalafix.internal.util.SymbolOps.SignatureName
+import scalafix.patch.TreePatch.MoveSymbol
+
+object MoveSymbolOps {
+  private object Select {
+    def unapply(arg: Ref): Option[(Ref, Name)] = arg match {
+      case Term.Select(a: Ref, b) => Some(a -> b)
+      case Type.Select(a, b) => Some(a -> b)
+      case _ => None
+    }
+  }
+
+  def naiveMoveSymbolPatch(moveSymbols: Seq[MoveSymbol])(
+      implicit ctx: RewriteCtx,
+      mirror: Database): Patch = {
+    val moves: Map[Symbol, Symbol] =
+      ctx.config.patches.moveSymbols.toIterator.flatMap {
+        case MoveSymbol(term @ Symbol.Global(qual, Signature.Term(name)), to) =>
+          (term -> to) ::
+            (Symbol.Global(qual, Signature.Type(name)) -> to) ::
+            Nil
+      }.toMap
+    def loop(ref: Ref, sym: Symbol): (Patch, Symbol) = {
+      (ref, sym) match {
+        // same length
+        case (a @ Name(_), Symbol.Global(Symbol.None, SignatureName(b))) =>
+          ctx.rename(a, b) -> Symbol.None
+        // ref is shorter
+        case (a @ Name(_), sym @ Symbol.Global(qual, SignatureName(b))) =>
+          ctx.rename(a, b) -> sym
+        // ref is longer
+        case (
+            Select(qual, Name(_)),
+            Symbol.Global(Symbol.None, SignatureName(b))) =>
+          ctx.replaceTree(qual, b) -> Symbol.None
+        // recurse
+        case (
+            Select(qual: Ref, a @ Name(_)),
+            Symbol.Global(symQual, SignatureName(b))) =>
+          val (patch, toImport) = loop(qual, symQual)
+          (patch + ctx.rename(a, b)) -> toImport
+      }
+    }
+    object Move {
+      def unapply(name: Name): Option[Symbol] = {
+        val result = mirror.names
+          .get(name.pos)
+          .toIterator
+          .flatMap {
+            case Symbol.Multi(syms) => syms
+            case els => els :: Nil
+          }
+          .map(_.normalized)
+          .collectFirst { case x if moves.contains(x) => moves(x) }
+        result
+      }
+    }
+    val toImport = mutable.Set.empty[Symbol]
+    val patches = ctx.tree.collect {
+      case n @ Move(to) =>
+        n.parent match {
+          case Some(i @ Importee.Name(_)) =>
+            ctx.removeImportee(i)
+          case Some(parent @ Select(_, `n`)) =>
+            val (patch, imp) = loop(parent, to)
+            toImport += imp
+            patch
+          case _ =>
+            toImport += to
+            ctx.rename(n, to.name)
+        }
+    }
+    val importPatch = toImport.foldLeft(Patch.empty) {
+      case (p, BottomSymbol()) => p
+      case (p, Symbol.Global(BottomSymbol(), _)) => p
+      case (p, sym) => p + ctx.addGlobalImport(sym)
+    }
+    importPatch ++ patches
+  }
+}

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/SymbolOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/SymbolOps.scala
@@ -1,0 +1,39 @@
+package scalafix.internal.util
+
+import scala.meta._
+
+object SymbolOps {
+  object SignatureName {
+    def unapply(arg: Signature): Option[String] = arg match {
+      case Signature.Term(a) => Some(a)
+      case Signature.Type(a) => Some(a)
+      case _ => None
+    }
+  }
+  object BottomSymbol {
+    def unapply(arg: Symbol): Boolean = arg match {
+      case Symbol.Global(Symbol.None, Signature.Term("_root_")) => true
+      case _ => false
+    }
+  }
+  def toTermRef(symbol: Symbol): Term.Ref = {
+    symbol match {
+      case Symbol.Global(BottomSymbol(), signature) =>
+        Term.Name(signature.name)
+      case Symbol.Global(qual, signature) =>
+        Term.Select(toTermRef(qual), Term.Name(signature.name))
+    }
+  }
+  def toImporter(symbol: Symbol): Option[Importer] = {
+    symbol match {
+      case Symbol.Global(BottomSymbol(), SignatureName(name)) =>
+        None
+      case Symbol.Global(qual, SignatureName(name)) =>
+        Some(
+          Importer(
+            toTermRef(qual),
+            List(Importee.Name(Name.Indeterminate(name)))))
+      case _ => None
+    }
+  }
+}

--- a/scalafix-core/shared/src/main/scala/scalafix/patch/PatchOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/patch/PatchOps.scala
@@ -3,7 +3,6 @@ package scalafix
 package patch
 
 import scala.meta._
-import org.scalameta.FileLine
 
 trait PatchOps {
   // Syntactic patch ops.
@@ -11,12 +10,16 @@ trait PatchOps {
   def replaceToken(token: Token, toReplace: String): Patch
   def removeTokens(tokens: Tokens): Patch
   def removeToken(token: Token): Patch
+  def replaceTree(from: Tree, to: String): Patch
   def rename(from: Name, to: Name): Patch
+  def rename(from: Name, to: String): Patch
   def addRight(tok: Token, toAdd: String): Patch
   def addLeft(tok: Token, toAdd: String): Patch
 
   // Semantic patch ops.
+  def moveSymbol(from: Symbol.Global, to: Symbol.Global)(implicit mirror: Mirror): Patch
   def removeGlobalImport(symbol: Symbol)(implicit mirror: Mirror): Patch
+  def addGlobalImport(symbol: Symbol): Patch
   def addGlobalImport(importer: Importer)(implicit mirror: Mirror): Patch
   def replace(from: Symbol,
               to: Term.Ref,

--- a/scalafix-core/shared/src/main/scala/scalafix/syntax/package.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/syntax/package.scala
@@ -14,6 +14,7 @@ import org.scalameta.logger
 import scala.compat.Platform.EOL
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.scalafix.ScalafixScalametaHacks
+import scalafix.internal.util.SymbolOps
 import scalafix.util.TreeOps
 
 package object syntax {

--- a/scalafix-tests/input/src/main/scala/test/MoveSymbol.scala
+++ b/scalafix-tests/input/src/main/scala/test/MoveSymbol.scala
@@ -1,0 +1,27 @@
+/*
+patches.removeGlobalImports = [
+  "scala.collection.mutable"
+]
+patches.moveSymbols = [
+  { from = "scala.collection.mutable.ListBuffer"
+    to = "com.geirsson.mutable.CoolBuffer" }
+  { from = "scala.collection.mutable.HashMap"
+    to = "com.geirsson.mutable.unsafe.CoolMap" }
+  { from = "scala.math.package.sqrt"
+    to = "com.geirsson.fastmath.sqrt" }
+]
+ */
+package fix
+
+import scala.collection.mutable.HashMap
+import scala.collection.mutable.ListBuffer
+import scala.collection.mutable
+
+object MoveSymbol {
+  math.sqrt(9)
+  val u: mutable.HashMap[Int, Int] = HashMap.empty[Int, Int]
+  val x: ListBuffer[Int] = ListBuffer.empty[Int]
+  val y: mutable.ListBuffer[Int] = mutable.ListBuffer.empty[Int]
+  val z: scala.collection.mutable.ListBuffer[Int] =
+    scala.collection.mutable.ListBuffer.empty[Int]
+}

--- a/scalafix-tests/output/src/main/scala/com/geirsson/fastmath.scala
+++ b/scalafix-tests/output/src/main/scala/com/geirsson/fastmath.scala
@@ -1,0 +1,5 @@
+package com.geirsson
+
+object fastmath {
+  def sqrt(double: Double): Double = ???
+}

--- a/scalafix-tests/output/src/main/scala/com/geirsson/mutable/CoolBuffer.scala
+++ b/scalafix-tests/output/src/main/scala/com/geirsson/mutable/CoolBuffer.scala
@@ -1,0 +1,8 @@
+package com.geirsson.mutable
+
+// dummy code to make symbol patches compile
+
+class CoolBuffer[T]
+object CoolBuffer {
+  def empty[T] = new CoolBuffer[T]
+}

--- a/scalafix-tests/output/src/main/scala/com/geirsson/mutable/unsafe/CoolMap.scala
+++ b/scalafix-tests/output/src/main/scala/com/geirsson/mutable/unsafe/CoolMap.scala
@@ -1,0 +1,7 @@
+package com.geirsson.mutable.unsafe
+
+class CoolMap[A, B]
+
+object CoolMap {
+  def empty[A, B] = new CoolMap[A, B]
+}

--- a/scalafix-tests/output/src/main/scala/test/MoveSymbol.scala
+++ b/scalafix-tests/output/src/main/scala/test/MoveSymbol.scala
@@ -1,0 +1,16 @@
+package fix
+
+import com.geirsson.mutable.CoolBuffer
+import com.geirsson.mutable
+import com.geirsson.mutable.unsafe.CoolMap
+import com.geirsson.mutable.unsafe
+import com.geirsson.fastmath
+
+object MoveSymbol {
+  fastmath.sqrt(9)
+  val u: unsafe.CoolMap[Int, Int] = CoolMap.empty[Int, Int]
+  val x: CoolBuffer[Int] = CoolBuffer.empty[Int]
+  val y: mutable.CoolBuffer[Int] = mutable.CoolBuffer.empty[Int]
+  val z: com.geirsson.mutable.CoolBuffer[Int] =
+    com.geirsson.mutable.CoolBuffer.empty[Int]
+}

--- a/scalafix-tests/output/src/main/scala/test/Xor2Either.scala
+++ b/scalafix-tests/output/src/main/scala/test/Xor2Either.scala
@@ -1,8 +1,8 @@
 package test
 
+import scala.concurrent.Future
 import cats.implicits._
 import cats.data.EitherT
-import scala.concurrent.Future
 trait Xor2Either {
   type MyDisjunction = Either[Int, String]
   val r: MyDisjunction = Right("")


### PR DESCRIPTION
This patch can be used to move or rename call-sites of a global
definition like a class, trait, object or static def. This
implementation is crude, it is likely produce invalid code in many
cases. The patch tries to preserve the prefix when possible. For
example:

```
// config
from = a.b.c
to = d.b.x
// code before
import a.b.c
import a.b
b.c
c
// code after
import a.b
import d.b
import d.b.x
b.x
x
```

Room for improvement:

- Observe that `import a.b` is not removed as it may be used to prefix
  other identifiers from the `a.b.` package. It should be possible to
  remove the imports if its not used elsewhere.
- It's possible that duplicate imports are added, for example if
  the source contains `import a.b_` then scalafix may still add
  redundant `import a.b.c`.
- Imports are always inserted fully qualified at the bottom of the
  global imports list. It might be nice if it handled
  - imports grouped by curly braces
  - import sorting
  - local imports