### PR TITLE
Use coursier to fetch scalafix-cli jars.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -197,6 +197,10 @@ lazy val `scalafix-sbt` = project
     Defaults.itSettings,
     ScriptedPlugin.scriptedSettings,
     sbtPlugin := true,
+    libraryDependencies ++= Seq(
+      "io.get-coursier" %% "coursier" % "1.0.0-RC6",
+      "io.get-coursier" %% "coursier-cache" % "1.0.0-RC6"
+    ),
     testQuick := {}, // these test are slow.
     test.in(IntegrationTest) := {
       RunSbtCommand(

--- a/scalafix-sbt/src/main/scala/scalafix/internal/sbt/CliWrapperPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/internal/sbt/CliWrapperPlugin.scala
@@ -1,5 +1,6 @@
 package scalafix.internal.sbt
 
+import scalaz.concurrent.Task
 import sbt.AutoPlugin
 import sbt.Def
 import sbt.File
@@ -31,8 +32,8 @@ object CliWrapperPlugin extends AutoPlugin {
     def main(args: Array[String]): Unit
   }
   object autoImport {
-    val cliWrapperClasspath: TaskKey[Classpath] =
-      taskKey[Classpath]("classpath to run code generation in")
+    val cliWrapperClasspath: TaskKey[Seq[File]] =
+      taskKey[Seq[File]]("classpath to run code generation in")
     val cliWrapperMainClass: TaskKey[String] =
       taskKey[String]("Fully qualified name of main class")
     val cliWrapperMain: TaskKey[HasMain] =
@@ -41,7 +42,7 @@ object CliWrapperPlugin extends AutoPlugin {
   import autoImport._
   override def globalSettings: Seq[Def.Setting[_]] = Seq(
     cliWrapperMain := {
-      val cp = cliWrapperClasspath.value.map(_.data.toURI.toURL)
+      val cp = cliWrapperClasspath.value.map(_.toURI.toURL)
       val cl = new java.net.URLClassLoader(cp.toArray, null)
       val cls = cl.loadClass(cliWrapperMainClass.value)
       val constuctor = cls.getDeclaredConstructor()

--- a/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixJarFetcher.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixJarFetcher.scala
@@ -1,0 +1,38 @@
+package scalafix.internal.sbt
+
+import sbt.File
+
+object ScalafixJarFetcher {
+  def fetchJars(org: String, artifact: String, version: String): List[File] =
+    this.synchronized {
+      import coursier._
+      val start = Resolution(Set(Dependency(Module(org, artifact), version)))
+      val repositories = Seq(
+        Cache.ivy2Local,
+        MavenRepository("https://repo1.maven.org/maven2")
+      )
+      val fetch = Fetch.from(repositories, Cache.fetch())
+      val resolution = start.process.run(fetch).unsafePerformSync
+      val errors = resolution.metadataErrors
+      if (errors.nonEmpty) {
+        sys.error(errors.mkString("\n"))
+      }
+      val localArtifacts = scalaz.concurrent.Task
+        .gatherUnordered(
+          resolution.artifacts.map(Cache.file(_).run)
+        )
+        .unsafePerformSync
+        .map(_.toEither)
+      val failures = localArtifacts.collect { case Left(e) => e }
+      if (failures.nonEmpty) {
+        sys.error(failures.mkString("\n"))
+      } else {
+        val jars = localArtifacts.collect {
+          case Right(file) if file.getName.endsWith(".jar") =>
+            file
+        }
+        jars
+      }
+    }
+
+}

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/test
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/test
@@ -1,7 +1,5 @@
 # compile should not affect scalafix
 > compile
-# This should not fail, see https://github.com/scalacenter/scalafix/issues/200
-> scalafix-stub/compile
 > scalafix
 > check
 


### PR DESCRIPTION
This removed the usage of synthetic projects in sbt-scalafix with
cours. I was trying out sbt-scalafix in the scalafix repo itself
and noticed that it didn't play nicely with with root build
auto-aggregation.