### PR TITLE
Prepare for v0.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   - CI_TEST: ci-slow
     CI_SCALA_VERSION: 2.11.11
   - CI_TEST: scalafmt
-  - CI_TEST: mimaReportBinaryIssues
+  - CI_TEST: mima
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,10 @@ commands += Command.command("ci-slow") { s =>
   "scalafix-sbt/it:test" ::
     s
 }
+commands += Command.command("mima") { s =>
+  "very mimaReportBinaryIssues" ::
+    s
+}
 
 lazy val adhocRepoUri = sys.props("scalafix.repository.uri")
 lazy val adhocRepoCredentials = sys.props("scalafix.repository.credentials")
@@ -66,14 +70,13 @@ lazy val publishSettings = Seq(
     )
   ),
   mimaPreviousArtifacts := {
+    val previousArtifactVersion = "0.5.0"
     // NOTE(olafur) shudder, can't figure out simpler way to do the same.
     val binaryVersion =
       if (crossVersion.value.isInstanceOf[CrossVersion.Full]) scalaVersion.value
       else scalaBinaryVersion.value
     Set(
-      organization.value %
-        s"${moduleName.value}_$binaryVersion" %
-        sys.props.getOrElse("scalafix.stable.version", stableVersion.value)
+      organization.value % s"${moduleName.value}_$binaryVersion" % previousArtifactVersion
     )
   },
   mimaBinaryIssueFilters ++= Mima.ignoredABIProblems,
@@ -88,6 +91,8 @@ lazy val publishSettings = Seq(
 )
 
 lazy val noPublish = allSettings ++ Seq(
+  mimaReportBinaryIssues := {},
+  mimaPreviousArtifacts := Set.empty,
   publishArtifact := false,
   publish := {},
   publishLocal := {}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 
 object Dependencies {
 
-  val scalametaV = "2.0.0-RC3"
+  val scalametaV = "2.0.1"
   val metaconfigV = "0.5.2"
   def semanticdbSbt = "0.4.0"
   def dotty = "0.1.1-bin-20170530-f8f52cc-NIGHTLY"

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/build.sbt
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/build.sbt
@@ -1,6 +1,11 @@
 import _root_.scalafix.Versions
-updateOptions in ThisBuild := updateOptions.value.withLatestSnapshots(false)
-scalacOptions in ThisBuild += "-Ywarn-adapted-args" // For NoAutoTupling
+inThisBuild(
+  List(
+    updateOptions := updateOptions.value.withLatestSnapshots(false),
+    scalacOptions += "-Ywarn-adapted-args", // For NoAutoTupling
+    resolvers += Resolver.sonatypeRepo("releases")
+  )
+)
 lazy val root = project
   .in(file("."))
   .aggregate(


### PR DESCRIPTION
- bump scalameta dependency
- run mima on 2.11 and 2.12, previously it only ran in 2.12