### PR TITLE
Fail fast when no files are to be fixed.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -453,7 +453,6 @@ lazy val compilerOptions = Def.setting {
     "-encoding",
     "UTF-8",
     "-feature",
-    warnUnusedImports,
     "-unchecked"
   )
 }

--- a/scalafix-tests/unit/src/test/scala/scalafix/cli/BaseCliTest.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/cli/BaseCliTest.scala
@@ -42,15 +42,22 @@ trait BaseCliTest extends FunSuite with DiffAssertions {
       args: Seq[String],
       expectedLayout: String,
       expectedExit: ExitStatus,
-      common: CommonOptions = devNull
+      outputAssert: String => Unit = _ => ()
   ): Unit = {
     test(name) {
+      val out = new ByteArrayOutputStream()
       val root = StringFS.string2dir(originalLayout)
       val exit =
-        Cli.runMain(args, common.copy(workingDirectory = root.toString()))
+        Cli.runMain(
+          args,
+          default.common.copy(
+            workingDirectory = root.toString(),
+            out = new PrintStream(out)
+          ))
       assert(exit == expectedExit)
       val obtained = StringFS.dir2string(root)
       assertNoDiff(obtained, expectedLayout)
+      outputAssert(out.toString)
     }
   }
   def parse(args: Seq[String]): CliCommand =


### PR DESCRIPTION
Previously, scalafix silently picked the empty rewrite when the input
files were empty and just printed out the message "Running scalafix on 0
files.". Now scalafix reports an error instead with a message saying
which absolute paths it tried to find .scala and .sbt files.

Fixes #295 

cc/ @usrinivasan