### PR TITLE
Various fixes discovered in collection-strawman rewrites.

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/SemanticCtxImpl.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/SemanticCtxImpl.scala
@@ -6,12 +6,12 @@ import scala.meta._
 class SemanticCtxImpl(val database: Database) extends SemanticCtx {
   override def toString: String = database.toString()
   override def hashCode(): Int = database.hashCode()
-  private val _denots: Map[Symbol, Denotation] = {
+  private lazy val _denots: Map[Symbol, Denotation] = {
     val builder = Map.newBuilder[Symbol, Denotation]
     database.symbols.foreach(r => builder += (r.sym -> r.denot))
     builder.result()
   }
-  private val _names: Map[Position, ResolvedName] = {
+  private lazy val _names: Map[Position, ResolvedName] = {
     val builder = Map.newBuilder[Position, ResolvedName]
     def add(r: ResolvedName) = {
       builder += (r.pos -> r)
@@ -22,9 +22,9 @@ class SemanticCtxImpl(val database: Database) extends SemanticCtx {
     }
     builder.result()
   }
-
   def symbol(position: Position): Option[Symbol] =
     _names.get(position).map(_.sym)
   def denotation(symbol: Symbol): Option[Denotation] =
     _denots.get(symbol)
+  override def names: Seq[ResolvedName] = _names.values.toSeq
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/SymbolOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/SymbolOps.scala
@@ -40,16 +40,14 @@ object SymbolOps {
   def normalize(symbol: Symbol): Symbol = symbol match {
     case Symbol.Multi(syms) =>
       Symbol.Multi(syms.map(normalize))
-    case Symbol.Global(sym, Signature.Type(name)) =>
-      Symbol.Global(sym, Signature.Term(name))
     case Symbol.Global(sym, Signature.Term("package")) =>
       normalize(sym)
     case Symbol.Global(
         Symbol.Global(sym, Signature.Term(name)),
         Signature.Method("apply", _)) =>
       Symbol.Global(sym, Signature.Term(name))
-    case Symbol.Global(sym, Signature.Method(name, _)) =>
-      Symbol.Global(normalize(sym), Signature.Term(name))
+    case Symbol.Global(sym, sig) =>
+      Symbol.Global(normalize(sym), Signature.Term(sig.name))
     case x => x
   }
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/patch/PatchOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/patch/PatchOps.scala
@@ -20,5 +20,6 @@ trait PatchOps {
   def addGlobalImport(importer: Importer)(implicit mirror: SemanticCtx): Patch
   def replaceSymbol(fromSymbol: Symbol.Global, toSymbol: Symbol.Global)(
       implicit mirror: SemanticCtx): Patch
+  def replaceSymbols(toReplace: (String, String)*)(implicit mirror: SemanticCtx): Patch
   def renameSymbol(fromSymbol: Symbol.Global, toName: String)(implicit mirror: SemanticCtx): Patch
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/rewrite/RewriteCtx.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/rewrite/RewriteCtx.scala
@@ -5,6 +5,7 @@ import scala.meta.contrib.AssociatedComments
 import scala.meta.tokens.Tokens
 import scalafix.syntax._
 import scalafix.config.ScalafixConfig
+import scalafix.config.ScalafixMetaconfigReaders
 import scalafix.config.ScalafixReporter
 import scalafix.internal.util.SymbolOps.BottomSymbol
 import scalafix.patch.PatchOps
@@ -79,6 +80,14 @@ case class RewriteCtx(tree: Tree, config: ScalafixConfig) extends PatchOps {
   def replaceSymbol(fromSymbol: Symbol.Global, toSymbol: Symbol.Global)(
       implicit mirror: SemanticCtx): Patch =
     TreePatch.ReplaceSymbol(fromSymbol, toSymbol)
+  def replaceSymbols(toReplace: (String, String)*)(
+      implicit mirror: SemanticCtx): Patch =
+    toReplace.foldLeft(Patch.empty) {
+      case (a, (from, to)) =>
+        val (fromSymbol, toSymbol) =
+          ScalafixMetaconfigReaders.parseReplaceSymbol(from, to).get
+        a + ctx.replaceSymbol(fromSymbol, toSymbol)
+    }
   def renameSymbol(fromSymbol: Symbol.Global, toName: String)(
       implicit mirror: SemanticCtx): Patch =
     TreePatch.ReplaceSymbol(

--- a/scalafix-core/shared/src/main/scala/scalafix/util/SemanticCtx.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/util/SemanticCtx.scala
@@ -11,8 +11,8 @@ import scalafix.internal.util.SemanticCtxImpl
   */
 trait SemanticCtx {
   def database: Database
+  def names: Seq[ResolvedName]
   def entries: Seq[Attributes] = database.entries
-  def names: Seq[ResolvedName] = database.names
   def messages: Seq[Message] = database.messages
   def symbols: Seq[ResolvedSymbol] = database.symbols
   def sugars: Seq[Sugar] = database.sugars

--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -124,7 +124,6 @@ object ScalafixPlugin extends AutoPlugin {
       val verbose = if (scalafixVerbose.value) "--verbose" :: Nil else Nil
       val main = cliWrapperMain.value
       val log = streams.value.log
-
       compile.all(filter).value // trigger compilation
       val classpath = classDirectory.all(filter).value.asPath
       val directoriesToFix: Seq[String] =

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRewriteSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRewriteSuite.scala
@@ -3,6 +3,7 @@ package testkit
 
 import scalafix.syntax._
 import scala.meta._
+import scalafix.internal.util.SemanticCtxImpl
 import org.scalameta.logger
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FunSuite
@@ -14,6 +15,15 @@ abstract class SemanticRewriteSuite(
 ) extends FunSuite
     with DiffAssertions
     with BeforeAndAfterAll { self =>
+  def this(
+      database: Database,
+      inputSourceroot: AbsolutePath,
+      expectedOutputSourceroot: Seq[AbsolutePath]
+  ) =
+    this(
+      new SemanticCtxImpl(database),
+      inputSourceroot,
+      expectedOutputSourceroot)
 
   private def dialectToPath(dialect: String): Option[String] =
     Option(dialect).collect {


### PR DESCRIPTION
- .normalized didn't recurse properly
- ctx.addGlobalImports didn't deduplicate symbols
- inserted grouped imports were not sorted alphabetically
- SemanticCtx.names did not include symbols from sugars
- new PatchOps.replaceSymbols which is a wrapper over .replaceSymbol
- SemanticTests constructor overload for backwards compatibility with
  scalacenter/scalafix.g8 generated code.