### PR TITLE
Harden ExplicitReturnTypes

### DIFF
--- a/readme/Rewrites.scalatex
+++ b/readme/Rewrites.scalatex
@@ -34,17 +34,11 @@
         Inserts type annotations only for implicit definitions by default. To configure the
         rewrite to run on non-implicit definitions
         @config
-          explicitReturnTypes {
-             memberKind = [
-               Def
-               Var
-               Val
-             ]
-             memberVisibility = [
-               Public
-               Protected
-            ]
-          }
+          explicitReturnTypes.memberKind = [Val, Def, Var]
+          explicitReturnTypes.memberVisibility = [Public, Protected]
+          // Experimental, shorten fully qualified names and insert missing imports
+          // By default, names are fully qualified and prefixed with _root_.
+          unsafeShortenNames = true // false by default.
 
 
   @sect(RemoveUnusedImports.toString)

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
@@ -3,7 +3,7 @@ package scalafix.internal.patch
 import scala.collection.mutable
 import scala.meta._
 import scalafix._
-import scalafix.internal.util.SymbolOps.BottomSymbol
+import scalafix.internal.util.SymbolOps.Root
 import scalafix.internal.util.SymbolOps.SignatureName
 import scalafix.patch.Patch
 import scalafix.patch.TreePatch.ReplaceSymbol
@@ -74,7 +74,7 @@ object ReplaceSymbolOps {
       case n @ Move(to) =>
         // was this written as `to = "blah"` instead of `to = _root_.blah`
         val isSelected = to match {
-          case Symbol.Global(BottomSymbol(), _) => false
+          case Root(_) => false
           case _ => true
         }
         n.parent match {
@@ -90,8 +90,7 @@ object ReplaceSymbolOps {
         }
     }
     val importPatch = toImport.foldLeft(Patch.empty) {
-      case (p, BottomSymbol()) => p
-      case (p, Symbol.Global(BottomSymbol(), _)) => p
+      case (p, Root(_)) => p
       case (p, sym) => p + ctx.addGlobalImport(sym)
     }
     importPatch ++ patches

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rewrite/RewriteCtxImpl.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rewrite/RewriteCtxImpl.scala
@@ -7,7 +7,7 @@ import scalafix.LintMessage
 import scalafix._
 import scalafix.internal.config.ScalafixConfig
 import scalafix.internal.config.ScalafixMetaconfigReaders
-import scalafix.internal.util.SymbolOps.BottomSymbol
+import scalafix.internal.util.SymbolOps.Root
 import scalafix.patch.LintPatch
 import scalafix.patch.TokenPatch
 import scalafix.patch.TokenPatch.Add
@@ -106,8 +106,6 @@ case class RewriteCtxImpl(tree: Tree, config: ScalafixConfig)
     }
   def renameSymbol(fromSymbol: Symbol.Global, toName: String)(
       implicit sctx: SemanticCtx): Patch =
-    TreePatch.ReplaceSymbol(
-      fromSymbol,
-      Symbol.Global(BottomSymbol(), Signature.Term(toName)))
+    TreePatch.ReplaceSymbol(fromSymbol, Root(Signature.Term(toName)))
 
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/SemanticTypeSyntax.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/SemanticTypeSyntax.scala
@@ -3,10 +3,12 @@ package scalafix.internal.util
 import scala.meta._
 import scalafix._
 import scalafix.util.SymbolMatcher
