### PR TITLE
Fix #255, fallback to default config in ExplicitReturnTypes.

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/config/ScalafixConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/config/ScalafixConfig.scala
@@ -19,6 +19,9 @@ case class ScalafixConfig(
     // configuration from the user.
     x: Conf = Conf.Obj()
 ) {
+  def getRewriteConfig[T: ConfDecoder](key: String, default: T): T = {
+    x.getOrElse[T](key)(default).get
+  }
 
   val reader: ConfDecoder[ScalafixConfig] =
     ConfDecoder.instanceF[ScalafixConfig] { conf =>

--- a/scalafix-core/shared/src/main/scala/scalafix/rewrite/ExplicitReturnTypes.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/rewrite/ExplicitReturnTypes.scala
@@ -90,10 +90,8 @@ case class ExplicitReturnTypes(mirror: Mirror) extends SemanticRewrite(mirror) {
         defn: D,
         mods: Traversable[Mod],
         body: Term)(implicit ev: Extract[D, Mod]): Boolean = {
-      val config =
-        ctx.config.x.dynamic.explicitReturnTypes
-          .as[ExplicitReturnTypesConfig]
-          .get
+      val config = ctx.config
+        .getRewriteConfig("explicitReturnTypes", ExplicitReturnTypesConfig())
       import config._
 
       def matchesMemberVisibility(): Boolean =


### PR DESCRIPTION
I find it a bit unsatisfying that rewrites must throw exceptions to
communicate errors in the configuration. Moreover, it's unnecessary
that the rewrite must validate the configuration on every RewriteCtx
instead of only once during construction. This fix is a short term
solution, we should eventually try to solve the root of the issue.