### PR TITLE
Fix linter issues discovered while writing scala-lang blogpost.

### DIFF
--- a/scalafix-core/shared/src/main/scala/org/langmeta/internal/ScalafixLangmetaHacks.scala
+++ b/scalafix-core/shared/src/main/scala/org/langmeta/internal/ScalafixLangmetaHacks.scala
@@ -17,9 +17,9 @@ object ScalafixLangmetaHacks {
         val count = end - start
         val eolOffset =
           if (input.chars.lift(start + count - 1).contains('\n')) -1 else 0
-        new String(input.chars, start, count + eolOffset)
+        new String(input.chars, start, math.max(0, count + eolOffset))
       }
-      var caret = " " * pos.startColumn + "^"
+      val caret = " " * pos.startColumn + "^"
       header + EOL + line + EOL + caret
     } else {
       s"$severity: $message"

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/NoInfer.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/NoInfer.scala
@@ -36,7 +36,6 @@ case object NoInfer {
     Symbol("_root_.java.io.Serializable#"),
     Symbol("_root_.scala.Any#"),
     Symbol("_root_.scala.AnyVal#"),
-    Symbol("_root_.scala.AnyVal#"),
     Symbol("_root_.scala.Product#")
   )
 

--- a/scalafix-core/shared/src/main/scala/scalafix/lint/LintCategory.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/lint/LintCategory.scala
@@ -19,6 +19,7 @@ final case class LintCategory(
 ) {
   def key(owner: RuleName): String =
     if (owner.isEmpty) id
+    else if (id.isEmpty) owner.value
     else s"${owner.value}.$id"
   private def noExplanation: LintCategory =
     new LintCategory(id, explanation, severity)

--- a/scalafix-tests/input/src/main/scala/test/LintAsserts.scala
+++ b/scalafix-tests/input/src/main/scala/test/LintAsserts.scala
@@ -1,0 +1,12 @@
+/*
+rules = [
+  NoInfer
+  "class:scalafix.test.DummyLinter"
+]
+ */
+package test
+
+class LintAsserts {
+  List(1, (1, 2)) // assert: NoInfer.any
+}
+// assert: DummyLinter

--- a/scalafix-tests/unit/src/main/scala/scalafix/test/DummyLinter.scala
+++ b/scalafix-tests/unit/src/main/scala/scalafix/test/DummyLinter.scala
@@ -1,0 +1,13 @@
+package scalafix.test
+
+import scalafix.LintCategory
+import scalafix.LintMessage
+import scalafix.Rule
+import scalafix.RuleCtx
+
+object DummyLinter extends Rule("DummyLinter") {
+  val error = LintCategory.error("Bam!")
+  override def check(ctx: RuleCtx): Seq[LintMessage] = {
+    error.at(ctx.tokenList.prev(ctx.tokens.last).pos) :: Nil
+  }
+}


### PR DESCRIPTION
- Rule names are now attached to their reported patches.
  This is necessary to support multiple linters in testkit,
  but will also later be necessary for escape hatches.
  The implementation is a bit hacky, but that should not leak
  into the public api.
- Off-by-one errors in lint asserts
- Lint category id was wrong for composite rules
- Remove trailing `.` when category.id is empty.
- Better detection of linters (but still not perfect).