### PR TITLE
Fail fast on missing semanticdb.

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/MetaconfigPendingUpstream.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/MetaconfigPendingUpstream.scala
@@ -5,6 +5,8 @@ import metaconfig.Conf
 import metaconfig.ConfDecoder
 import metaconfig.ConfError
 import metaconfig.Configured
+import metaconfig.Configured.NotOk
+import metaconfig.Configured.Ok
 import metaconfig.Metaconfig
 
 // TODO(olafur) contribute upstream to metaconfig.
@@ -21,6 +23,10 @@ object MetaconfigPendingUpstream {
       case Some(value) => ev.read(value)
       case None => ConfError.missingField(conf, path).notOk
     }
+  }
+  def get_![T](configured: Configured[T]): T = configured match {
+    case Ok(a) => a
+    case NotOk(e) => sys.error(e.toString())
   }
 
   def orElse[T](a: ConfDecoder[T], b: ConfDecoder[T]): ConfDecoder[T] =

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/test
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/test
@@ -1,5 +1,8 @@
 # compile should not affect scalafix
 > compile
-> scalafix
+> scalafix ProcedureSyntax
+# Should fail because 2.10 has no semanticdb
+# Other >2.10 projects should succeed
+-> scalafix
 > check
 


### PR DESCRIPTION
Previously, scalafix-cli would fail silently if running a semantic
rewrite with no semanticdb files. Now it fails fast.
Fixes #264