### PR TITLE
Remove unnecessary tags from docs

### DIFF
--- a/website/src/main/tut/docs/rules/Disable.md
+++ b/website/src/main/tut/docs/rules/Disable.md
@@ -1,7 +1,6 @@
 ---
 layout: docs
 title: Disable
-tag: rule
 ---
 
 # Disable

--- a/website/src/main/tut/docs/rules/DottyVarArgPattern.md
+++ b/website/src/main/tut/docs/rules/DottyVarArgPattern.md
@@ -1,7 +1,6 @@
 ---
 layout: docs
 title: DottyVarArgPattern
-tag: rule
 ---
 
 # DottyVarArgPattern

--- a/website/src/main/tut/docs/rules/NoInfer.md
+++ b/website/src/main/tut/docs/rules/NoInfer.md
@@ -1,7 +1,6 @@
 ---
 layout: docs
 title: NoInfer
-tag: rule
 ---
 
 # NoInfer


### PR DESCRIPTION
These were leftover from an old experiment with the new website.