### PR TITLE
Normalize `package` in symbols.

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/SymbolOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/SymbolOps.scala
@@ -36,4 +36,19 @@ object SymbolOps {
       case _ => None
     }
   }
+  def normalize(symbol: Symbol): Symbol = symbol match {
+    case Symbol.Multi(syms) =>
+      Symbol.Multi(syms.map(normalize))
+    case Symbol.Global(sym, Signature.Type(name)) =>
+      Symbol.Global(sym, Signature.Term(name))
+    case Symbol.Global(sym, Signature.Term("package")) =>
+      normalize(sym)
+    case Symbol.Global(
+        Symbol.Global(sym, Signature.Term(name)),
+        Signature.Method("apply", _)) =>
+      Symbol.Global(sym, Signature.Term(name))
+    case Symbol.Global(sym, Signature.Method(name, _)) =>
+      Symbol.Global(normalize(sym), Signature.Term(name))
+    case x => x
+  }
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/syntax/package.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/syntax/package.scala
@@ -94,23 +94,7 @@ package object syntax {
       syms.exists(otherSyms.contains)
     }
 
-    /** Returns simplified version of this Symbol.
-      *
-      * - No Symbol.Multi
-      * - No Signature.{Type,Method}
-      */
-    def normalized: Symbol = symbol match {
-      case Symbol.Multi(sym +: _) => sym.normalized
-      case Symbol.Global(sym, Signature.Type(name)) =>
-        Symbol.Global(sym, Signature.Term(name))
-      case Symbol.Global(
-          Symbol.Global(sym, Signature.Term(name)),
-          Signature.Method("apply", _)) =>
-        Symbol.Global(sym, Signature.Term(name))
-      case Symbol.Global(sym, Signature.Method(name, _)) =>
-        Symbol.Global(sym.normalized, Signature.Term(name))
-      case x => x
-    }
+    def normalized: Symbol = SymbolOps.normalize(symbol)
 
     /** Returns corresponding scala.meta.Tree for symbol
       * Caveat: not thoroughly tested, may crash

--- a/scalafix-tests/input/src/main/scala/test/MoveSymbol.scala
+++ b/scalafix-tests/input/src/main/scala/test/MoveSymbol.scala
@@ -7,7 +7,7 @@ patches.moveSymbols = [
     to = "com.geirsson.mutable.CoolBuffer" }
   { from = "scala.collection.mutable.HashMap"
     to = "com.geirsson.mutable.unsafe.CoolMap" }
-  { from = "scala.math.package.sqrt"
+  { from = "scala.math.sqrt"
     to = "com.geirsson.fastmath.sqrt" }
 ]
  */


### PR DESCRIPTION
I also observed that we throw away the tail of symbols in Symbol.Multi.
This behavior does not make sense in normalize, instead it makes more
sense to normalize all the underlying symbols and provide another helper
to simplify Symbol.Multi.