### PR TITLE
depend only on the part of cats actually used

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -259,7 +259,7 @@ lazy val testsDeps = List(
   // integration property tests
   "org.renucci" %% "scala-xml-quote" % "0.1.4",
   "org.typelevel" %% "catalysts-platform" % "0.0.5",
-  "org.typelevel" %% "cats" % "0.9.0",
+  "org.typelevel" %% "cats-core" % "0.9.0",
   "com.typesafe.slick" %% "slick" % "3.2.0-M2",
   "com.chuusai" %% "shapeless" % "2.3.2",
   "org.scalacheck" %% "scalacheck" % "1.13.4"


### PR DESCRIPTION
this is better in general... but also, dbuild doesn't understand the
combo-style dependency, so this is needed for Scala community build
compatibility