### PR TITLE
Add PatchOps.renameSymbol.

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/SymbolOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/SymbolOps.scala
@@ -11,6 +11,7 @@ object SymbolOps {
     }
   }
   object BottomSymbol {
+    def apply(): Symbol = Symbol.Global(Symbol.None, Signature.Term("_root_"))
     def unapply(arg: Symbol): Boolean = arg match {
       case Symbol.Global(Symbol.None, Signature.Term("_root_")) => true
       case _ => false

--- a/scalafix-core/shared/src/main/scala/scalafix/patch/Patch.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/patch/Patch.scala
@@ -84,7 +84,6 @@ private[scalafix] object TreePatch {
   case class AddGlobalSymbol(symbol: Symbol) extends ImportPatch
   case class ReplaceSymbol(from: Symbol.Global, to: Symbol.Global)
       extends TreePatch
-
 }
 
 // implementation detail

--- a/scalafix-core/shared/src/main/scala/scalafix/patch/PatchOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/patch/PatchOps.scala
@@ -20,4 +20,5 @@ trait PatchOps {
   def addGlobalImport(importer: Importer)(implicit mirror: Mirror): Patch
   def replaceSymbol(fromSymbol: Symbol.Global, toSymbol: Symbol.Global)(
       implicit mirror: Mirror): Patch
+  def renameSymbol(fromSymbol: Symbol.Global, toName: String)(implicit mirror: Mirror): Patch
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/rewrite/RewriteCtx.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/rewrite/RewriteCtx.scala
@@ -6,6 +6,7 @@ import scala.meta.tokens.Tokens
 import scalafix.syntax._
 import scalafix.config.ScalafixConfig
 import scalafix.config.ScalafixReporter
+import scalafix.internal.util.SymbolOps.BottomSymbol
 import scalafix.patch.PatchOps
 import scalafix.patch.TokenPatch
 import scalafix.patch.TokenPatch.Add
@@ -77,5 +78,10 @@ case class RewriteCtx(tree: Tree, config: ScalafixConfig) extends PatchOps {
   def replaceSymbol(fromSymbol: Symbol.Global, toSymbol: Symbol.Global)(
       implicit mirror: Mirror): Patch =
     TreePatch.ReplaceSymbol(fromSymbol, toSymbol)
+  def renameSymbol(fromSymbol: Symbol.Global, toName: String)(
+      implicit mirror: Mirror): Patch =
+    TreePatch.ReplaceSymbol(
+      fromSymbol,
+      Symbol.Global(BottomSymbol(), Signature.Term(toName)))
 
 }

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRewriteSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRewriteSuite.scala
@@ -1,7 +1,9 @@
 package scalafix
 package testkit
 
+import scalafix.syntax._
 import scala.meta._
+import org.scalameta.logger
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FunSuite
 
@@ -51,6 +53,15 @@ abstract class SemanticRewriteSuite(
         candidateBytes
       )
       assertNoDiff(obtained, expected)
+    }
+  }
+
+  /** Helper method to print out mirror for individual files */
+  def debugFile(filename: String): Unit = {
+    mirror.entries.foreach { entry =>
+      if (entry.input.label.contains(filename)) {
+        logger.elem(entry)
+      }
     }
   }
 

--- a/scalafix-tests/input/src/main/scala/test/ReplaceSymbol.scala
+++ b/scalafix-tests/input/src/main/scala/test/ReplaceSymbol.scala
@@ -12,6 +12,14 @@ patches.replaceSymbols = [
     to = "com.geirsson.mutable.unsafe.CoolMap" }
   { from = "scala.math.sqrt"
     to = "com.geirsson.fastmath.sqrt" }
+  // normalized symbol renames all overloaded methods
+  { from = "_root_.scala.collection.TraversableOnce.mkString."
+    to = "unsafeMkString" }
+  // non-normalized symbol renames single method overload
+  { from = "_root_.java.lang.String#substring(I)Ljava/lang/String;."
+    to = "substringFrom" }
+  { from = "_root_.java.lang.String#substring(II)Ljava/lang/String;."
+    to = "substringBetween" }
 ]
  */
 package fix
@@ -24,6 +32,10 @@ import scala.concurrent.Future
 object ReplaceSymbol {
   Future.successful(1 + 2)
   math.sqrt(9)
+  List(1).tail.mkString
+  List(1).tail.mkString("blah")
+  "blah".substring(1)
+  "blah".substring(1, 2)
   val u: mutable.HashMap[Int, Int] = HashMap.empty[Int, Int]
   val x: ListBuffer[Int] = ListBuffer.empty[Int]
   val y: mutable.ListBuffer[Int] = mutable.ListBuffer.empty[Int]

--- a/scalafix-tests/output/src/main/scala/fix/package.scala
+++ b/scalafix-tests/output/src/main/scala/fix/package.scala
@@ -1,0 +1,12 @@
+
+package object fix {
+  implicit class XtensionList[T](lst: List[T]) {
+    def unsafeMkString = lst.mkString
+    def unsafeMkString(sep: String) = lst.mkString(sep)
+  }
+  implicit class XtensionString[T](str: String) {
+    def substringFrom(beginIndex: Int): String = str.substring(beginIndex)
+    def substringBetween(beginIndex: Int, endIndex: Int): String = str.substring(beginIndex, endIndex)
+  }
+
+}

--- a/scalafix-tests/output/src/main/scala/test/ReplaceSymbol.scala
+++ b/scalafix-tests/output/src/main/scala/test/ReplaceSymbol.scala
@@ -8,6 +8,10 @@ import com.geirsson.mutable.unsafe.CoolMap
 object ReplaceSymbol {
   Future.successful(1 + 2)
   fastmath.sqrt(9)
+  List(1).tail.unsafeMkString
+  List(1).tail.unsafeMkString("blah")
+  "blah".substringFrom(1)
+  "blah".substringBetween(1, 2)
   val u: unsafe.CoolMap[Int, Int] = CoolMap.empty[Int, Int]
   val x: CoolBuffer[Int] = CoolBuffer.empty[Int]
   val y: mutable.CoolBuffer[Int] = mutable.CoolBuffer.empty[Int]


### PR DESCRIPTION
This is a helpful patch to rename a method. The implementation piggy
backs on the ReplaceSymbol since the two are very similar.