### PR TITLE
Upgrade to scalameta v2.0-RC1.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 
 object Dependencies {
 
-  val scalametaV = "2.0.0-M3"
+  val scalametaV = "2.0.0-RC2"
   val metaconfigV = "0.5.2"
   def semanticdbSbt = "0.4.0"
   def dotty = "0.1.1-bin-20170530-f8f52cc-NIGHTLY"

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/SymbolOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/SymbolOps.scala
@@ -10,6 +10,12 @@ object SymbolOps {
       case _ => None
     }
   }
+  object SymbolType {
+    def unapply(arg: Symbol): Boolean = arg match {
+      case Symbol.Global(_, Signature.Type(_)) => true
+      case _ => false
+    }
+  }
   object Root {
     def apply(): Symbol.Global =
       Symbol.Global(Symbol.None, Signature.Term("_root_"))

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/TypeSyntax.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/TypeSyntax.scala
@@ -32,9 +32,6 @@ object TypeSyntax {
       }
     }
 
-    type -> = Int
-    val x: -> = 2
-
     def stableRef(sym: Symbol): (Patch, Type) = {
       var patch = Patch.empty
       def loop[T](symbol: Symbol): T = {

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/TypeSyntax.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/TypeSyntax.scala
@@ -2,10 +2,12 @@ package scalafix.internal.util
 
 import scala.meta._
 import scalafix._
+import scalafix.internal.util.SymbolOps.SymbolType
 import scalafix.util.SymbolMatcher
 import scalafix.util.TreeExtractors._
+import org.langmeta.semanticdb.Symbol
 
-object SemanticTypeSyntax {
+object TypeSyntax {
   def prettify(tpe: Type, ctx: RewriteCtx, shortenNames: Boolean)(
       implicit sctx: SemanticCtx): (Type, Patch) = {
 
@@ -25,10 +27,41 @@ object SemanticTypeSyntax {
       symbol match {
         case Symbol.Global(owner, Signature.Term(_) | Signature.Type(_)) =>
           loop(owner)
-        case els =>
+        case _ =>
           false
       }
     }
+
+    type -> = Int
+    val x: -> = 2
+
+    def stableRef(sym: Symbol): (Patch, Type) = {
+      var patch = Patch.empty
+      def loop[T](symbol: Symbol): T = {
+        val result = symbol match {
+          case Symbol.Global(Symbol.None, Signature.Term(name)) =>
+            Term.Name(name)
+          case Symbol.Global(owner @ SymbolType(), Signature.Type(name)) =>
+            Type.Project(loop[Type](owner), Type.Name(name))
+          case Symbol.Global(owner, Signature.Term(name)) =>
+            if (shortenNames && isStable(owner)) {
+              patch += ctx.addGlobalImport(symbol)
+              Term.Name(name)
+            } else Term.Select(loop(owner), Term.Name(name))
+          case Symbol.Global(owner, Signature.Type(name)) =>
+            if (shortenNames && isStable(owner)) {
+              patch += ctx.addGlobalImport(symbol)
+              Type.Name(name)
+            } else Type.Select(loop(owner), Type.Name(name))
+          case Symbol.Global(_, Signature.TypeParameter(name)) =>
+            Type.Name(name)
+        }
+        result.asInstanceOf[T]
+      }
+      val tpe = loop[Type](sym)
+      patch -> tpe
+    }
+
     var patch = Patch.empty
     def loop[T](tpe: Tree): T = {
       val result = tpe match {
@@ -42,26 +75,14 @@ object SemanticTypeSyntax {
           val rargs = args.map(loop[Type])
           Type.Tuple(rargs)
 
-        // shorten names
-        case Select(_, name @ sctx.Symbol(sym))
-            if shortenNames && isStable(sym) =>
-          patch += ctx.addGlobalImport(sym)
-          name
+        case Type.Name(_) :&&: sctx.Symbol(sym) =>
+          val (addImport, tpe) = stableRef(sym)
+          patch += addImport
+          tpe
 
-        // _root_ qualify names
-        case Select(qual @ Term.Name(pkg), n)
-            // NOTE(olafur): can't resolve symbol here since it's not always
-            // included in sctx  for Denotation.signature.
-            if !shortenNames && pkg != "_root_" =>
-          n match {
-            case name: Type.Name => Type.Select(q"_root_.$qual", name)
-            case name: Term.Name => q"_root_.$qual.$name"
-          }
-        // Recursive cases
-        case Type.Select(qual, name) =>
-          Type.Select(loop[Term.Ref](qual), name)
-        case Term.Select(qual, name) =>
-          Term.Select(loop[Term.Ref](qual), name)
+        // TODO(olafur): handle select after https://github.com/scalameta/scalameta/pull/1107
+
+        // Recursive case
         case Type.Apply(qual, args) =>
           val rargs = args.map(loop[Type])
           Type.Apply(loop[Type](qual), rargs)

--- a/scalafix-tests/input/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypes.scala
+++ b/scalafix-tests/input/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypes.scala
@@ -8,6 +8,7 @@ package test
 import scala.language.implicitConversions
 
 object ExplicitReturnTypes {
+  def none[T] =  None.asInstanceOf[Option[T]]
   val a = 1 + 2
   def b() = "a" + "b"
   var c = 1 == 1
@@ -33,11 +34,6 @@ object ExplicitReturnTypes {
   implicit def tparam[T](e: T) = e
   implicit def tparam2[T](e: T) = List(e)
   implicit def tparam3[T](e: T) = Map(e -> e)
-  class Path {
-    class B { class C }
-    implicit val x = new B
-    implicit val y = new x.C
-  }
   class TwoClasses[T](e: T)
   class TwoClasses2 {
     implicit val x = new TwoClasses(10)

--- a/scalafix-tests/input/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesBase.scala
+++ b/scalafix-tests/input/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesBase.scala
@@ -3,11 +3,11 @@ rewrites = ExplicitReturnTypes
 explicitReturnTypes.memberKind = [Val, Def, Var]
 explicitReturnTypes.memberVisibility = [Public, Protected]
  */
-package test
+package test.explicitReturnTypes
 
 import scala.language.implicitConversions
 
-object ExplicitReturnTypes {
+object ExplicitReturnTypesBase {
   def none[T] =  None.asInstanceOf[Option[T]]
   val a = 1 + 2
   def b() = "a" + "b"
@@ -34,36 +34,11 @@ object ExplicitReturnTypes {
   implicit def tparam[T](e: T) = e
   implicit def tparam2[T](e: T) = List(e)
   implicit def tparam3[T](e: T) = Map(e -> e)
-  class TwoClasses[T](e: T)
-  class TwoClasses2 {
-    implicit val x = new TwoClasses(10)
-  }
   class implicitlytrick {
-    implicit val s = "string"
+    implicit val s: _root_.java.lang.String = "string"
     implicit val x = implicitly[String]
   }
-  object InnerInnerObject {
-    object B {
-      class C
-      object C {
-        implicit val x = List(new C)
-      }
-    }
-  }
-  object SiblingObject {
-    class B
-  }
-  object A {
-    class C {
-      implicit val x = List(new SiblingObject.B)
-    }
-  }
-  object slick {
-    case class Supplier(id: Int, name: String)
-    implicit val supplierGetter = (arg: (Int, String)) =>
-      Supplier(arg._1, arg._2)
-  }
-  def foo(x: Int) =
+  def comment(x: Int) =
     // comment
     x + 2
   object ExtraSpace {
@@ -71,27 +46,5 @@ object ExplicitReturnTypes {
     def foo_ = "abc".length
     def `x` = "abc".length
     def `x ` = "abc".length
-  }
-}
-
-class DeeperPackage[T](e: T)
-package foo {
-  class B {
-    implicit val x = new DeeperPackage(10)
-  }
-}
-
-package shallwpackage {
-  class A[T](e: T)
-}
-class shallobpackage {
-  implicit val x = new shallwpackage.A(10)
-}
-
-package enclosingPackageStripIsLast { class B }
-package a {
-  import enclosingPackageStripIsLast.B
-  class A {
-    implicit val x = new B
   }
 }

--- a/scalafix-tests/input/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesPathDependent.scala
+++ b/scalafix-tests/input/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesPathDependent.scala
@@ -1,0 +1,14 @@
+/*
+rewrites = ExplicitReturnTypes
+ */
+package test
+
+object ExplicitReturnTypesPathDependent {
+  class Path {
+    class B { class C }
+    implicit val x = new B
+    implicit val y = new x.C
+    def gimme(yy: x.C) = ???; gimme(y)
+  }
+  implicit val b = new Path().x
+}

--- a/scalafix-tests/input/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesPathDependent.scala
+++ b/scalafix-tests/input/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesPathDependent.scala
@@ -1,7 +1,7 @@
 /*
 rewrites = ExplicitReturnTypes
  */
-package test
+package test.explicitReturnTypes
 
 object ExplicitReturnTypesPathDependent {
   class Path {

--- a/scalafix-tests/input/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesShort.scala
+++ b/scalafix-tests/input/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesShort.scala
@@ -2,7 +2,7 @@
 rewrites = ExplicitReturnTypes
 explicitReturnTypes.unsafeShortenNames = true
  */
-package test
+package test.explicitReturnTypes
 
 import scala.language.implicitConversions
 

--- a/scalafix-tests/input/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesShort.scala
+++ b/scalafix-tests/input/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesShort.scala
@@ -14,10 +14,7 @@ object ExplicitReturnTypesShort {
   implicit val x = List.empty[Map[Int, Set[String]]]
   implicit val y = HashMap.empty[String, Success[ListBuffer[Int]]]
   implicit def z(x: Int) = List.empty[String]
-  trait Y { type X; def x: X }
-  implicit def pathDependent(x: Y) = {
-    implicit val result: x.X = x.x
-    result
-  }
+  implicit var zz = scala.collection.immutable.ListSet.empty[String]
   implicit val FALSE = (x: Any) => false
+  implicit def tparam[T](e: T) = e
 }

--- a/scalafix-tests/input/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesSingleton.scala
+++ b/scalafix-tests/input/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesSingleton.scala
@@ -1,0 +1,9 @@
+/*
+rewrites = ExplicitReturnTypes
+explicitReturnTypes.unsafeShortenNames = true
+ */
+package test.explicitReturnTypes
+
+object ExplicitReturnTypesSingleton {
+  implicit val default = ExplicitReturnTypesSingleton
+}

--- a/scalafix-tests/output/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypes.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypes.scala
@@ -3,12 +3,13 @@ package test
 import scala.language.implicitConversions
 
 object ExplicitReturnTypes {
+  def none[T]: _root_.scala.Option[T] =  None.asInstanceOf[Option[T]]
   val a: _root_.scala.Int = 1 + 2
   def b(): _root_.java.lang.String = "a" + "b"
   var c: _root_.scala.Boolean = 1 == 1
   protected val d = 1.0f
   protected def e(a: Int, b: Double): _root_.scala.Double = a + b
-  protected var f: _root_.scala.Function1[_root_.scala.Int, _root_.scala.Int] = (x: Int) => x + 1
+  protected var f: _root_.scala.Int => _root_.scala.Int = (x: Int) => x + 1
   private val g = 1
   private def h(a: Int) = ""
   private var i = 22
@@ -28,11 +29,6 @@ object ExplicitReturnTypes {
   implicit def tparam[T](e: T): T = e
   implicit def tparam2[T](e: T): _root_.scala.collection.immutable.List[T] = List(e)
   implicit def tparam3[T](e: T): _root_.scala.collection.immutable.Map[T, T] = Map(e -> e)
-  class Path {
-    class B { class C }
-    implicit val x: Path.this.B = new B
-    implicit val y: Path.this.x.C = new x.C
-  }
   class TwoClasses[T](e: T)
   class TwoClasses2 {
     implicit val x: _root_.test.ExplicitReturnTypes.TwoClasses[_root_.scala.Int] = new TwoClasses(10)

--- a/scalafix-tests/output/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesBase.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesBase.scala
@@ -1,8 +1,8 @@
-package test
+package test.explicitReturnTypes
 
 import scala.language.implicitConversions
 
-object ExplicitReturnTypes {
+object ExplicitReturnTypesBase {
   def none[T]: _root_.scala.Option[T] =  None.asInstanceOf[Option[T]]
   val a: _root_.scala.Int = 1 + 2
   def b(): _root_.java.lang.String = "a" + "b"
@@ -29,36 +29,11 @@ object ExplicitReturnTypes {
   implicit def tparam[T](e: T): T = e
   implicit def tparam2[T](e: T): _root_.scala.collection.immutable.List[T] = List(e)
   implicit def tparam3[T](e: T): _root_.scala.collection.immutable.Map[T, T] = Map(e -> e)
-  class TwoClasses[T](e: T)
-  class TwoClasses2 {
-    implicit val x: _root_.test.ExplicitReturnTypes.TwoClasses[_root_.scala.Int] = new TwoClasses(10)
-  }
   class implicitlytrick {
     implicit val s: _root_.java.lang.String = "string"
     implicit val x = implicitly[String]
   }
-  object InnerInnerObject {
-    object B {
-      class C
-      object C {
-        implicit val x: _root_.scala.collection.immutable.List[_root_.test.ExplicitReturnTypes.InnerInnerObject.B.C] = List(new C)
-      }
-    }
-  }
-  object SiblingObject {
-    class B
-  }
-  object A {
-    class C {
-      implicit val x: _root_.scala.collection.immutable.List[_root_.test.ExplicitReturnTypes.SiblingObject.B] = List(new SiblingObject.B)
-    }
-  }
-  object slick {
-    case class Supplier(id: Int, name: String)
-    implicit val supplierGetter: ((_root_.scala.Int, _root_.scala.Predef.String)) => _root_.test.ExplicitReturnTypes.slick.Supplier = (arg: (Int, String)) =>
-      Supplier(arg._1, arg._2)
-  }
-  def foo(x: Int): _root_.scala.Int =
+  def comment(x: Int): _root_.scala.Int =
     // comment
     x + 2
   object ExtraSpace {
@@ -69,24 +44,3 @@ object ExplicitReturnTypes {
   }
 }
 
-class DeeperPackage[T](e: T)
-package foo {
-  class B {
-    implicit val x: _root_.test.DeeperPackage[_root_.scala.Int] = new DeeperPackage(10)
-  }
-}
-
-package shallwpackage {
-  class A[T](e: T)
-}
-class shallobpackage {
-  implicit val x: _root_.test.shallwpackage.A[_root_.scala.Int] = new shallwpackage.A(10)
-}
-
-package enclosingPackageStripIsLast { class B }
-package a {
-  import enclosingPackageStripIsLast.B
-  class A {
-    implicit val x: _root_.test.enclosingPackageStripIsLast.B = new B
-  }
-}

--- a/scalafix-tests/output/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesPathDependent.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesPathDependent.scala
@@ -1,11 +1,11 @@
-package test
+package test.explicitReturnTypes
 
 object ExplicitReturnTypesPathDependent {
   class Path {
     class B { class C }
-    implicit val x: _root_.test.ExplicitReturnTypesPathDependent.Path#B = new B
+    implicit val x: _root_.test.explicitReturnTypes.ExplicitReturnTypesPathDependent.Path#B = new B
     implicit val y: x.C = new x.C
     def gimme(yy: x.C) = ???; gimme(y)
   }
-  implicit val b: _root_.test.ExplicitReturnTypesPathDependent.Path#B = new Path().x
+  implicit val b: _root_.test.explicitReturnTypes.ExplicitReturnTypesPathDependent.Path#B = new Path().x
 }

--- a/scalafix-tests/output/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesPathDependent.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesPathDependent.scala
@@ -1,0 +1,11 @@
+package test
+
+object ExplicitReturnTypesPathDependent {
+  class Path {
+    class B { class C }
+    implicit val x: _root_.test.ExplicitReturnTypesPathDependent.Path#B = new B
+    implicit val y: x.C = new x.C
+    def gimme(yy: x.C) = ???; gimme(y)
+  }
+  implicit val b: _root_.test.ExplicitReturnTypesPathDependent.Path#B = new Path().x
+}

--- a/scalafix-tests/output/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesShort.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesShort.scala
@@ -1,4 +1,4 @@
-package test
+package test.explicitReturnTypes
 
 import scala.language.implicitConversions
 

--- a/scalafix-tests/output/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesShort.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesShort.scala
@@ -5,15 +5,13 @@ import scala.language.implicitConversions
 import scala.collection.immutable.HashMap
 import scala.collection.mutable.ListBuffer
 import scala.util.Success
+import scala.collection.immutable.ListSet
 
 object ExplicitReturnTypesShort {
   implicit val x: List[Map[Int, Set[String]]] = List.empty[Map[Int, Set[String]]]
   implicit val y: HashMap[String, Success[ListBuffer[Int]]] = HashMap.empty[String, Success[ListBuffer[Int]]]
-  implicit def z(x: Int): scala.collection.immutable.List[scala.Predef.String] = List.empty[String]
-  trait Y { type X; def x: X }
-  implicit def pathDependent(x: Y): x.X = {
-    implicit val result: x.X = x.x
-    result
-  }
+  implicit def z(x: Int): List[String] = List.empty[String]
+  implicit var zz: ListSet[String] = scala.collection.immutable.ListSet.empty[String]
   implicit val FALSE: Any => Boolean = (x: Any) => false
+  implicit def tparam[T](e: T): T = e
 }

--- a/scalafix-tests/output/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesSingleton.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitReturnTypes/ExplicitReturnTypesSingleton.scala
@@ -1,0 +1,5 @@
+package test.explicitReturnTypes
+
+object ExplicitReturnTypesSingleton {
+  implicit val default: ExplicitReturnTypesSingleton.type = ExplicitReturnTypesSingleton
+}


### PR DESCRIPTION
ExplicitReturnTypes can now resolve symbols inside defs and vars.
The only known limitation at the moment is path dependent types are
widened to their non-path-dependent types. A fix for that bug is
pending here https://github.com/scalameta/scalameta/pull/1107