### PR TITLE
s/MoveSymbol/ReplaceSymbol/

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/config/ConfigRewritePatches.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/config/ConfigRewritePatches.scala
@@ -2,12 +2,12 @@ package scalafix.config
 
 import scalafix.Patch
 import scalafix.patch.TreePatch.AddGlobalImport
-import scalafix.patch.TreePatch.MoveSymbol
+import scalafix.patch.TreePatch.ReplaceSymbol
 import scalafix.patch.TreePatch.RemoveGlobalImport
 import metaconfig.ConfDecoder
 
 case class ConfigRewritePatches(
-    moveSymbols: List[MoveSymbol] = Nil,
+    replaceSymbols: List[ReplaceSymbol] = Nil,
     addGlobalImports: List[AddGlobalImport] = Nil,
     removeGlobalImports: List[RemoveGlobalImport] = Nil
 ) {
@@ -15,12 +15,13 @@ case class ConfigRewritePatches(
     ConfDecoder.instanceF[ConfigRewritePatches] { conf =>
       import conf._
       (
-        getOrElse("moveSymbols")(moveSymbols) |@|
+        getOrElse("replaceSymbols")(replaceSymbols) |@|
           getOrElse("addGlobalImports")(addGlobalImports) |@|
           getOrElse("removeGlobalImports")(removeGlobalImports)
       ).map { case ((a, b), c) => ConfigRewritePatches(a, b, c) }
     }
-  def all: List[Patch] = moveSymbols ++ addGlobalImports ++ removeGlobalImports
+  def all: List[Patch] =
+    replaceSymbols ++ addGlobalImports ++ removeGlobalImports
 }
 
 object ConfigRewritePatches {

--- a/scalafix-core/shared/src/main/scala/scalafix/config/ScalafixMetaconfigReaders.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/config/ScalafixMetaconfigReaders.scala
@@ -139,12 +139,12 @@ trait ScalafixMetaconfigReaders {
     }
   }
 
-  implicit lazy val MoveSymbolReader: ConfDecoder[MoveSymbol] =
-    ConfDecoder.instanceF[MoveSymbol] { c =>
+  implicit lazy val MoveSymbolReader: ConfDecoder[ReplaceSymbol] =
+    ConfDecoder.instanceF[ReplaceSymbol] { c =>
       (
         c.get[Symbol.Global]("from") |@|
           c.get[Symbol.Global]("to")
-      ).map { case (a, b) => MoveSymbol(a, b) }
+      ).map { case (a, b) => ReplaceSymbol(a, b) }
     }
 
   def rewriteConfDecoderSyntactic(

--- a/scalafix-core/shared/src/main/scala/scalafix/patch/Patch.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/patch/Patch.scala
@@ -12,8 +12,9 @@ import scalafix.patch.TokenPatch.Remove
 import scalafix.patch.TreePatch.ImportPatch
 import scalafix.diff.DiffUtils
 import scalafix.internal.patch.ImportPatchOps
+import scalafix.internal.patch.ReplaceSymbolOps
 import scalafix.internal.util.TokenOps
-import scalafix.patch.TreePatch.MoveSymbol
+import scalafix.patch.TreePatch.ReplaceSymbol
 
 /** A data structure that can produce a .patch file.
   *
@@ -81,9 +82,9 @@ private[scalafix] object TreePatch {
   case class RemoveImportee(importee: Importee) extends ImportPatch
   case class AddGlobalImport(importer: Importer) extends ImportPatch
   case class AddGlobalSymbol(symbol: Symbol) extends ImportPatch
-  case class MoveSymbol(from: Symbol.Global, to: Symbol.Global)
+  case class ReplaceSymbol(from: Symbol.Global, to: Symbol.Global)
       extends TreePatch
-  object MoveSymbol {}
+  object ReplaceSymbol {}
 
 }
 
@@ -146,10 +147,10 @@ object Patch {
       patch: Patch)(implicit ctx: RewriteCtx, mirror: Database): String = {
     val base = underlying(patch)
     val moveSymbol = underlying(
-      MoveSymbolOps.naiveMoveSymbolPatch(base.collect {
-        case m: MoveSymbol => m
+      ReplaceSymbolOps.naiveMoveSymbolPatch(base.collect {
+        case m: ReplaceSymbol => m
       }))
-    val patches = base.filterNot(_.isInstanceOf[MoveSymbol]) ++ moveSymbol
+    val patches = base.filterNot(_.isInstanceOf[ReplaceSymbol]) ++ moveSymbol
     val tokenPatches = patches.collect { case e: TokenPatch => e }
     val importPatches = patches.collect { case e: ImportPatch => e }
     val importTokenPatches = {

--- a/scalafix-tests/input/src/main/scala/test/ReplaceSymbol.scala
+++ b/scalafix-tests/input/src/main/scala/test/ReplaceSymbol.scala
@@ -2,7 +2,7 @@
 patches.removeGlobalImports = [
   "scala.collection.mutable"
 ]
-patches.moveSymbols = [
+patches.replaceSymbols = [
   { from = "scala.collection.mutable.ListBuffer"
     to = "com.geirsson.mutable.CoolBuffer" }
   { from = "scala.collection.mutable.HashMap"
@@ -17,7 +17,7 @@ import scala.collection.mutable.HashMap
 import scala.collection.mutable.ListBuffer
 import scala.collection.mutable
 
-object MoveSymbol {
+object ReplaceSymbol {
   math.sqrt(9)
   val u: mutable.HashMap[Int, Int] = HashMap.empty[Int, Int]
   val x: ListBuffer[Int] = ListBuffer.empty[Int]

--- a/scalafix-tests/output/src/main/scala/test/ReplaceSymbol.scala
+++ b/scalafix-tests/output/src/main/scala/test/ReplaceSymbol.scala
@@ -4,7 +4,7 @@ import com.geirsson.{ fastmath, mutable }
 import com.geirsson.mutable.{ CoolBuffer, unsafe }
 import com.geirsson.mutable.unsafe.CoolMap
 
-object MoveSymbol {
+object ReplaceSymbol {
   fastmath.sqrt(9)
   val u: unsafe.CoolMap[Int, Int] = CoolMap.empty[Int, Int]
   val x: CoolBuffer[Int] = CoolBuffer.empty[Int]


### PR DESCRIPTION
The motivation for this change is that "move" makes it sound as if the
definition of the symbol will be moved, while the patch only updates
the use-sites of the symbol.