### PR TITLE
#238 Rule to remove unused local val and var

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -306,7 +306,7 @@ lazy val testsInput = project
     scalacOptions += s"-P:semanticdb:sourceroot:${sourceDirectory.in(Compile).value}",
     scalacOptions ~= (_.filterNot(_ == "-Yno-adapted-args")),
     scalacOptions += "-Ywarn-adapted-args", // For NoAutoTupling
-    scalacOptions += "-Ywarn-unused-import", // For RemoveUnusedImports
+    scalacOptions += "-Ywarn-unused", // For RemoveUnusedImports and RemoveUnusedTerms
     logLevel := Level.Error, // avoid flood of compiler warnings
     // TODO: Remove once scala-xml-quote is merged into scala-xml
     resolvers += Resolver.bintrayRepo("allanrenucci", "maven"),

--- a/build.sbt
+++ b/build.sbt
@@ -306,7 +306,8 @@ lazy val testsInput = project
     scalacOptions += s"-P:semanticdb:sourceroot:${sourceDirectory.in(Compile).value}",
     scalacOptions ~= (_.filterNot(_ == "-Yno-adapted-args")),
     scalacOptions += "-Ywarn-adapted-args", // For NoAutoTupling
-    scalacOptions += "-Ywarn-unused", // For RemoveUnusedImports and RemoveUnusedTerms
+    scalacOptions += "-Ywarn-unused-import", // For RemoveUnusedImports
+    scalacOptions += "-Ywarn-unused", // For RemoveUnusedTerms
     logLevel := Level.Error, // avoid flood of compiler warnings
     // TODO: Remove once scala-xml-quote is merged into scala-xml
     resolvers += Resolver.bintrayRepo("allanrenucci", "maven"),

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/RemoveUnusedTerms.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/RemoveUnusedTerms.scala
@@ -1,0 +1,36 @@
+package scalafix.internal.rule
+
+import scala.meta._
+import scalafix.Patch
+import scalafix.SemanticdbIndex
+import scalafix.rule.RuleCtx
+import scalafix.rule.SemanticRule
+
+case class RemoveUnusedTerms(index: SemanticdbIndex)
+    extends SemanticRule(index, "RemoveUnusedTerms") {
+
+  private val unusedTerms = {
+    val UnusedLocalVal = """local (.*) is never used""".r
+    index.messages.toIterator.collect {
+      case Message(pos, _, UnusedLocalVal(_*))  =>
+        pos
+    }.toSet
+  }
+
+  private def isUnused(defn: Defn) =
+    unusedTerms.contains(defn.pos)
+
+  private def removeLiterals(rhs: Term): String =
+    rhs match {
+      case Lit(_) => ""
+      case r => r.syntax
+    }
+
+  override def fix(ctx: RuleCtx): Patch = {
+    ctx.debugIndex()
+    ctx.tree.collect {
+      case i: Defn.Val if isUnused(i) => ctx.replaceTree(i, removeLiterals(i.rhs))
+      case i: Defn.Var if isUnused(i) => ctx.replaceTree(i, i.rhs.fold("")(removeLiterals))
+    }.asPatch
+  }
+}

--- a/scalafix-core/shared/src/main/scala/scalafix/rule/ScalafixRules.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/rule/ScalafixRules.scala
@@ -19,6 +19,7 @@ object ScalafixRules {
     Sbt1(index),
     ExplicitResultTypes(index),
     RemoveUnusedImports(index),
+    RemoveUnusedTerms(index),
     NoAutoTupling(index),
     Disable(index, DisableConfig.empty)
   )

--- a/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixRuleNames.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixRuleNames.scala
@@ -16,6 +16,7 @@ object ScalafixRuleNames {
     "ExplicitResultTypes",
     "ExplicitReturnTypes",
     "RemoveUnusedImports",
+    "RemoveUnusedTerms",
     "NoAutoTupling",
     "Disable"
   )

--- a/scalafix-tests/input/src/main/scala/test/RemoveUnusedTerms.scala
+++ b/scalafix-tests/input/src/main/scala/test/RemoveUnusedTerms.scala
@@ -1,0 +1,16 @@
+/*
+rule = RemoveUnusedTerms
+ */
+package test
+
+object RemoveUnusedTerms {
+
+  def foo {
+    val a = "unused"
+    val aa = println(5)
+    var b = println(0)
+    println(1)
+  }
+
+  val unused = 0
+}

--- a/scalafix-tests/input/src/main/scala/test/RemoveUnusedTerms.scala
+++ b/scalafix-tests/input/src/main/scala/test/RemoveUnusedTerms.scala
@@ -8,9 +8,10 @@ object RemoveUnusedTerms {
   def foo {
     val a = "unused"
     val aa = println(5)
-    var b = println(0)
+    var b = 0
+    var bb = println(0)
     println(1)
   }
 
-  val unused = 0
+  val cc = 0
 }

--- a/scalafix-tests/output/src/main/scala/test/RemoveUnusedTerms.scala
+++ b/scalafix-tests/output/src/main/scala/test/RemoveUnusedTerms.scala
@@ -1,0 +1,13 @@
+package test
+
+object RemoveUnusedTerms {
+
+  def foo {
+    
+    println(5)
+    println(0)
+    println(1)
+  }
+
+  val unused = 0
+}

--- a/scalafix-tests/output/src/main/scala/test/RemoveUnusedTerms.scala
+++ b/scalafix-tests/output/src/main/scala/test/RemoveUnusedTerms.scala
@@ -5,9 +5,10 @@ object RemoveUnusedTerms {
   def foo {
     
     println(5)
+    
     println(0)
     println(1)
   }
 
-  val unused = 0
+  val cc = 0
 }


### PR DESCRIPTION
This PR implements the rule described in #238.

In the specific, it removed unused local vals and vars. If litteral expressions are involved, the whole expression is removed, otherwise only the val definition is removed.

I'll try to send another PR for unused def/trait/classes in the near future.