### PR TITLE
Update 0.5.0 changelog.

### DIFF
--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC9")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.19")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC10")
 unmanagedSources.in(Compile) += baseDirectory.value / ".." / "Dependencies.scala"

--- a/readme/Changelog.scalatex
+++ b/readme/Changelog.scalatex
@@ -3,6 +3,9 @@
 @import scalafix.Versions
 
 @sect{Changelog}
-  @scalatex.Changelog05()
-  @scalatex.Changelog04()
-  @scalatex.Changelog03()
+  @sect{0.5.x}
+    @scalatex.Changelog05()
+  @sect{0.4.x}
+    @scalatex.Changelog04()
+  @sect{0.3.x}
+    @scalatex.Changelog03()

--- a/readme/Changelog05.scalatex
+++ b/readme/Changelog05.scalatex
@@ -4,58 +4,96 @@
 
 @sect{0.5.0}
   @p
-    @note. This changelog is still incomplete and will be updated before the
+    @note This changelog is still incomplete and will be updated before the
     final 0.5.0 release.
-    We hope to provide scalafix migration rewrites for most of the mechanical
-    breaking changes.
 
+  @h4{New features for end users}
+    @users
   @p
-    This release introduces major improvements to scalafix integrations (sbt/cli)
-    as well as increased focus on stability for future releases. In particular,
-    our CI will from now on guard against binary breaking changes in the public API,
-    which has been separated from the internal API.
-
-  @h4{New features}
+    This release introduces major improvements to @sect.ref{sbt-scalafix},
+    @sect.ref{scalafix-cli}.
   @ul
     @li
-      @sect.ref{sbt-scalafix} tab completion for rewrites.
+      @code{scalafixBuild} task in @sect.ref{sbt-scalafix} to run rewrites
+      on build sources.
     @li
-      @sect.ref{scalafix-cli} bash/zsh tab completion.
+      @sect.ref{Sbt1} rewrite to migrate usage of deprecated sbt 0.13 APIs,
+      by @user{jvican}.
     @li
-      @sect.ref{scalafix-cli} automatic inference of semantic/syntactic rewrites,
-      meaning the cli (with the sbt plugin uses) will no longer build a semantic
-      context if the rewrites are only syntactic.
+      Scala.js support for @sect.ref{scalafix-core}, by @user{gabro}.
     @li
-      Scala.js support for @sect.ref{scalafix-core}.
+      Configurable @sect.ref{ExplicitReturnTypes}, by @user{taisuke}.
     @li
-      New @sect.ref{replace:} syntax to move usage of symbols around
-      as well as to rename methods. Note, the implementation is still buggy
-      in some cases but we opted to not delay the release any further.
-      Please report bugs you encounter.
+      @sect.ref{sbt-scalafix} rewrite tab completion.
     @li
-      Support for querying symbols inside "sugars", for example inferred implicits,
-      type parameters and extension methods. Thanks to upstream improvements in the
-      @lnk("Scalameta v2.0 Semantic API", "http://scalameta.org/tutorial/#SemanticAPI").
+      @sect.ref{scalafix-cli} @code{--zsh} and @code{--bash} to generate tab
+      completion scripts for zsh and bash.
+    @li
+      @sect.ref{scalafix-cli} automatically inferences semantic/syntactic rewrites.
+      This means it's possible to run custom syntactic rewrites from scalafix-cli
+      without passing in @code{--classpath}.
+    @li
+      @sect.ref{replace:} to run quick one-off refactorings.
+
+  @h4{New features for rewrite authors}
+    @authors
+  @ul
+    @li
+      Ability to implement rewrites for sources of sbt builds, including
+      @code{*.sbt} files. The API to write sbt rewrites is identical to
+      regular Scala rewrites.
+    @li
+      Thanks to upstream improvements in the
+      @lnk("Scalameta v2.0 Semantic API", "http://scalameta.org/tutorial/#SemanticAPI"),
+      it is now possible to query symbols of inferred
+      @ul
+        @li
+          implicit arguments
+        @li
+          implicit conversions (including extension methods)
+        @li
+          type parameters
+        @li
+          @code{.apply}/@code{.unapply}
+    @li
+      @code{PatchOps.replaceSymbol/replaceTree}, see @sect.ref{Patch}.
 
   @h4{Bug fixes / Improvements}
 
   @ul
     @li
-      More robust classloading in @sect.ref{sbt-scalafix} (no synthetic projects)
-      and many other small things.
+      More robust classloading to invoke scalafix in @sect.ref{sbt-scalafix}.
+      Previously, sbt-scalafix used synthetic projects which cause problem
+      in some multi-module builds. Now, sbt-scalafix uses Coursier instead.
     @li
       Improved dynamic compilation of @sect.ref{Custom rewrites} while running
