### PR TITLE
Publish using 2.12.3 on the CI (this fixes the Scaladoc version issue)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ env:
   matrix:
   - CI_TEST: ci-fast
     CI_SCALA_VERSION: 2.11.11
-    CI_PUBLISH: true
   - CI_TEST: ci-fast
     CI_SCALA_VERSION: 2.12.3
+    CI_PUBLISH: true
   - CI_TEST: ci-slow
     CI_SCALA_VERSION: 2.11.11
   - CI_TEST: scalafmt


### PR DESCRIPTION
I just switched to 2.12.3 the entire CI job. I don't see any obvious drawback, since we're running the slow version on scala 2.11.11 anyway.

This fixes the issue with the version of Scaladoc used (reported in #393)