+import scalafix.util.TreeExtractors._
 
 object SemanticTypeSyntax {
   def prettify(tpe: Type, ctx: RewriteCtx, shortenNames: Boolean)(
       implicit sctx: SemanticCtx): (Type, Patch) = {
+
     val functionN: SymbolMatcher = SymbolMatcher.exact(
       1.to(22).map(i => Symbol(s"_root_.scala.Function$i#")): _*
     )

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/SymbolOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/SymbolOps.scala
@@ -10,16 +10,22 @@ object SymbolOps {
       case _ => None
     }
   }
-  object BottomSymbol {
-    def apply(): Symbol = Symbol.Global(Symbol.None, Signature.Term("_root_"))
-    def unapply(arg: Symbol): Boolean = arg match {
-      case Symbol.Global(Symbol.None, Signature.Term("_root_")) => true
-      case _ => false
+  object Root {
+    def apply(): Symbol.Global =
+      Symbol.Global(Symbol.None, Signature.Term("_root_"))
+    def apply(signature: Signature): Symbol.Global =
+      Symbol.Global(apply(), signature)
+    def unapply(arg: Symbol): Option[Signature] = arg match {
+      case Symbol.Global(
+          Symbol.Global(Symbol.None, Signature.Term("_root_")),
+          sig) =>
+        Some(sig)
+      case _ => None
     }
   }
   def toTermRef(symbol: Symbol): Term.Ref = {
     symbol match {
-      case Symbol.Global(BottomSymbol(), signature) =>
+      case Root(signature) =>
         Term.Name(signature.name)
       case Symbol.Global(qual, signature) =>
         Term.Select(toTermRef(qual), Term.Name(signature.name))
@@ -27,7 +33,7 @@ object SymbolOps {
   }
   def toImporter(symbol: Symbol): Option[Importer] = {
     symbol match {
-      case Symbol.Global(BottomSymbol(), SignatureName(name)) =>
+      case Root(SignatureName(name)) =>
         None
       case Symbol.Global(qual, SignatureName(name)) =>
         Some(

--- a/scalafix-core/shared/src/main/scala/scalafix/util/TreeOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/util/TreeOps.scala
@@ -1,7 +1,21 @@
 package scalafix.util
 
-import scala.meta.Tree
+import scala.meta._
 
+object TreeExtractors {
+  object :&&: {
+    def unapply[A](arg: A): Option[(A, A)] =
+      Some(arg -> arg)
+  }
+
+  object Select {
+    def unapply(tree: Tree): Option[(Term, Name)] = tree match {
+      case Term.Select(qual, name) => Some(qual -> name)
+      case Type.Select(qual, name) => Some(qual -> name)
+      case _ => None
+    }
+  }
+}
 object TreeOps {
   def parents(tree: Tree): Stream[Tree] =
     tree #:: (tree.parent match {

--- a/scalafix-tests/input/src/main/scala/test/ExplicitReturnTypes.scala
+++ b/scalafix-tests/input/src/main/scala/test/ExplicitReturnTypes.scala
@@ -12,11 +12,18 @@ object ExplicitReturnTypes {
   def b() = "a" + "b"
   var c = 1 == 1
   protected val d = 1.0f
-  protected def e(a:Int,b:Double) = a + b
+  protected def e(a: Int, b: Double) = a + b
   protected var f = (x: Int) => x + 1
   private val g = 1
-  private def h(a:Int) = ""
-  private var i = 1
+  private def h(a: Int) = ""
+  private var i = 22
+
+  locally {
+    implicit val Implicit = scala.concurrent.Future.successful(2)
+    val Var = scala.concurrent.Future.successful(2)
+    val Val = scala.concurrent.Future.successful(2)
+    def Def = scala.concurrent.Future.successful(2)
+  }
 
   private implicit var j = 1
 

--- a/scalafix-tests/input/src/main/scala/test/ExplicitReturnTypesShort.scala
+++ b/scalafix-tests/input/src/main/scala/test/ExplicitReturnTypesShort.scala
@@ -20,4 +20,5 @@ object ExplicitReturnTypesShort {
     result
   }
   implicit val p = pathDependent(new Y { type X = Int; def x = 2 })
+  implicit val FALSE = (x: Any) => false
 }

--- a/scalafix-tests/input/src/main/scala/test/ExplicitReturnTypesShort.scala
+++ b/scalafix-tests/input/src/main/scala/test/ExplicitReturnTypesShort.scala
@@ -19,6 +19,5 @@ object ExplicitReturnTypesShort {
     implicit val result: x.X = x.x
     result
   }
-  implicit val p = pathDependent(new Y { type X = Int; def x = 2 })
   implicit val FALSE = (x: Any) => false
 }

--- a/scalafix-tests/output/src/main/scala/test/ExplicitReturnTypes.scala
+++ b/scalafix-tests/output/src/main/scala/test/ExplicitReturnTypes.scala
@@ -3,24 +3,31 @@ package test
 import scala.language.implicitConversions
 
 object ExplicitReturnTypes {
-  val a: scala.Int = 1 + 2
-  def b(): java.lang.String = "a" + "b"
-  var c: scala.Boolean = 1 == 1
+  val a: _root_.scala.Int = 1 + 2
+  def b(): _root_.java.lang.String = "a" + "b"
+  var c: _root_.scala.Boolean = 1 == 1
   protected val d = 1.0f
-  protected def e(a:Int,b:Double): scala.Double = a + b
-  protected var f: scala.Function1[scala.Int, scala.Int] = (x: Int) => x + 1
+  protected def e(a: Int, b: Double): _root_.scala.Double = a + b
+  protected var f: _root_.scala.Function1[_root_.scala.Int, _root_.scala.Int] = (x: Int) => x + 1
   private val g = 1
-  private def h(a:Int) = ""
-  private var i = 1
+  private def h(a: Int) = ""
+  private var i = 22
 
-  private implicit var j: scala.Int = 1
+  locally {
+    implicit val Implicit: _root_.scala.concurrent.Future[_root_.scala.Int] = scala.concurrent.Future.successful(2)
+    val Var = scala.concurrent.Future.successful(2)
+    val Val = scala.concurrent.Future.successful(2)
+    def Def = scala.concurrent.Future.successful(2)
+  }
 
-  implicit val L: scala.collection.immutable.List[scala.Int] = List(1)
-  implicit val M: scala.collection.immutable.Map[scala.Int, java.lang.String] = Map(1 -> "STRING")
-  implicit def D: scala.Int = 2
+  private implicit var j: _root_.scala.Int = 1
+
+  implicit val L: _root_.scala.collection.immutable.List[_root_.scala.Int] = List(1)
+  implicit val M: _root_.scala.collection.immutable.Map[_root_.scala.Int, _root_.java.lang.String] = Map(1 -> "STRING")
+  implicit def D: _root_.scala.Int = 2
   implicit def tparam[T](e: T): T = e
-  implicit def tparam2[T](e: T): scala.collection.immutable.List[T] = List(e)
-  implicit def tparam3[T](e: T): scala.collection.immutable.Map[T, T] = Map(e -> e)
+  implicit def tparam2[T](e: T): _root_.scala.collection.immutable.List[T] = List(e)
+  implicit def tparam3[T](e: T): _root_.scala.collection.immutable.Map[T, T] = Map(e -> e)
   class Path {
     class B { class C }
     implicit val x: Path.this.B = new B
@@ -28,17 +35,17 @@ object ExplicitReturnTypes {
   }
   class TwoClasses[T](e: T)
   class TwoClasses2 {
-    implicit val x: test.ExplicitReturnTypes.TwoClasses[scala.Int] = new TwoClasses(10)
+    implicit val x: _root_.test.ExplicitReturnTypes.TwoClasses[_root_.scala.Int] = new TwoClasses(10)
   }
   class implicitlytrick {
-    implicit val s: java.lang.String = "string"
+    implicit val s: _root_.java.lang.String = "string"
     implicit val x = implicitly[String]
   }
   object InnerInnerObject {
     object B {
       class C
       object C {
-        implicit val x: scala.collection.immutable.List[test.ExplicitReturnTypes.InnerInnerObject.B.C] = List(new C)
+        implicit val x: _root_.scala.collection.immutable.List[_root_.test.ExplicitReturnTypes.InnerInnerObject.B.C] = List(new C)
       }
     }
   }
@@ -47,29 +54,29 @@ object ExplicitReturnTypes {
   }
   object A {
     class C {
-      implicit val x: scala.collection.immutable.List[test.ExplicitReturnTypes.SiblingObject.B] = List(new SiblingObject.B)
+      implicit val x: _root_.scala.collection.immutable.List[_root_.test.ExplicitReturnTypes.SiblingObject.B] = List(new SiblingObject.B)
     }
   }
   object slick {
     case class Supplier(id: Int, name: String)
-    implicit val supplierGetter: ((scala.Int, scala.Predef.String)) => test.ExplicitReturnTypes.slick.Supplier = (arg: (Int, String)) =>
+    implicit val supplierGetter: ((_root_.scala.Int, _root_.scala.Predef.String)) => _root_.test.ExplicitReturnTypes.slick.Supplier = (arg: (Int, String)) =>
       Supplier(arg._1, arg._2)
   }
-  def foo(x: Int): scala.Int =
+  def foo(x: Int): _root_.scala.Int =
     // comment
     x + 2
   object ExtraSpace {
-    def * : scala.Int = "abc".length
-    def foo_ : scala.Int = "abc".length
-    def `x`: scala.Int = "abc".length
-    def `x `: scala.Int = "abc".length
+    def * : _root_.scala.Int = "abc".length
+    def foo_ : _root_.scala.Int = "abc".length
+    def `x`: _root_.scala.Int = "abc".length
+    def `x `: _root_.scala.Int = "abc".length
   }
 }
 
 class DeeperPackage[T](e: T)
 package foo {
   class B {
-    implicit val x: test.DeeperPackage[scala.Int] = new DeeperPackage(10)
+    implicit val x: _root_.test.DeeperPackage[_root_.scala.Int] = new DeeperPackage(10)
   }
 }
 
@@ -77,13 +84,13 @@ package shallwpackage {
   class A[T](e: T)
 }
 class shallobpackage {
-  implicit val x: test.shallwpackage.A[scala.Int] = new shallwpackage.A(10)
+  implicit val x: _root_.test.shallwpackage.A[_root_.scala.Int] = new shallwpackage.A(10)
 }
 
 package enclosingPackageStripIsLast { class B }
 package a {
   import enclosingPackageStripIsLast.B
   class A {
-    implicit val x: test.enclosingPackageStripIsLast.B = new B
+    implicit val x: _root_.test.enclosingPackageStripIsLast.B = new B
   }
 }

--- a/scalafix-tests/output/src/main/scala/test/ExplicitReturnTypesShort.scala
+++ b/scalafix-tests/output/src/main/scala/test/ExplicitReturnTypesShort.scala
@@ -15,6 +15,5 @@ object ExplicitReturnTypesShort {
     implicit val result: x.X = x.x
     result
   }
-  implicit val p: Int = pathDependent(new Y { type X = Int; def x = 2 })
   implicit val FALSE: Any => Boolean = (x: Any) => false
 }

--- a/scalafix-tests/output/src/main/scala/test/ExplicitReturnTypesShort.scala
+++ b/scalafix-tests/output/src/main/scala/test/ExplicitReturnTypesShort.scala
@@ -16,4 +16,5 @@ object ExplicitReturnTypesShort {
     result
   }
   implicit val p: Int = pathDependent(new Y { type X = Int; def x = 2 })
+  implicit val FALSE: Any => Boolean = (x: Any) => false
 }


### PR DESCRIPTION
Prefixing with `_root_.` is a necessary evil. with `unsafeShortenName`, users have an opt-out solution so I think it's fine to go all-in on safety by default. I think it's most important that the rewrite produces compiling code.