-      in multi-threaded environments such as multi-module sbt builds.
+      from multi-module sbt builds.
+    @li
+      Extension methods now resolve to the correct symbol. For example,
+      @code{head} in @code{Array[Int].head} previously resolved to
+      @code{Predef.intArrayOps} and now it resolves to
+      @code{IndexedSeqOptimized.head}.
 
-  @h4{Breaking changes}
-
+  @h4{Breaking changes for rewrite authors}
   @p
-    A big part of the scalafix codebase has been moved under
-    @code{scalafix.internal}. From now on, we will guard against breaking
-    binary compatibility changes in CI using MiMa.
+    From 0.5 onwards, our CI will check binary breaking changes in the public API
+    on every pull request.
+    Note that modules inside the package @code{scalafix.internal} don't promise
+    binary compatibility between any releases, including PATCH upgrades.
 
   @ul
     @li
-      @code{scala.meta.Mirror} is now @code{scalafix.SemanticCtx}, using the
-      abbreviated name @code{sctx: SemanticCtx} as convention.
+      @code{scala.meta.Mirror} is now @code{scalafix.SemanticCtx}.
+    @li
+      @code{scalafix.config} has been moved to @code{scalafix.internal.config}.
+      Configuration case classes break binary compatility with every new field.
+    @li
+      @code{.symbol} now returns @code{Option[Symbol]} instead of @code{Symbol}.
+      @code{.symbolOpt} has been deprecated.
+    @li
+      A large number of unused methods and classes inside @code{scalafix.Failure},
+      @code{scalafix.`package`} and @code{scalafix.syntax} has been removed.
+    @li
+      upgraded to Scalameta 2.0, which has several breaking changes
+      in the Tree api.
 

--- a/readme/Configuration.scalatex
+++ b/readme/Configuration.scalatex
@@ -38,13 +38,15 @@
 
       @sect{replace:}
 
-        @b{New/Experimental}.
+        @experimental
 
-        To replace usage of one class/object/trait. Note, will not move the
-        definition only the call-sites.
+        To replace usage of one class/object/trait/def with another.
+        Note, does not move definitions like "Move" does in an IDE. This
+        only moves use-sites.
 
         @config
           rewrite = "replace:com.company.App/io.company.App"
+          // From sbt shell: > scalafix replace:from/to
 
         To rename a method
 
@@ -64,7 +66,7 @@
           rewrite = "https://gist.githubusercontent.com/olafurpg/fc6f43a695ac996bd02000f45ed02e63/raw/80218434edb85120a9c6fd6533a4418118de8ba7/ExampleRewrite.scala"
 
   @sect{patches}
-    For simple use-cases, it's possible to write custom rewrites directly
+    For simple use-cases, it's possible to write custom rewrites directly in
     .scalafix.conf.
     @config
       patches.removeGlobalImports = [
@@ -79,7 +81,7 @@
       ]
       // Helper to see which symbols appear in your source files
       debug.printSymbols = true
-    For more advanced use-cases, I recommend you use @sect.ref{scalafix-core}
-    as a library.
+    For more advanced use-cases, I recommend you use see
+    @sect.ref{Creating your own rewrite}.
 
 

--- a/readme/Faq.scalatex
+++ b/readme/Faq.scalatex
@@ -2,32 +2,37 @@
 @import scalafix.Readme._
 @import scalafix.{Versions => V}
 
