### PR TITLE
File file: tab completion in sbt-scalafix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -405,6 +405,7 @@ lazy val unit = project
         )
         .value,
     buildInfoKeys := Seq[BuildInfoKey](
+      "baseDirectory" -> baseDirectory.in(ThisBuild).value,
       "inputSourceroot" ->
         sourceDirectory.in(testsInput, Compile).value,
       "inputSbtSourceroot" ->

--- a/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
+++ b/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
@@ -348,7 +348,10 @@ object CliRunner {
       else computeAndCacheDatabase()
     }
     private val lazySemanticdbIndex: LazySemanticdbIndex =
-      new LazySemanticdbIndex(resolveDatabase, diagnostic)
+      new LazySemanticdbIndex(
+        resolveDatabase,
+        diagnostic,
+        cli.common.workingPath)
 
     // expands a single file into a list of files.
     def expand(matcher: FilterMatcher)(path: AbsolutePath): Seq[FixFile] = {

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/LazySemanticdbIndex.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/LazySemanticdbIndex.scala
@@ -1,6 +1,7 @@
 package scalafix.internal.config
 
 import scalafix.SemanticdbIndex
+import org.langmeta.io.AbsolutePath
 
 // The challenge when loading a rule is that 1) if it's semantic it needs a
 // index constructor argument and 2) we don't know upfront if it's semantic.
@@ -12,13 +13,19 @@ import scalafix.SemanticdbIndex
 //type LazySemanticdbIndex = RuleKind => Option[SemanticdbIndex]
 class LazySemanticdbIndex(
     f: RuleKind => Option[SemanticdbIndex],
-    val reporter: ScalafixReporter)
-    extends Function[RuleKind, Option[SemanticdbIndex]] {
+    val reporter: ScalafixReporter,
+    val workingDirectory: AbsolutePath
+) extends Function[RuleKind, Option[SemanticdbIndex]] {
   override def apply(v1: RuleKind): Option[SemanticdbIndex] = f(v1)
 }
 
 object LazySemanticdbIndex {
-  lazy val empty = new LazySemanticdbIndex(_ => None, ScalafixReporter.default)
-  def apply(f: RuleKind => Option[SemanticdbIndex]): LazySemanticdbIndex =
-    new LazySemanticdbIndex(f, ScalafixReporter.default)
+  lazy val empty = new LazySemanticdbIndex(
+    _ => None,
+    ScalafixReporter.default,
+    AbsolutePath.workingDirectory)
+  def apply(
+      f: RuleKind => Option[SemanticdbIndex],
+      cwd: AbsolutePath = AbsolutePath.workingDirectory): LazySemanticdbIndex =
+    new LazySemanticdbIndex(f, ScalafixReporter.default, cwd)
 }

--- a/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
@@ -1,6 +1,8 @@
 package scalafix.internal.sbt
 
 import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
 import sbt.complete.DefaultParsers
 import sbt.complete.DefaultParsers._
 import sbt.complete.FileExamples
@@ -9,22 +11,49 @@ import sbt.complete.Parser
 object ScalafixCompletions {
   private val names = ScalafixRuleNames.all
 
-  private def uri(protocol: String) =
-    token(protocol + ":") ~> NotQuoted.map(x => s"$protocol:$x")
+  private def toAbsolutePath(path: Path, cwd: Path): Path = {
+    if (path.isAbsolute) path
+    else cwd.resolve(path)
+  }.normalize()
 
-  private def fileRule(base: File): Parser[String] =
+  // Extend FileExamples to tab complete when the prefix is an absolute path or `..`
+  private class AbsolutePathExamples(cwd: Path, prefix: String = "")
+      extends FileExamples(cwd.toFile, prefix) {
+    override def withAddedPrefix(addedPrefix: String): FileExamples = {
+      val nextPrefix =
+        if (addedPrefix.startsWith(".")) addedPrefix
+        else prefix + addedPrefix
+      val (b, p) = AbsolutePathCompleter.mkBase(nextPrefix, cwd)
+      new AbsolutePathExamples(b, p)
+    }
+  }
+  private object AbsolutePathCompleter {
+    def mkBase(prefix: String, fallback: Path): (Path, String) = {
+      val path = toAbsolutePath(Paths.get(prefix), fallback)
+      if (prefix.endsWith(File.separator)) path -> ""
+      else path.getParent -> path.getFileName.toString
+    }
+  }
+
+  private def fileRule(cwd: Path): Parser[String] =
     token("file:") ~>
       StringBasic
-        .examples(new FileExamples(base))
-        .map(f => s"file:${new File(base, f).getAbsolutePath}")
+        .examples(new AbsolutePathExamples(cwd))
+        .map { f =>
+          val path = toAbsolutePath(Paths.get(f), cwd).toString
+          "file:" + path
+        }
+
+  private def uri(protocol: String) =
+    token(protocol + ":") ~> NotQuoted.map(x => s"$protocol:$x")
 
   private val namedRule: Parser[String] =
     names.map(literal).reduceLeft(_ | _)
 
-  def parser(base: File): Parser[Seq[String]] = {
+  def parser(cwd: Path): Parser[Seq[String]] = {
     val all =
       namedRule |
-        fileRule(base) |
+        fileRule(cwd) |
         uri("github") |
         uri("replace") |
         uri("http") |

--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -107,7 +107,8 @@ object ScalafixPlugin extends AutoPlugin {
   // hack to avoid illegal dynamic reference, can't figure out how to do
   // scalafixParser(baseDirectory.in(ThisBuild).value).parsed
   private def workingDirectory = file(sys.props("user.dir"))
-  private val scalafixParser = ScalafixCompletions.parser(workingDirectory)
+  private val scalafixParser =
+    ScalafixCompletions.parser(workingDirectory.toPath)
   private val isSupportedScalaVersion = Def.setting {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 11 | 12)) => true

--- a/scalafix-sbt/src/test/scala/scalafix/internal/sbt/ScalafixCompletionsTest.scala
+++ b/scalafix-sbt/src/test/scala/scalafix/internal/sbt/ScalafixCompletionsTest.scala
@@ -1,0 +1,23 @@
+package scalafix.internal.sbt
+
+import java.nio.file.Paths
+import org.scalatest.FunSuite
+import sbt.complete.Parser
+
+class ScalafixCompletionsTest extends FunSuite {
+  val cwd = Paths.get("").toAbsolutePath
+  println(cwd)
+  val parser = ScalafixCompletions.parser(cwd)
+  val expected = Set("-diff", "-testkit", "-sbt", "-core", "-cli")
+  def check(path: String): Unit = {
+    test(path) {
+      val completions = Parser.completions(parser, " file:" + path, 0)
+      val obtained = completions.get.map(_.append).intersect(expected)
+      assert(obtained == expected)
+    }
+  }
+
+  check("scalafix") // relative path
+  check(cwd.resolve("scalafix").toString) // absolute path
+  check(Paths.get("..").resolve("scalafix").resolve("scalafix").toString)
+}

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/reflect/ScalafixReflectTests.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/reflect/ScalafixReflectTests.scala
@@ -2,7 +2,6 @@ package scalafix.tests.reflect
 
 import scalafix.internal.config.LazySemanticdbIndex
 import scalafix.internal.reflect.ScalafixCompilerDecoder
-import scalafix.reflect.ScalafixReflect
 import scalafix.rule.Rule
 import scalafix.tests.BuildInfo
 import metaconfig.Conf

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/reflect/ScalafixReflectTests.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/reflect/ScalafixReflectTests.scala
@@ -1,0 +1,36 @@
+package scalafix.tests.reflect
+
+import scalafix.internal.config.LazySemanticdbIndex
+import scalafix.internal.reflect.ScalafixCompilerDecoder
+import scalafix.reflect.ScalafixReflect
+import scalafix.rule.Rule
+import scalafix.tests.BuildInfo
+import metaconfig.Conf
+import metaconfig.ConfDecoder
+import org.langmeta.io.AbsolutePath
+import org.langmeta.io.RelativePath
+import org.scalatest.FunSuite
+
+class ScalafixReflectTests extends FunSuite {
+  val cwd: AbsolutePath = AbsolutePath(BuildInfo.baseDirectory)
+    .resolve("scalafix-tests")
+    .resolve("unit")
+    .resolve("src")
+    .resolve("main")
+    .resolve("scala")
+    .resolve("scalafix")
+    .resolve("test")
+  val relpath = RelativePath("DummyLinter.scala")
+  val abspath: AbsolutePath = cwd.resolve(relpath)
+  val decoder: ConfDecoder[Rule] = ScalafixCompilerDecoder.baseCompilerDecoder(
+    LazySemanticdbIndex(_ => None, cwd))
+  val expected = "DummyLinter"
+  test("absolute path resolves as is") {
+    val obtained = decoder.read(Conf.Str(s"file:$abspath")).get.name.value
+    assert(expected == obtained)
+  }
+  test("relative resolves from custom working directory") {
+    val obtained = decoder.read(Conf.Str(s"file:$relpath")).get.name.value
+    assert(expected == obtained)
+  }
+}


### PR DESCRIPTION
Previously, all paths were resolves from the base, including absolute
paths. This made it impossible to use `file:/absolute/path`, causing
FileNotFound errors like in
https://gist.github.com/xeno-by/94db732fffc99997ee2c2812ba97e4e2

This commit both fixes that bug and extends the file tab completion to
tab complete from absolute paths `file:/proj<TAB>` to `file:/project` as
well as from `file:../proj<TAB>` to `file:../project`. I'm a bit
surprised the built-inf sbt tab completer doesn't do this by default,
this patch might be worth contributing to sbt.