### PR TITLE
Upgrade to coursier RC9.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -205,8 +205,8 @@ lazy val `scalafix-sbt` = project
     },
     sbtPlugin := true,
     libraryDependencies ++= Seq(
-      "io.get-coursier" %% "coursier" % "1.0.0-RC6",
-      "io.get-coursier" %% "coursier-cache" % "1.0.0-RC6"
+      "io.get-coursier" %% "coursier" % coursier.util.Properties.version,
+      "io.get-coursier" %% "coursier-cache" % coursier.util.Properties.version
     ),
     testQuick := {}, // these test are slow.
     test.in(IntegrationTest) := {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,8 @@
 addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.9")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC6")
+addSbtPlugin(
+  "io.get-coursier" % "sbt-coursier" % coursier.util.Properties.version)
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "1.2.0")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC6")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC9")
 unmanagedSources.in(Compile) += baseDirectory.value / ".." / "Dependencies.scala"


### PR DESCRIPTION
There were regressions in RC7/RC8 which cause the jar fetcher in
sbt-scalafix to fail. Discovered while testing on scastie.