### PR TITLE
Fix #373: addLeft's implementation doesn't match its specification

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/RuleCtxImpl.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/RuleCtxImpl.scala
@@ -85,7 +85,7 @@ case class RuleCtxImpl(tree: Tree, config: ScalafixConfig) extends RuleCtx {
     toks(tree).lastOption.fold(Patch.empty)(addRight(_, toAdd))
   def addLeft(tok: Token, toAdd: String): Patch = Add(tok, toAdd, "")
   def addLeft(tree: Tree, toAdd: String): Patch =
-    toks(tree).lastOption.fold(Patch.empty)(addLeft(_, toAdd))
+    toks(tree).headOption.fold(Patch.empty)(addLeft(_, toAdd))
 
   // Semantic patch ops.
   def removeGlobalImport(symbol: Symbol)(

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SyntacticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SyntacticRuleSuite.scala
@@ -8,8 +8,18 @@ import scalafix.syntax._
 
 import org.scalatest.FunSuiteLike
 
-class SyntacticRuleSuite(rule: Rule) extends FunSuiteLike with DiffAssertions {
+class SyntacticRuleSuite(defaultRule: Rule = Rule.empty)
+    extends FunSuiteLike
+    with DiffAssertions {
   def check(name: String, original: String, expected: String): Unit = {
+    check(defaultRule, name, original, expected)
+  }
+
+  def check(
+      rule: Rule,
+      name: String,
+      original: String,
+      expected: String): Unit = {
     test(name) {
       import scala.meta._
       val obtained = rule.apply(Input.String(original))
@@ -18,6 +28,10 @@ class SyntacticRuleSuite(rule: Rule) extends FunSuiteLike with DiffAssertions {
   }
 
   def checkDiff(original: Input, expected: String): Unit = {
+    checkDiff(defaultRule, original, expected)
+  }
+
+  def checkDiff(rule: Rule, original: Input, expected: String): Unit = {
     test(original.label) {
       val ctx = RuleCtx(original.parse[Source].get, ScalafixConfig.default)
       val obtained = rule.diff(ctx)


### PR DESCRIPTION
Return `headOption` instead of `lastOption` in addLeft's implementation.
Additionally, add a unit test, and refactor the syntax tests.

TESTED=unit tests pass