### PR TITLE
Add --tool-classpath to cli for file: and class: protocols.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -256,10 +256,7 @@ lazy val `scalafix-sbt` = project
     },
     sbtPlugin := true,
     crossSbtVersions := Vector(sbt013, sbt1),
-    libraryDependencies ++= Seq(
-      "io.get-coursier" %% "coursier" % coursier.util.Properties.version,
-      "io.get-coursier" %% "coursier-cache" % coursier.util.Properties.version
-    ),
+    libraryDependencies ++= coursierDeps,
     testQuick := {}, // these test are slow.
     test.in(IntegrationTest) := {
       RunSbtCommand(
@@ -306,6 +303,11 @@ lazy val testsDeps = List(
   "com.typesafe.slick" %% "slick" % "3.2.0-M2",
   "com.chuusai" %% "shapeless" % "2.3.2",
   "org.scalacheck" %% "scalacheck" % "1.13.4"
+)
+
+lazy val coursierDeps = Seq(
+  "io.get-coursier" %% "coursier" % coursier.util.Properties.version,
+  "io.get-coursier" %% "coursier-cache" % coursier.util.Properties.version
 )
 
 lazy val semanticdbSettings = Seq(
@@ -393,6 +395,9 @@ lazy val unit = project
     javaOptions := Nil,
     buildInfoPackage := "scalafix.tests",
     buildInfoObject := "BuildInfo",
+    sources.in(Test) +=
+      sourceDirectory.in(`scalafix-sbt`, Compile).value /
+        "scala" / "scalafix" / "internal" / "sbt" / "ScalafixJarFetcher.scala",
     compileInputs.in(Compile, compile) :=
       compileInputs
         .in(Compile, compile)
@@ -421,6 +426,7 @@ lazy val unit = project
       "semanticClasspath" -> classDirectory.in(testsInput, Compile).value,
       "sharedClasspath" -> classDirectory.in(testsShared, Compile).value
     ),
+    libraryDependencies ++= coursierDeps,
     libraryDependencies ++= testsDeps
   )
   .enablePlugins(BuildInfoPlugin)
@@ -539,6 +545,7 @@ def setId(project: Project): Project = {
     .copy(base = file(newId))
     .settings(moduleName := newId)
 }
+
 def customScalafixVersion = sys.props.get("scalafix.version")
 
 inScope(Global)(

--- a/scalafix-cli/src/main/scala/scalafix/internal/cli/ScalafixOptions.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/cli/ScalafixOptions.scala
@@ -58,13 +58,16 @@ case class ScalafixOptions(
         "semanticdb-scalac compiler plugin and are necessary for semantic rules " +
         "like ExplicitResultTypes to function."
     )
-    @ValueDescription("entry1.jar:entry2.jar:target/scala-2.12/classes")
+    @ValueDescription("entry1.jar:entry2.jar:target/scala-2.12/classes/")
     classpath: Option[String] = None,
     @HelpMessage(
       "Automatically infer --classpath starting from these directories. " +
         "Ignored if --classpath is provided.")
-    @ValueDescription("target:project/target")
     classpathAutoRoots: Option[String] = None,
+    @HelpMessage(
+      "Additional classpath to use when classloading/compiling rules")
+    @ValueDescription("entry1.jar:entry2.jar:target/scala-2.12/classes/")
+    toolClasspath: Option[String] = None,
     @HelpMessage("Disable validation when loading semanticdb files.")
     noStrictSemanticdb: Boolean = false,
     @HelpMessage(

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/LazySemanticdbIndex.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/LazySemanticdbIndex.scala
@@ -12,20 +12,20 @@ import org.langmeta.io.AbsolutePath
 // the moment we instantiate the rule.
 //type LazySemanticdbIndex = RuleKind => Option[SemanticdbIndex]
 class LazySemanticdbIndex(
-    f: RuleKind => Option[SemanticdbIndex],
-    val reporter: ScalafixReporter,
-    val workingDirectory: AbsolutePath
+    f: RuleKind => Option[SemanticdbIndex] = _ => None,
+    val reporter: ScalafixReporter = ScalafixReporter.default,
+    // The working directory when compiling file:relativepath/
+    val workingDirectory: AbsolutePath = AbsolutePath.workingDirectory,
+    // Additional classpath entries to use when compiling/classloading rules.
+    val toolClasspath: List[AbsolutePath] = Nil
 ) extends Function[RuleKind, Option[SemanticdbIndex]] {
   override def apply(v1: RuleKind): Option[SemanticdbIndex] = f(v1)
 }
 
 object LazySemanticdbIndex {
-  lazy val empty = new LazySemanticdbIndex(
-    _ => None,
-    ScalafixReporter.default,
-    AbsolutePath.workingDirectory)
+  lazy val empty = new LazySemanticdbIndex()
   def apply(
       f: RuleKind => Option[SemanticdbIndex],
       cwd: AbsolutePath = AbsolutePath.workingDirectory): LazySemanticdbIndex =
-    new LazySemanticdbIndex(f, ScalafixReporter.default, cwd)
+    new LazySemanticdbIndex(f, ScalafixReporter.default, cwd, Nil)
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/ClassloadRule.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/ClassloadRule.scala
@@ -115,7 +115,7 @@ class ClassloadRule[T](classLoader: ClassLoader)(implicit ev: ClassTag[T]) {
 }
 
 object ClassloadRule {
-  lazy val defaultClassloader = getClass.getClassLoader
+  def defaultClassloader: ClassLoader = getClass.getClassLoader
   def apply(
       fqn: String,
       args: Class[_] => Seq[AnyRef],

--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ScalafixToolbox.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ScalafixToolbox.scala
@@ -3,11 +3,13 @@ package scalafix.internal.reflect
 import java.io.File
 import java.net.URLClassLoader
 import java.net.URLDecoder
+import java.util.function
 import scala.meta.inputs.Input
 import scala.reflect.internal.util.AbstractFileClassLoader
 import scala.reflect.internal.util.BatchSourceFile
 import scala.tools.nsc.Global
 import scala.tools.nsc.Settings
+import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.io.VirtualDirectory
 import scala.tools.nsc.reporters.StoreReporter
 import scala.{meta => m}
@@ -15,6 +17,7 @@ import scalafix.internal.config.LazySemanticdbIndex
 import scalafix.internal.config.classloadRule
 import scalafix.internal.util.ClassloadRule
 import scalafix.rule.Rule
+import metaconfig.ConfDecoder
 import metaconfig.ConfError
 import metaconfig.Configured
 
@@ -22,7 +25,12 @@ object ScalafixToolbox extends ScalafixToolbox
 class ScalafixToolbox {
   private val ruleCache =
     new java.util.concurrent.ConcurrentHashMap[Input, Configured[Rule]]()
-  private val compiler = new Compiler()
+  private val compilerCache =
+    new java.util.concurrent.ConcurrentHashMap[String, RuleCompiler]()
+  private val newCompiler: function.Function[String, RuleCompiler] =
+    new function.Function[String, RuleCompiler] {
+      override def apply(classpath: String) = new RuleCompiler(classpath)
+    }
 
   def getRule(code: Input, index: LazySemanticdbIndex): Configured[Rule] =
     ruleCache.getOrDefault(code, {
@@ -39,6 +47,14 @@ class ScalafixToolbox {
       code: Input,
       index: LazySemanticdbIndex): Configured[Rule] =
     synchronized {
+      val cp = RuleCompiler.defaultClasspath + (
+        if (index.toolClasspath.isEmpty) ""
+        else {
+          File.pathSeparator +
+            index.toolClasspath.mkString(File.pathSeparator)
+        }
+      )
+      val compiler = compilerCache.computeIfAbsent(cp, newCompiler)
       (
         compiler.compile(code) |@|
           RuleInstrumentation.getRuleFqn(code)
@@ -55,36 +71,41 @@ class ScalafixToolbox {
     }
 }
 
-class Compiler() {
-  val target = new VirtualDirectory("(memory)", None)
+object RuleCompiler {
+  def defaultClasspath: String = {
+    getClass.getClassLoader match {
+      case u: URLClassLoader =>
+        val paths = u.getURLs.toList.map(u => {
+          if (u.getProtocol.startsWith("bootstrap")) {
+            import java.io._
+            import java.nio.file._
+            val stream = u.openStream
+            val tmp = File.createTempFile("bootstrap-" + u.getPath, ".jar")
+            Files.copy(
+              stream,
+              Paths.get(tmp.getAbsolutePath),
+              StandardCopyOption.REPLACE_EXISTING)
+            tmp.getAbsolutePath
+          } else {
+            URLDecoder.decode(u.getPath, "UTF-8")
+          }
+        })
+        paths.mkString(File.pathSeparator)
+      case _ => ""
+    }
+  }
+}
+
+class RuleCompiler(
+    classpath: String,
+    target: AbstractFile = new VirtualDirectory("(memory)", None)) {
   private val settings = new Settings()
   settings.deprecation.value = true // enable detailed deprecation warnings
   settings.unchecked.value = true // enable detailed unchecked warnings
   settings.outputDirs.setSingleOutput(target)
-  getClass.getClassLoader match {
-    case u: URLClassLoader =>
-      val paths = u.getURLs.toList.map(u => {
-        if (u.getProtocol.startsWith("bootstrap")) {
-          import java.io._
-          import java.nio.file._
-          val stream = u.openStream
-          val tmp = File.createTempFile("bootstrap-" + u.getPath, ".jar")
-          Files.copy(
-            stream,
-            Paths.get(tmp.getAbsolutePath),
-            StandardCopyOption.REPLACE_EXISTING)
-          tmp.getAbsolutePath
-        } else {
-          URLDecoder.decode(u.getPath, "UTF-8")
-        }
-      })
-      settings.classpath.value = paths.mkString(File.pathSeparator)
-    case _ => ""
-  }
+  settings.classpath.value = classpath
   lazy val reporter = new StoreReporter
-
   private val global = new Global(settings, reporter)
-
   private val classLoader =
     new AbstractFileClassLoader(target, this.getClass.getClassLoader)
 

--- a/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixJarFetcher.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixJarFetcher.scala
@@ -1,7 +1,7 @@
 package scalafix.internal.sbt
 
+import java.io.File
 import java.io.OutputStreamWriter
-import sbt.File
 
 private[scalafix] object ScalafixJarFetcher {
   def fetchJars(org: String, artifact: String, version: String): List[File] =

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/reflect/ToolClasspathTests.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/reflect/ToolClasspathTests.scala
@@ -1,0 +1,77 @@
+package scalafix.tests.reflect
+
+import java.io.File
+import java.nio.file.Files
+import scala.reflect.io.Directory
+import scala.reflect.io.PlainDirectory
+import scalafix.internal.config.LazySemanticdbIndex
+import scalafix.internal.config.ScalafixMetaconfigReaders
+import scalafix.internal.reflect.RuleCompiler
+import scalafix.internal.reflect.ScalafixCompilerDecoder
+import metaconfig.Conf
+import org.langmeta.inputs.Input
+import org.langmeta.io.AbsolutePath
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.FunSuite
+
+class ToolClasspathTests extends FunSuite with BeforeAndAfterAll {
+  var scalafmtClasspath: List[AbsolutePath] = _
+  override def beforeAll(): Unit = {
+    val scalaBinaryVersion =
+      scala.util.Properties.versionNumberString
+        .split("\\.")
+        .take(2)
+        .mkString(".")
+    val jars: List[File] = scalafix.internal.sbt.ScalafixJarFetcher.fetchJars(
+      "com.geirsson",
+      "scalafmt-core_" + scalaBinaryVersion,
+      "1.2.0"
+    )
+    scalafmtClasspath = jars.map(AbsolutePath(_))
+  }
+
+  test("--tool-classpath is respected when compiling from source") {
+    val scalafmtRewrite =
+      """
+        |import org.scalafmt._
+        |import scalafix._
+        |
+        |object FormatRule extends Rule("FormatRule") {
+        |  override def fix(ctx: RuleCtx): Patch = {
+        |    val formatted = Scalafmt.format(ctx.tokens.mkString).get
+        |    ctx.addLeft(ctx.tokens.last, formatted)
+        |  }
+        |}
+      """.stripMargin
+    val tmp = Files.createTempFile("scalafix", "FormatRule.scala")
+    Files.write(tmp, scalafmtRewrite.getBytes)
+    val index =
+      new LazySemanticdbIndex(toolClasspath = scalafmtClasspath)
+    val decoder = ScalafixCompilerDecoder.baseCompilerDecoder(index)
+    val obtained = decoder.read(Conf.Str(s"file:$tmp")).get
+    val expected = "FormatRule"
+    assert(obtained.name.value == expected)
+  }
+
+  test("--tool-classpath is respected during classloading") {
+    // Couldn't figure out how to test this.
+    val rewrite =
+      """package custom
+        |import scalafix._
+        |class CustomRule extends Rule("CustomRule")
+      """.stripMargin
+    val tmp = Files.createTempDirectory("scalafix")
+    val compiler = new RuleCompiler(
+      RuleCompiler.defaultClasspath,
+      new PlainDirectory(new Directory(tmp.toFile)))
+    compiler.compile(Input.VirtualFile("CustomRule.scala", rewrite))
+    val index =
+      new LazySemanticdbIndex(toolClasspath = AbsolutePath(tmp) :: Nil)
+    val decoder = ScalafixMetaconfigReaders.classloadRuleDecoder(index)
+    val obtained = decoder.read(Conf.Str(s"class:custom.CustomRule")).get
+    val expected = "CustomRule"
+    assert(obtained.name.value == expected)
+    assert(decoder.read(Conf.Str("class:does.not.Exist")).isNotOk)
+  }
+
+}


### PR DESCRIPTION
Previously, you needed to include the classpath as part of the scalafix
cli binary in order to use 3rd party dependencies. This commit makes it
possible to use the same scalafix binary with a custom classpath for
loading rules.

Fixes #383