### PR TITLE
Integrate sbtfix into scalafix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,6 +81,7 @@ lazy val buildInfoSettings: Seq[Def.Setting[_]] = Seq(
     "coursier" -> coursier.util.Properties.version,
     "nightly" -> version.value,
     "scalameta" -> scalametaV,
+    "sbthost" -> sbthostV,
     scalaVersion,
     "supportedScalaVersions" -> Seq(scala211, scala212),
     "scala211" -> scala211,

--- a/build.sbt
+++ b/build.sbt
@@ -24,11 +24,10 @@ commands += Command.command("release") { s =>
     "gitPushTag" ::
     s
 }
-commands += CiCommand("ci-fast")(
-  ci("test") ::
-    "such testsOutputDotty/test" ::
-    Nil
-)
+commands += Command.command("ci-fast") { s =>
+  "test" ::
+    s
+}
 commands += Command.command("ci-slow") { s =>
   "scalafix-sbt/it:test" ::
     s
@@ -152,7 +151,6 @@ lazy val core = crossProject
   )
   .enablePlugins(BuildInfoPlugin)
   .dependsOn(diff)
-
 lazy val coreJS = core.js
 lazy val coreJVM = core.jvm
 
@@ -436,20 +434,6 @@ lazy val readme = scalatex
 lazy val isFullCrossVersion = Seq(
   crossVersion := CrossVersion.full
 )
-
-lazy val dotty = "0.1.1-bin-20170530-f8f52cc-NIGHTLY"
-lazy val scala210 = "2.10.6"
-lazy val scala211 = "2.11.11"
-lazy val scala212 = "2.12.3"
-lazy val ciScalaVersion = sys.env.get("CI_SCALA_VERSION")
-def CiCommand(name: String)(commands: List[String]): Command =
-  Command.command(name) { initState =>
-    commands.foldLeft(initState) {
-      case (state, command) => command :: state
-    }
-  }
-def ci(command: String) =
-  s"plz ${ciScalaVersion.getOrElse("No CI_SCALA_VERSION defined")} $command"
 
 lazy val compilerOptions = Seq(
   "-deprecation",

--- a/build.sbt
+++ b/build.sbt
@@ -311,6 +311,8 @@ lazy val testsOutputDotty = project
   .settings(
     allSettings,
     noPublish,
+    // Skip this project for IntellIJ, see https://youtrack.jetbrains.com/issue/SCL-12237
+    SettingKey[Boolean]("ide-skip-project") := true,
     scalaVersion := dotty,
     crossScalaVersions := List(dotty),
     libraryDependencies := libraryDependencies.value.map(_.withDottyCompat()),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,6 +7,11 @@ object Dependencies {
   val scalametaV = "2.0.0-M2"
   val metaconfigV = "0.5.1"
   def sbthostV = "0.3.1"
+  def dotty = "0.1.1-bin-20170530-f8f52cc-NIGHTLY"
+  def scala210 = "2.10.6"
+  def scala211 = "2.11.11"
+  def scala212 = "2.12.3"
+  def ciScalaVersion = sys.env.get("CI_SCALA_VERSION")
 
   var testClasspath: String = "empty"
   def semanticdb: ModuleID = "org.scalameta" % "semanticdb-scalac" % scalametaV cross CrossVersion.full

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,7 @@ object Dependencies {
 
   val scalametaV = "2.0.0-M2"
   val metaconfigV = "0.5.1"
+  def sbthostV = "0.3.0+20170814-1550"
 
   var testClasspath: String = "empty"
   def semanticdb: ModuleID = "org.scalameta" % "semanticdb-scalac" % scalametaV cross CrossVersion.full

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
 
   val scalametaV = "2.0.0-M2"
   val metaconfigV = "0.5.1"
-  def sbthostV = "0.3.0+20170814-1550"
+  def sbthostV = "0.3.1"
 
   var testClasspath: String = "empty"
   def semanticdb: ModuleID = "org.scalameta" % "semanticdb-scalac" % scalametaV cross CrossVersion.full

--- a/readme/Installation.scalatex
+++ b/readme/Installation.scalatex
@@ -59,9 +59,14 @@
               Description
         @tbody
           @sbtkey("scalafix <rewrite>..", "Unit")
-            Run scalafix with rewrites.
+            Run scalafix on project sources.
             See @sect.ref{Rewrites} or use tab completion to explore
             supported rewrites.
+          @sbtkey("scalafixBuild <rewrite>..", "Unit")
+            Run scalafix on the build sources, @code{*.sbt} and
+            @code{project/*}.
+            @note Requires @sect.ref{semanticdb-sbt} enabled globally
+            for semantic rewrites.
           @sbtkey("scalafixEnabled", "Boolean")
             True by default.
             If false, then sbt-scalafix will not enable the
@@ -82,6 +87,23 @@
             Which version of org.scalameta:semanticdb-scalac to run.
           @sbtkey("scalafixVerbose", "Boolean")
             If true, print out debug information.
+    @sect{semanticdb-sbt}
+      @b{Experimental}.
+      semanticdb-sbt is a Scala 2.10 compiler plugin that extracts semantic
+      information from the sbt compiler. To enable semanticdb-sbt,
+
+      @hl.scala
+        // ~/.sbt/0.13/plugins/plugins.sbt
+        addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "@V.stableVersion")
+        // ~/.sbt/0.13/build.sbt
+        import scalafix.sbt.ScalafixPlugin.autoImport._
+        scalafixBuildSettings // enable semanticdb-sbt for sbt metabuilds.
+
+      @note This integration is new, you can expect to face problems from enabling
+      sbt-scalafix globally. In particular, sbt-scalafix does not at the moment
+      support older versions of 2.11 than @V.scala211 and 2.12 than @V.scala212.
+      It's possible to disable sbt-scalafix with @code{scalafixEnabled := false}.
+      Please report back on your experience.
 
   @sect{scalafix-core}
     Scalafix can be used as a library to run custom rewrites.

--- a/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
+++ b/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
@@ -18,6 +18,7 @@ import scala.meta._
 import scala.meta.inputs.Input
 import scala.meta.internal.inputs._
 import scala.meta.io.AbsolutePath
+import scala.meta.sbthost.Sbthost
 import scala.util.Try
 import scala.util.control.NonFatal
 import scalafix.internal.config.Class2Hocon
@@ -273,8 +274,10 @@ object CliRunner {
       val result: Configured[SemanticCtx] = cachedDatabase.getOrElse {
         try {
           resolveClasspath.map { classpath =>
-            val db = new SemanticCtxImpl(
-              Database.load(classpath, Sourcepath(resolvedSourceroot)))
+            val db = SemanticCtx.load(
+              Sbthost.patchDatabase(
+                Database.load(classpath, Sourcepath(resolvedSourceroot)),
+                resolvedSourceroot))
             if (verbose) {
               common.err.println(
                 s"Loaded database with ${db.entries.length} entries.")

--- a/scalafix-core/shared/src/main/scala/scalafix/config/package.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/config/package.scala
@@ -17,7 +17,7 @@ package object config {
   def fromString(
       configuration: String,
       decoder: ConfDecoder[Rewrite]
-  ): Configured[(Rewrite, ScalafixConfig)] =
+  ): Configured[(Rewrite, internal.config.ScalafixConfig)] =
     fromInput(Input.String(configuration), _ => None, Nil, decoder)
 
   /** Load configuration from an input.
@@ -38,7 +38,7 @@ package object config {
       semanticCtx: LazySemanticCtx,
       extraRewrites: List[String],
       rewriteDecoder: ConfDecoder[Rewrite]
-  ): Configured[(Rewrite, ScalafixConfig)] =
-    ScalafixConfig.fromInput(configuration, semanticCtx, extraRewrites)(
-      rewriteDecoder)
+  ): Configured[(Rewrite, internal.config.ScalafixConfig)] =
+    internal.config.ScalafixConfig
+      .fromInput(configuration, semanticCtx, extraRewrites)(rewriteDecoder)
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/SemanticCtxImpl.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/SemanticCtxImpl.scala
@@ -27,4 +27,7 @@ class SemanticCtxImpl(val database: Database) extends SemanticCtx {
   def denotation(symbol: Symbol): Option[Denotation] =
     _denots.get(symbol)
   override def names: Seq[ResolvedName] = _names.values.toSeq
+
+  override def merge(other: SemanticCtx): SemanticCtx =
+    new SemanticCtxImpl(Database(database.entries ++ other.database.entries))
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/SemanticCtxImpl.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/SemanticCtxImpl.scala
@@ -27,7 +27,4 @@ class SemanticCtxImpl(val database: Database) extends SemanticCtx {
   def denotation(symbol: Symbol): Option[Denotation] =
     _denots.get(symbol)
   override def names: Seq[ResolvedName] = _names.values.toSeq
-
-  override def merge(other: SemanticCtx): SemanticCtx =
-    new SemanticCtxImpl(Database(database.entries ++ other.database.entries))
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/rewrite/Sbt1.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/rewrite/Sbt1.scala
@@ -1,0 +1,119 @@
+package scalafix.rewrite
+
+import scalafix._
+import scala.meta._
+import scala.meta.tokens.Token.RightParen
+import scala.meta.tokens.Token.LeftParen
+
+case class Sbt1(sctx: SemanticCtx) extends SemanticRewrite(sctx) {
+  override def rewrite(ctx: RewriteCtx): Patch = {
+    sealed abstract class SbtOperator {
+      val operator: String
+      val newOperator: String
+
+      object SbtSelectors {
+        val value = ".value"
+        val evaluated = ".evaluated"
+      }
+
+      object SbtTypes {
+        val inputKey: String = "sbt.InputKey["
+      }
+
+      def unapply(tree: Term): Option[(Term, Token, Term)] = tree match {
+        case Term.ApplyInfix(lhs, o @ Term.Name(`operator`), _, Seq(rhs)) =>
+          Some((lhs, o.tokens.head, rhs))
+        case Term
+              .Apply(Term.Select(lhs, o @ Term.Name(`operator`)), Seq(rhs)) =>
+          Some((lhs, o.tokens.head, rhs))
+        case Term.Apply(
+            Term.ApplyType(Term.Select(lhs, o @ Term.Name(`operator`)), _),
+            Seq(rhs)) =>
+          Some((lhs, o.tokens.head, rhs))
+        case _ =>
+          None
+      }
+
+      private def wrapInParenthesis(tokens: Tokens): List[Patch] =
+        List(ctx.addLeft(tokens.head, "("), ctx.addRight(tokens.last, ")"))
+
+      private def isParensWrapped(tokens: Tokens): Boolean = {
+        tokens.head.isInstanceOf[LeftParen] &&
+        tokens.last.isInstanceOf[RightParen]
+      }
+
+      private def infoStartsWith(r: Term.Ref, prefix: String): Boolean =
+        sctx
+          .symbol(r.pos)
+          .flatMap(sctx.denotation)
+          .exists(denot => denot.info.startsWith(prefix))
+
+      private def existKeys(lhs: Term, typePrefix: String): Boolean = {
+        val singleNames = lhs match {
+          case tn @ Term.Name(name) if infoStartsWith(tn, typePrefix) =>
+            tn :: Nil
+          case _ => Nil
+        }
+        val scopedNames = lhs.collect {
+          case Term.Select(tn @ Term.Name(name), Term.Name("in"))
+              if infoStartsWith(tn, typePrefix) =>
+            name
+          case Term.ApplyInfix(tn @ Term.Name(name), Term.Name("in"), _, _)
+              if infoStartsWith(tn, typePrefix) =>
+            name
+        }
+        (singleNames ++ scopedNames).nonEmpty
+      }
+
+      def rewriteDslOperator(
+          lhs: Term,
+          opToken: Token,
+          rhs: Term): List[Patch] = {
+        val wrapExpression = rhs match {
+          case arg @ Term.Apply(_, Seq(_: Term.Block))
+              if !isParensWrapped(arg.tokens) =>
+            wrapInParenthesis(arg.tokens)
+          case arg: Term.ApplyInfix if !isParensWrapped(arg.tokens) =>
+            wrapInParenthesis(arg.tokens)
+          case _ => Nil
+        }
+
+        val removeOperator = ctx.removeToken(opToken)
+        val addNewOperator = ctx.addLeft(opToken, newOperator)
+        val rewriteRhs = {
+          val requiresEvaluated = existKeys(lhs, SbtTypes.inputKey)
+          val newSelector =
+            if (requiresEvaluated) SbtSelectors.evaluated
+            else SbtSelectors.value
+          ctx.addRight(rhs.tokens.last, newSelector)
+        }
+
+        (removeOperator :: addNewOperator :: wrapExpression) ++ Seq(rewriteRhs)
+      }
+    }
+
+    object `<<=` extends SbtOperator {
+      override final val operator = "<<="
+      override final val newOperator: String = ":="
+    }
+
+    object `<+=` extends SbtOperator {
+      override final val operator = "<+="
+      override final val newOperator: String = "+="
+    }
+
+    object `<++=` extends SbtOperator {
+      override final val operator = "<++="
+      override final val newOperator: String = "++="
+    }
+
+    ctx.tree.collect {
+      case `<<=`(lhs: Term, opToken: Token, rhs: Term) =>
+        `<<=`.rewriteDslOperator(lhs, opToken, rhs)
+      case `<+=`(lhs: Term, opToken: Token, rhs: Term) =>
+        `<+=`.rewriteDslOperator(lhs, opToken, rhs)
+      case `<++=`(lhs: Term, opToken: Token, rhs: Term) =>
+        `<++=`.rewriteDslOperator(lhs, opToken, rhs)
+    }.flatten.asPatch
+  }
+}

--- a/scalafix-core/shared/src/main/scala/scalafix/rewrite/Sbt1.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/rewrite/Sbt1.scala
@@ -107,13 +107,16 @@ case class Sbt1(sctx: SemanticCtx) extends SemanticRewrite(sctx) {
       override final val newOperator: String = "++="
     }
 
-    ctx.tree.collect {
-      case `<<=`(lhs: Term, opToken: Token, rhs: Term) =>
-        `<<=`.rewriteDslOperator(lhs, opToken, rhs)
-      case `<+=`(lhs: Term, opToken: Token, rhs: Term) =>
-        `<+=`.rewriteDslOperator(lhs, opToken, rhs)
-      case `<++=`(lhs: Term, opToken: Token, rhs: Term) =>
-        `<++=`.rewriteDslOperator(lhs, opToken, rhs)
-    }.flatten.asPatch
+    ctx.tree
+      .collect {
+        case `<<=`(lhs: Term, opToken: Token, rhs: Term) =>
+          `<<=`.rewriteDslOperator(lhs, opToken, rhs)
+        case `<+=`(lhs: Term, opToken: Token, rhs: Term) =>
+          `<+=`.rewriteDslOperator(lhs, opToken, rhs)
+        case `<++=`(lhs: Term, opToken: Token, rhs: Term) =>
+          `<++=`.rewriteDslOperator(lhs, opToken, rhs)
+      }
+      .flatten
+      .asPatch
   }
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/rewrite/ScalafixRewrites.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/rewrite/ScalafixRewrites.scala
@@ -12,6 +12,7 @@ object ScalafixRewrites {
     DottyVarArgPattern
   )
   def semantic(semanticCtx: SemanticCtx): List[Rewrite] = List(
+    Sbt1(semanticCtx),
     ExplicitReturnTypes(semanticCtx),
     RemoveUnusedImports(semanticCtx),
     NoAutoTupling(semanticCtx)

--- a/scalafix-core/shared/src/main/scala/scalafix/util/SemanticCtx.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/util/SemanticCtx.scala
@@ -16,7 +16,6 @@ trait SemanticCtx {
   def messages: Seq[Message] = database.messages
   def symbols: Seq[ResolvedSymbol] = database.symbols
   def sugars: Seq[Sugar] = database.sugars
-  def merge(other: SemanticCtx): SemanticCtx
 
   /** Lookup symbol at this position. */
   def symbol(position: Position): Option[Symbol]

--- a/scalafix-core/shared/src/main/scala/scalafix/util/SemanticCtx.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/util/SemanticCtx.scala
@@ -16,6 +16,7 @@ trait SemanticCtx {
   def messages: Seq[Message] = database.messages
   def symbols: Seq[ResolvedSymbol] = database.symbols
   def sugars: Seq[Sugar] = database.sugars
+  def merge(other: SemanticCtx): SemanticCtx
 
   /** Lookup symbol at this position. */
   def symbol(position: Position): Option[Symbol]
@@ -34,4 +35,6 @@ object SemanticCtx {
     new SemanticCtxImpl(Database.load(classpath, sourcepath))
   def load(bytes: Array[Byte]): SemanticCtx =
     new SemanticCtxImpl(Database.load(bytes))
+  def load(db: Database): SemanticCtx =
+    new SemanticCtxImpl(db)
 }

--- a/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixRewriteNames.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixRewriteNames.scala
@@ -10,8 +10,10 @@ object ScalafixRewriteNames {
     "ProcedureSyntax",
     "ExplicitUnit",
     "DottyVarArgPattern",
+    "Sbt1",
     "ExplicitReturnTypes",
     "RemoveUnusedImports",
     "NoAutoTupling"
   )
 }
+

--- a/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixRewriteNames.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixRewriteNames.scala
@@ -16,4 +16,3 @@ object ScalafixRewriteNames {
     "NoAutoTupling"
   )
 }
-

--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -10,7 +10,6 @@ import sbt.plugins.JvmPlugin
 import scalafix.internal.sbt.ScalafixCompletions
 import scalafix.internal.sbt.ScalafixJarFetcher
 import sbt.Def
-import sbt.Def
 
 object ScalafixPlugin extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
@@ -57,6 +56,8 @@ object ScalafixPlugin extends AutoPlugin {
     scalafixEnabled := true,
     scalafixVerbose := false,
     scalafixBuild := Def.inputTaskDyn {
+      // Will currently fail silently if semanticdb-sbt is not enabled.
+      // See https://github.com/scalacenter/scalafix/issues/264
       val baseDir = (baseDirectory in ThisBuild).value
       val sbtDir: File = baseDir./("project")
       val sbtFiles = baseDir.*("*.sbt").get

--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -28,6 +28,8 @@ object ScalafixPlugin extends AutoPlugin {
           "compiler plugin, which is necessary for semantic rewrites.")
     def scalafixScalacOptions: Def.Initialize[Seq[String]] =
       ScalafixPlugin.scalafixScalacOptions
+    def scalafixBuildSettings: Seq[Def.Setting[_]] =
+      ScalafixPlugin.scalafixBuildSettings
     val scalafixVerbose: SettingKey[Boolean] =
       settingKey[Boolean]("pass --verbose to scalafix")
     def scalafixSettings: Seq[Def.Setting[_]] =
@@ -98,7 +100,19 @@ object ScalafixPlugin extends AutoPlugin {
     }
   }
 
-  lazy val scalafixScalacSettings: Seq[Def.Setting[_]] = Seq(
+  lazy val scalafixBuildSettings: Seq[Def.Setting[_]] = Def.settings(
+    libraryDependencies ++= {
+      val sbthost = "org.scalameta" % "sbthost-nsc" % "0.3.1" cross CrossVersion.full
+      val isMetabuild = {
+        val p = thisProject.value
+        p.id.endsWith("-build") && p.base.getName == "project"
+      }
+      if (isMetabuild) compilerPlugin(sbthost) :: Nil
+      else Nil
+    }
+  )
+
+  lazy val scalafixScalacSettings: Seq[Def.Setting[_]] = Def.settings(
     scalacOptions ++= {
       if (isSupportedScalaVersion.value) {
         scalafixScalacOptions.value

--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -117,7 +117,7 @@ object ScalafixPlugin extends AutoPlugin {
 
   lazy val scalafixBuildSettings: Seq[Def.Setting[_]] = Def.settings(
     libraryDependencies ++= {
-      val sbthost = "org.scalameta" % "sbthost-nsc" % "0.3.1" cross CrossVersion.full
+      val sbthost = "org.scalameta" % "sbthost-nsc" % Versions.sbthost cross CrossVersion.full
       val isMetabuild = {
         val p = thisProject.value
         p.id.endsWith("-build") && p.base.getName == "project"

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/build.sbt
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/build.sbt
@@ -30,9 +30,10 @@ TaskKey[Unit]("check") := {
       |  }
       |}""".stripMargin
   val testExpected = expected.replaceFirst("Main", "MainTest")
+  // NOTE: ProcedureSyntax runs since it's syntactic. Only semantic rewrites
+  // don't trigger.
   def unchanged(code: String) =
     code
-      .replace(": Unit =", "")
       .replace("((", "(")
       .replace("\"))", "\")")
 

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRewriteSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRewriteSuite.scala
@@ -10,11 +10,20 @@ import org.scalatest.FunSuite
 
 abstract class SemanticRewriteSuite(
     val semanticCtx: SemanticCtx,
-    val inputSourceroot: AbsolutePath,
+    val inputSourceroot: Seq[AbsolutePath],
     val expectedOutputSourceroot: Seq[AbsolutePath]
 ) extends FunSuite
     with DiffAssertions
     with BeforeAndAfterAll { self =>
+  def this(
+      sctx: SemanticCtx,
+      inputSourceroot: AbsolutePath,
+      expectedOutputSourceroot: Seq[AbsolutePath]
+  ) = this(
+    sctx,
+    List(inputSourceroot),
+    expectedOutputSourceroot
+  )
   def this(
       database: Database,
       inputSourceroot: AbsolutePath,
@@ -23,7 +32,8 @@ abstract class SemanticRewriteSuite(
     this(
       new SemanticCtxImpl(database),
       inputSourceroot,
-      expectedOutputSourceroot)
+      expectedOutputSourceroot
+    )
 
   private def dialectToPath(dialect: String): Option[String] =
     Option(dialect).collect {

--- a/scalafix-tests/input-sbt/src/main/scala/sbtfix/SbtOneZeroMigrationTest.scala
+++ b/scalafix-tests/input-sbt/src/main/scala/sbtfix/SbtOneZeroMigrationTest.scala
@@ -1,0 +1,132 @@
+/*
+rewrite = Sbt1
+ */
+package sbtfix
+
+import sbt._
+
+object SbtOneZeroMigrationTest {
+  object `<++=` {
+    val key = taskKey[Seq[File]]("Seed.")
+    val target = taskKey[Seq[File]]("Target to be reassigned.")
+    key := List(new File("."))
+    target <++= key
+    target <++= (key)
+    target <++= (key in ThisBuild)
+    target <++= Def.task(key.value)
+    target <++= Def.task {
+      println("Executing task.")
+      (key).value
+    }
+  }
+
+  object `<+=` {
+    val key = taskKey[File]("Single.")
+    val target = taskKey[Seq[File]]("Target to be reassigned.")
+    key := new File(".")
+    target <+= key
+    target <+= (key)
+    target <+= (key in ThisBuild)
+    target <+= Def.task(key.value)
+    target.<+=[File](Def.task(key.value))
+    target <+= Def.task {
+      println("Executing task.")
+      (key).value
+    }
+  }
+
+  object `<<=` {
+    import Keys.{compile, name}
+    lazy val test1 = taskKey[sbt.inc.Analysis]("Test 1.")
+    test1 <<= (compile in Compile)
+    lazy val test1b = taskKey[sbt.inc.Analysis]("Test 1b.")
+    test1b <<= compile in Compile
+    lazy val test2 = taskKey[sbt.inc.Analysis]("Test 2.")
+    test2 <<= Def.task { (compile in Compile).value }
+    lazy val test3 = settingKey[String]("Test 3.")
+    test3 <<= name
+    lazy val test4 = settingKey[String]("Test 4.")
+    test4 <<= Def.setting { name.value }
+    lazy val test5 = taskKey[sbt.inc.Analysis]("Test 5.")
+    test5 <<= Def.task {
+      println("Executing task.")
+      (compile in Compile).value
+    }
+    lazy val test6 = settingKey[String]("Test 6.")
+    test6 <<= Def.setting {
+      println("Executing setting.")
+      name.value
+    }
+  }
+
+  object `special<<=` {
+    import Keys.{run, testOnly, runMain, testQuick}
+    val key = inputKey[Unit]("Seed.")
+    key := {}
+    run <<= key
+    run <<= (key in ThisProject)
+    run <<= key in ThisProject
+    run <<= Def.inputTask { key.value }
+    run <<= Def.inputTask { (key).value }
+    run <<= Def.inputTask {
+      println("Executing task.")
+      key.value
+    }
+
+    val key2 = inputKey[Unit]("Seed 2.")
+    key2 := {}
+    runMain <<= key2
+    runMain <<= (key2 in ThisProject)
+    runMain <<= key2 in ThisProject
+    runMain <<= Def.inputTask { key2.value }
+    runMain <<= Def.inputTask { (key2).value }
+    runMain <<= Def.inputTask {
+      println("Executing task.")
+      key2.value
+    }
+
+    val key3 = inputKey[Unit]("Seed 3.")
+    key3 := {}
+    testOnly <<= key3
+    testOnly <<= (key3 in ThisProject)
+    testOnly <<= key3 in ThisProject
+    testOnly <<= Def.inputTask { key3.value }
+    testOnly <<= Def.inputTask { (key3).value }
+    testOnly <<= Def.inputTask {
+      println("Executing task.")
+      key3.value
+    }
+
+    val key4 = inputKey[Unit]("Seed 4.")
+    key4 := {}
+    testQuick <<= key4
+    testQuick <<= (key4 in ThisProject)
+    testQuick <<= key4 in ThisProject
+    testQuick <<= Def.inputTask { key4.value }
+    testQuick <<= Def.inputTask { (key4).value }
+    testQuick <<= Def.inputTask {
+      println("Executing task.")
+      key4.value
+    }
+  }
+
+  object mapAndApply {
+    val sett1 = settingKey[String]("SettingKey 1")
+    val sett2 = settingKey[String]("SettingKey 2")
+    val sett3 = settingKey[String]("SettingKey 3")
+
+    val task1 = taskKey[String]("TaskKey 1")
+    val task2 = taskKey[String]("TaskKey 2")
+    val task3 = taskKey[String]("TaskKey 3")
+    val task4 = taskKey[String]("TaskKey 4")
+
+    sett1 := "s1"
+    sett2 := "s2"
+    sett3 <<= (sett1, sett2)(_ + _)
+
+    task1 := { println("t1"); "t1" }
+    task2 := { println("t2"); "t2" }
+    task3 <<= (task1, task2) map { (t1, t2) => println(t1 + t2); t1 + t2 }
+    task4 <<= (sett1, sett2) map { (s1, s2) => println(s1 + s2); s1 + s2 }
+  }
+}

--- a/scalafix-tests/output-sbt/src/main/scala/sbtfix/SbtOneZeroMigrationTest.scala
+++ b/scalafix-tests/output-sbt/src/main/scala/sbtfix/SbtOneZeroMigrationTest.scala
@@ -1,0 +1,129 @@
+package sbtfix
+
+import sbt._
+
+object SbtOneZeroMigrationTest {
+  object `<++=` {
+    val key = taskKey[Seq[File]]("Seed.")
+    val target = taskKey[Seq[File]]("Target to be reassigned.")
+    key := List(new File("."))
+    target ++= key.value
+    target ++= (key).value
+    target ++= (key in ThisBuild).value
+    target ++= Def.task(key.value).value
+    target ++= (Def.task {
+      println("Executing task.")
+      (key).value
+    }).value
+  }
+
+  object `<+=` {
+    val key = taskKey[File]("Single.")
+    val target = taskKey[Seq[File]]("Target to be reassigned.")
+    key := new File(".")
+    target += key.value
+    target += (key).value
+    target += (key in ThisBuild).value
+    target += Def.task(key.value).value
+    target.+=[File](Def.task(key.value).value)
+    target += (Def.task {
+      println("Executing task.")
+      (key).value
+    }).value
+  }
+
+  object `<<=` {
+    import Keys.{compile, name}
+    lazy val test1 = taskKey[sbt.inc.Analysis]("Test 1.")
+    test1 := (compile in Compile).value
+    lazy val test1b = taskKey[sbt.inc.Analysis]("Test 1b.")
+    test1b := (compile in Compile).value
+    lazy val test2 = taskKey[sbt.inc.Analysis]("Test 2.")
+    test2 := (Def.task { (compile in Compile).value }).value
+    lazy val test3 = settingKey[String]("Test 3.")
+    test3 := name.value
+    lazy val test4 = settingKey[String]("Test 4.")
+    test4 := (Def.setting { name.value }).value
+    lazy val test5 = taskKey[sbt.inc.Analysis]("Test 5.")
+    test5 := (Def.task {
+      println("Executing task.")
+      (compile in Compile).value
+    }).value
+    lazy val test6 = settingKey[String]("Test 6.")
+    test6 := (Def.setting {
+      println("Executing setting.")
+      name.value
+    }).value
+  }
+
+  object `special<<=` {
+    import Keys.{run, testOnly, runMain, testQuick}
+    val key = inputKey[Unit]("Seed.")
+    key := {}
+    run := key.evaluated
+    run := (key in ThisProject).evaluated
+    run := (key in ThisProject).evaluated
+    run := (Def.inputTask { key.value }).evaluated
+    run := (Def.inputTask { (key).value }).evaluated
+    run := (Def.inputTask {
+      println("Executing task.")
+      key.value
+    }).evaluated
+
+    val key2 = inputKey[Unit]("Seed 2.")
+    key2 := {}
+    runMain := key2.evaluated
+    runMain := (key2 in ThisProject).evaluated
+    runMain := (key2 in ThisProject).evaluated
+    runMain := (Def.inputTask { key2.value }).evaluated
+    runMain := (Def.inputTask { (key2).value }).evaluated
+    runMain := (Def.inputTask {
+      println("Executing task.")
+      key2.value
+    }).evaluated
+
+    val key3 = inputKey[Unit]("Seed 3.")
+    key3 := {}
+    testOnly := key3.evaluated
+    testOnly := (key3 in ThisProject).evaluated
+    testOnly := (key3 in ThisProject).evaluated
+    testOnly := (Def.inputTask { key3.value }).evaluated
+    testOnly := (Def.inputTask { (key3).value }).evaluated
+    testOnly := (Def.inputTask {
+      println("Executing task.")
+      key3.value
+    }).evaluated
+
+    val key4 = inputKey[Unit]("Seed 4.")
+    key4 := {}
+    testQuick := key4.evaluated
+    testQuick := (key4 in ThisProject).evaluated
+    testQuick := (key4 in ThisProject).evaluated
+    testQuick := (Def.inputTask { key4.value }).evaluated
+    testQuick := (Def.inputTask { (key4).value }).evaluated
+    testQuick := (Def.inputTask {
+      println("Executing task.")
+      key4.value
+    }).evaluated
+  }
+
+  object mapAndApply {
+    val sett1 = settingKey[String]("SettingKey 1")
+    val sett2 = settingKey[String]("SettingKey 2")
+    val sett3 = settingKey[String]("SettingKey 3")
+
+    val task1 = taskKey[String]("TaskKey 1")
+    val task2 = taskKey[String]("TaskKey 2")
+    val task3 = taskKey[String]("TaskKey 3")
+    val task4 = taskKey[String]("TaskKey 4")
+
+    sett1 := "s1"
+    sett2 := "s2"
+    sett3 := (sett1, sett2)(_ + _).value
+
+    task1 := { println("t1"); "t1" }
+    task2 := { println("t2"); "t2" }
+    task3 := ((task1, task2) map { (t1, t2) => println(t1 + t2); t1 + t2 }).value
+    task4 := ((sett1, sett2) map { (s1, s2) => println(s1 + s2); s1 + s2 }).value
+  }
+}

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/SemanticTests.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/SemanticTests.scala
@@ -8,7 +8,19 @@ import lang.meta.internal.io.PathIO
 
 class SemanticTests
     extends SemanticRewriteSuite(
-      SemanticTests.defaultCtx,
+      SemanticCtx.load(
+        Sbthost.patchDatabase(
+          Database.load(
+            Classpath(
+              List(
+                AbsolutePath(BuildInfo.semanticSbtClasspath),
+                AbsolutePath(BuildInfo.semanticClasspath)
+              )
+            )
+          ),
+          PathIO.workingDirectory
+        )
+      ),
       List(
         AbsolutePath(BuildInfo.inputSourceroot),
         AbsolutePath(BuildInfo.inputSbtSourceroot)
@@ -20,17 +32,4 @@ class SemanticTests
       )
     ) {
   runAllTests()
-}
-
-object SemanticTests {
-  def defaultCtx: SemanticCtx = {
-    val impl = Sbthost.patchDatabase(
-      Database.load(Classpath(AbsolutePath(BuildInfo.semanticSbtClasspath))),
-      PathIO.workingDirectory)
-    SemanticCtx
-      .load(impl)
-      .merge(
-        SemanticCtx.load(Classpath(AbsolutePath(BuildInfo.semanticClasspath)))
-      )
-  }
 }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/SemanticTests.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/SemanticTests.scala
@@ -2,16 +2,35 @@ package scalafix
 package tests
 
 import scala.meta._
+import scala.meta.sbthost.Sbthost
 import scalafix.testkit._
+import lang.meta.internal.io.PathIO
 
 class SemanticTests
     extends SemanticRewriteSuite(
-      SemanticCtx.load(Classpath(AbsolutePath(BuildInfo.semanticClasspath))),
-      AbsolutePath(BuildInfo.inputSourceroot),
+      SemanticTests.defaultCtx,
+      List(
+        AbsolutePath(BuildInfo.inputSourceroot),
+        AbsolutePath(BuildInfo.inputSbtSourceroot)
+      ),
       Seq(
         AbsolutePath(BuildInfo.outputSourceroot),
+        AbsolutePath(BuildInfo.outputSbtSourceroot),
         AbsolutePath(BuildInfo.outputDottySourceroot)
       )
     ) {
   runAllTests()
+}
+
+object SemanticTests {
+  def defaultCtx: SemanticCtx = {
+    val impl = Sbthost.patchDatabase(
+      Database.load(Classpath(AbsolutePath(BuildInfo.semanticSbtClasspath))),
+      PathIO.workingDirectory)
+    SemanticCtx
+      .load(impl)
+      .merge(
+        SemanticCtx.load(Classpath(AbsolutePath(BuildInfo.semanticClasspath)))
+      )
+  }
 }


### PR DESCRIPTION
This commit integrates the sbt 1.0 migration rewrites into scalafix. This means that users can use sbt-scalafix for both regular project sources as well as sbt build file sources. To run semantic rewrites on build sources, users will need to install the sbthost compiler plugin globally. Here is what I have setup on my laptop

```scala
// ~/.sbt/0.13/build.sbt
libraryDependencies ++= {
  val sbthost = "org.scalameta" % "sbthost-nsc" % "0.3.1" cross CrossVersion.full
  val isMetabuild = {
    val p = thisProject.value
    p.id.endsWith("-build") && p.base.getName == "project"
  }
  if (isMetabuild) compilerPlugin(sbthost) :: Nil
  else Nil
}
```

One neat effect of this change is that it's possible to write custom rewrites for sbt build sources. `> scalafixBuild github:foo/bar/v2` will work just like for `> scalafix` :D 