-@sect{FAQ / Troubleshooting}
+@sect{FAQ}
+  @p
+    If you have any questions, don't hesitate to ask on gitter @gitter.
+  @sect{Troubleshooting}
+    @sect{I get resolution errors for org.scalameta:semanticdb-scalac}
+      Make sure you are using a supported Scala version:
+      @V.supportedScalaVersions.mkString(", "). Note, the version must match
+      exactly, including the last number.
+    @sect{Enclosing tree [2873] does not include tree [2872]}
+      Scalafix requires code to compile with the scalac option @code{-Yrangepos}.
+      A macro that emits invalid tree positions is usually the cause of
+      compiler errors triggered by @code{-Yrangepos}.
+      Other tools like the presentation compiler (ENSIME/Scala IDE)
+      require @code{-Yrangepos} to work properly.
+    @sect{I get exceptions about coursier}
+      If you use sbt-coursier, make sure you are on version @V.coursier.
+    @sect{Scalafix doesn't do anything}
+      @ul
+        @li
+          If you use @sect.ref{sbt-scalafix}, try @sect.ref{Verify sbt installation}.
+        @li
+          Make sure that you are running at least one rewrite.
+        @li
+          Make sure that you are using a supported Scala
+          version: @V.supportedScalaVersions.mkString(", ")
 
-  If you have any questions, don't hesitate to ask on gitter @gitter.
+    @sect{RemoveUnusedImports does not remove unused imports}
+      Make sure that you followed the instructions in @sect.ref{RemoveUnusedImports}
+      regarding scalac options.
 
-  @sect{I get resolution errors for org.scalameta:semanticdb-scalac}
-    Make sure you are using a supported Scala version:
-    @V.supportedScalaVersions.mkString(", "). Note, the version must match
-    exactly, including the last number.
-  @sect{Enclosing tree [2873] does not include tree [2872]}
-    Scalafix requires code to compile with the scalac option @code{-Yrangepos}.
-    A macro that emits invalid tree positions is usually the cause of
-    compiler errors triggered by @code{-Yrangepos}.
-    Other tools like the presentation compiler (ENSIME) or
-    Scalameta Semantic API also require @code{-Yrangepos} to work properly.
-  @sect{I get exceptions about coursier}
-    If you use sbt-coursier, make sure you are on version @V.coursier.
-  @sect{Scalafix doesn't do anything}
-    @ul
-      @li
-        If you use @sect.ref{sbt-scalafix}, try @sect.ref{Verify sbt installation}.
-      @li
-        Make sure that you are running at least one rewrite.
-      @li
-        Make sure that you are using a supported Scala
-        version: @V.supportedScalaVersions.mkString(", ")
+  @sect{Features}
 
-  @sect{RemoveUnusedImports does not remove unused imports}
-    Make sure that you followed the instructions in @sect.ref{RemoveUnusedImports}
-    regarding scalac options.
+    @sect{IDE support}
+      Scalafix has no IDE support at the moment.

--- a/readme/Rewrites.scalatex
+++ b/readme/Rewrites.scalatex
@@ -11,6 +11,7 @@
     To create custom rewrites, see @sect.ref{scalafix-core}.
 
   @sect(ExplicitReturnTypes.toString)
+    @experimental
     Dotty requires implicit @code{val}s and @code{def}s to explicitly annotate
     return types.
     The @ExplicitReturnTypes.toString rewrite inserts the inferred type from the
@@ -29,12 +30,8 @@
         is available in scope. Track @issue(169) for updates on making the
         rewrite insert shorter names.
       @li
-        @note. This rewrite currently only inserts fully qualified names
-        for implicit vals. However, there exists configuration to limit
-        give fine-grained control on how the rewrite works, see
-        @lnk("ExplicitReturnTypesConfig",
-          "https://github.com/scalacenter/scalafix/blob/db6152304aaef19c4a8ba4fc77b732264bf52fec/scalafix-core/src/main/scala/scalafix/config/ExplicitReturnTypesConfig.scala").
-        Example configuration:
+        Inserts type annotations only for implicit definitions by default. To configure the
+        rewrite to run on non-implicit definitions
         @config
           explicitReturnTypes {
              memberKind = [
@@ -232,6 +229,24 @@
 
     @p
       The two syntaxes are equivalent and the presence of the @code{val} keyword has been deprecated since Scala 2.10.
+
+  @sect(Sbt1.toString)
+    @experimental
+    @p
+      To use this rewrite:
+      @ul
+        @li
+          Install @sect.ref{semanticdb-sbt}
+        @li
+          Run @code{scalafixBuild}
+    @hl.scala
+      // before
+      x <+= (y in Compile)
+      // after
+      x += (y in Compile).value
+
+    This rewrite currently handles many basic cases but may produce incorrect
+    output in more advanced cases. Please report back your experience.
 
   @sect{Planned rewrites...}
     See @lnk("here", "https://github.com/scalacenter/scalafix/labels/rewrite").

--- a/readme/src/main/scala/scalafix/Readme.scala
+++ b/readme/src/main/scala/scalafix/Readme.scala
@@ -1,22 +1,28 @@
 package scalafix
 
-import metaconfig._, typesafeconfig._
+import metaconfig._
+import typesafeconfig._
 import scala.meta.inputs.Input
 import scalafix.internal.config.ScalafixMetaconfigReaders
 import scalafix.reflect.ScalafixReflect
 import scalatags.Text.TypedTag
 import scalatags.Text.all._
+import scalatex.Main
 import scalatex.site.Highlighter
 
 object Readme {
+  def users = fa("users")
+  def authors = fa("terminal")
   def sbtkey(name: String, typ: String)(description: Frag*) =
     tr(
       td(code(name)),
       td(code(typ)),
       td(description)
     )
+  def fa(id: String) = i(cls := s"fa fa-$id")
   val highlight = new Highlighter {}
   def note = b("Note. ")
+  def experimental = p(b("Experimental ", fa("warning")))
   def gitter =
     raw(
       """<a href="https://gitter.im/scalacenter/scalafix?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge"><img src="https://camo.githubusercontent.com/382ebf95f5b4df9275ac203229928db8c8fd5c50/68747470733a2f2f6261646765732e6769747465722e696d2f6f6c6166757270672f7363616c61666d742e737667" alt="Join the chat at https://gitter.im/scalacenter/scalafix" data-canonical-src="https://badges.gitter.im/scalacenter/scalafix.svg" style="max-width:100%;"></a>""")


### PR DESCRIPTION
Following feedback from my colleagues to separate the
"new features" section into two parts: end users and rewrite authors.