### PR TITLE
Fix #266: Extended NoInfer adding extraSymbols field

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/NoInferConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/NoInferConfig.scala
@@ -1,0 +1,22 @@
+package scalafix.internal.config
+
+import metaconfig._
+import org.langmeta._
+
+case class NoInferConfig(
+    extraSymbols: List[Symbol] = Nil
+) {
+  implicit val reader: ConfDecoder[NoInferConfig] =
+    ConfDecoder.instanceF[NoInferConfig] { c =>
+        c.getOrElse("extraSymbols")(extraSymbols).map(xs => NoInferConfig(xs))
+    }
+  implicit val symbolReader: ConfDecoder[Symbol] =
+    ConfDecoder.instanceF[Symbol] { c =>
+      c.as[String].map(Symbol.apply)
+    }
+}
+
+object NoInferConfig {
+  val default = NoInferConfig()
+  implicit val reader: ConfDecoder[NoInferConfig] = default.reader
+}

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/.scalafix.conf
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/.scalafix.conf
@@ -2,3 +2,7 @@ rules = [
   ProcedureSyntax
   NoAutoTupling
 ]
+
+NoInfer.extraSymbols = [
+  "_root_.scala.Predef.any2stringadd."
+]

--- a/scalafix-tests/input/src/main/scala/test/NoInfer.scala
+++ b/scalafix-tests/input/src/main/scala/test/NoInfer.scala
@@ -1,5 +1,8 @@
 /*
 rule = NoInfer
+noInfer.extraSymbols = [
+  "_root_.test.NoInfer.B#"
+]
 */
 package test
 
@@ -14,4 +17,6 @@ case object NoInfer {
   }
   case class A()
   List(NoInfer, A())// assert: NoInfer.product
+  case class B()
+  List(B())// assert: NoInfer.b
 }


### PR DESCRIPTION
Done in Scala Center's spree in Dublin.