### PR TITLE
Fix #387, emit linter warnings from cli.

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/PrintStreamReporter.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/PrintStreamReporter.scala
@@ -1,5 +1,6 @@
 package scalafix.internal.config
 
+import java.io.OutputStream
 import scala.meta.Position
 import scala.meta.internal.inputs.XtensionPositionFormatMessage
 import java.io.PrintStream
@@ -32,6 +33,8 @@ case class PrintStreamReporter(
     }
   private val _errorCount = new AtomicInteger()
   override def reset: PrintStreamReporter = copy()
+  override def reset(os: OutputStream): ScalafixReporter =
+    copy(outStream = new PrintStream(os))
 
   override def report(message: String, position: Position, severity: Severity)(
       implicit ctx: LogContext): Unit = {

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/ScalafixConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/ScalafixConfig.scala
@@ -1,6 +1,7 @@
 package scalafix
 package internal.config
 
+import java.io.OutputStream
 import java.io.PrintStream
 import scala.meta._
 import scala.meta.dialects.Scala211
@@ -22,6 +23,13 @@ case class ScalafixConfig(
     reporter = reporter.reset,
     lint = lint.copy(
       reporter = lint.reporter.reset
+    )
+  )
+
+  def withFreshReporters(outStream: OutputStream): ScalafixConfig = copy(
+    reporter = reporter.reset(outStream),
+    lint = lint.copy(
+      reporter = lint.reporter.reset(outStream)
     )
   )
 

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/ScalafixReporter.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/ScalafixReporter.scala
@@ -1,5 +1,6 @@
 package scalafix.internal.config
 
+import java.io.OutputStream
 import scala.meta.Position
 import scalafix.internal.util.Severity
 import metaconfig.ConfDecoder
@@ -11,6 +12,7 @@ trait ScalafixReporter {
 
   /** Clear any internal mutable state */
   private[scalafix] def reset: ScalafixReporter
+  private[scalafix] def reset(outputStream: OutputStream): ScalafixReporter
 
   /** Returns the number of reported errors */
   def errorCount: Int

--- a/scalafix-core/shared/src/main/scala/scalafix/rule/Rule.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/rule/Rule.scala
@@ -9,7 +9,6 @@ import scalafix.syntax._
 import metaconfig.Conf
 import metaconfig.ConfDecoder
 import metaconfig.Configured
-import org.scalameta.logger
 
 /** A Scalafix Rule.
   *
@@ -70,13 +69,12 @@ abstract class Rule(ruleName: RuleName) { self =>
   final def andThen(other: Rule): Rule = merge(other)
 
   /** Returns string output of applying this single patch. */
-  final def apply(ctx: RuleCtx): String = apply(ctx, fix(ctx))
+  final def apply(ctx: RuleCtx): String = apply(ctx, fixWithName(ctx))
   final def apply(
       input: Input,
       config: ScalafixConfig = ScalafixConfig.default): String = {
     val ctx = RuleCtx(config.dialect(input).parse[Source].get, config)
-    val patch = fix(ctx)
-    apply(ctx, patch)
+    apply(ctx, fixWithName(ctx))
   }
   final def apply(input: String): String = apply(Input.String(input))
   final def apply(ctx: RuleCtx, patch: Patch): String = {

--- a/scalafix-tests/unit/src/test/scala/scalafix/cli/CliSyntacticTests.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/cli/CliSyntacticTests.scala
@@ -82,7 +82,10 @@ class CliSyntacticTests extends BaseCliTest {
     ),
     expectedLayout = s"""/foobar.scala
                         |$original""".stripMargin,
-    expectedExit = ExitStatus.LinterError
+    expectedExit = ExitStatus.LinterError,
+    outputAssert = { out =>
+      assert(out.contains("Error!"))
+    }
   )
 
   check(


### PR DESCRIPTION
This commit changes the cli to
- use the correct OutputStream for emitting lint messages
- call both fix and check instead of only fix

Review @blorente 