### PR TITLE
Tweak API docs link in docs

### DIFF
--- a/website/src/main/resources/microsite/data/menu.yml
+++ b/website/src/main/resources/microsite/data/menu.yml
@@ -23,5 +23,5 @@ options:
       - title: Glossary
         url: docs/rule-authors/glossary
       - title: API Docs
-        url: docs/api/
+        url: docs/api/scalafix/
 


### PR DESCRIPTION
Link to https://scalacenter.github.io/scalafix/docs/api/scalafix/
instead of the more barren https://scalacenter.github.io/scalafix/docs/api/.