### PR TITLE
Refactor build.sbt to use project/ScalafixBuild.scala

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -256,10 +256,7 @@ lazy val `scalafix-sbt` = project
     },
     sbtPlugin := true,
     crossSbtVersions := Vector(sbt013, sbt1),
-    libraryDependencies ++= Seq(
-      "io.get-coursier" %% "coursier" % coursier.util.Properties.version,
-      "io.get-coursier" %% "coursier-cache" % coursier.util.Properties.version
-    ),
+    libraryDependencies ++= coursierDeps,
     testQuick := {}, // these test are slow.
     test.in(IntegrationTest) := {
       RunSbtCommand(
@@ -306,6 +303,11 @@ lazy val testsDeps = List(
   "com.typesafe.slick" %% "slick" % "3.2.0-M2",
   "com.chuusai" %% "shapeless" % "2.3.2",
   "org.scalacheck" %% "scalacheck" % "1.13.4"
+)
+
+lazy val coursierDeps = Seq(
+  "io.get-coursier" %% "coursier" % coursier.util.Properties.version,
+  "io.get-coursier" %% "coursier-cache" % coursier.util.Properties.version
 )
 
 lazy val semanticdbSettings = Seq(
@@ -393,6 +395,9 @@ lazy val unit = project
     javaOptions := Nil,
     buildInfoPackage := "scalafix.tests",
     buildInfoObject := "BuildInfo",
+    sources.in(Test) +=
+      sourceDirectory.in(`scalafix-sbt`, Compile).value /
+        "scala" / "scalafix" / "internal" / "sbt" / "ScalafixJarFetcher.scala",
     compileInputs.in(Compile, compile) :=
       compileInputs
         .in(Compile, compile)
@@ -421,6 +426,7 @@ lazy val unit = project
       "semanticClasspath" -> classDirectory.in(testsInput, Compile).value,
       "sharedClasspath" -> classDirectory.in(testsShared, Compile).value
     ),
+    libraryDependencies ++= coursierDeps,
     libraryDependencies ++= testsDeps
   )
   .enablePlugins(BuildInfoPlugin)
@@ -539,6 +545,7 @@ def setId(project: Project): Project = {
     .copy(base = file(newId))
     .settings(moduleName := newId)
 }
+
 def customScalafixVersion = sys.props.get("scalafix.version")
 
 inScope(Global)(

--- a/build.sbt
+++ b/build.sbt
@@ -1,187 +1,33 @@
-import scalajsbundler.util.JSON._
 import sbt.ScriptedPlugin
 import sbt.ScriptedPlugin._
-import microsites._
 import Dependencies._
 
-inThisBuild(
-  List(
-    organization := "ch.epfl.scala",
-    version := customScalafixVersion.getOrElse(version.value.replace('+', '-'))
-  )
-)
-name := {
-  println(s"Welcome to scalafix ${version.value}")
-  "scalafixRoot"
-}
+version.in(ThisBuild) ~= (_.replace('+', '-'))
+name := "scalafixRoot"
+onLoadMessage := s"Welcome to Scalafix ${version.value}"
+noPublish
 
-lazy val crossVersions = Seq(scala211, scala212)
-
-commands += Command.command("ci-release") { s =>
-  "clean" ::
-    "very publishSigned" ::
-    "^^ 1.0.2 " ::
-    "scalafix-sbt/publishSigned" ::
-    "sonatypeReleaseAll" ::
-    s
-}
-commands += Command.command("ci-fast") { s =>
-  "test" ::
-    s
-}
-commands += Command.command("ci-slow") { s =>
-  "scalafix-sbt/it:test" ::
-    s
-}
-commands += Command.command("mima") { s =>
-  "very mimaReportBinaryIssues" ::
-    s
-}
-
-lazy val adhocRepoUri = sys.props("scalafix.repository.uri")
-lazy val adhocRepoCredentials = sys.props("scalafix.repository.credentials")
-lazy val isCustomRepository = adhocRepoUri != null && adhocRepoCredentials != null
-
-lazy val publishSettings = Seq(
-  publishTo := {
-    if (isCustomRepository) Some("adhoc" at adhocRepoUri)
-    else {
-      val uri = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-      Some("Releases" at uri)
-    }
-  },
-  credentials ++= {
-    val credentialsFile = {
-      if (adhocRepoCredentials != null) new File(adhocRepoCredentials)
-      else null
-    }
-    if (credentialsFile != null) List(new FileCredentials(credentialsFile))
-    else Nil
-  },
-  publishArtifact in Test := false,
-  licenses := Seq(
-    "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
-  homepage := Some(url("https://github.com/scalacenter/scalafix")),
-  autoAPIMappings := true,
-  apiURL := Some(url("https://scalacenter.github.io/scalafix/")),
-  scmInfo := Some(
-    ScmInfo(
-      url("https://github.com/scalacenter/scalafix"),
-      "scm:git:git@github.com:scalacenter/scalafix.git"
-    )
-  ),
-  mimaPreviousArtifacts := {
-    val previousArtifactVersion = "0.5.0"
-    // NOTE(olafur) shudder, can't figure out simpler way to do the same.
-    val binaryVersion =
-      if (crossVersion.value.isInstanceOf[CrossVersion.Full]) scalaVersion.value
-      else scalaBinaryVersion.value
-    Set(
-      organization.value % s"${moduleName.value}_$binaryVersion" % previousArtifactVersion
-    )
-  },
-  mimaBinaryIssueFilters ++= Mima.ignoredABIProblems,
-  developers ++= List(
-    Developer(
-      "gabro",
-      "Gabriele Petronella",
-      "gabriele@buildo.io",
-      url("https://buildo.io")
-    ),
-    Developer(
-      "olafurpg",
-      "Ólafur Páll Geirsson",
-      "olafurpg@gmail.com",
-      url("https://geirsson.com")
-    )
-  )
-)
-
-lazy val noPublish = allSettings ++ Seq(
-  mimaReportBinaryIssues := {},
-  mimaPreviousArtifacts := Set.empty,
-  publishArtifact := false,
-  publish := {},
-  publishLocal := {}
-)
-
-lazy val stableVersion =
-  settingKey[String]("Version of latest release to Maven.")
-
-inThisBuild(
-  Seq(
-    version := sys.props.getOrElse("scalafix.version", version.value),
-    stableVersion := version.value.replaceAll("\\-.*", "")
-  ))
-
-lazy val supportedScalaVersions = List(scala211, scala212)
-
-lazy val buildInfoSettings: Seq[Def.Setting[_]] = Seq(
-  buildInfoKeys := Seq[BuildInfoKey](
-    name,
-    version,
-    stableVersion,
-    "coursier" -> coursier.util.Properties.version,
-    "nightly" -> version.value,
-    "scalameta" -> scalametaV,
-    "semanticdbSbt" -> semanticdbSbt,
-    scalaVersion,
-    "supportedScalaVersions" -> supportedScalaVersions,
-    "scala211" -> scala211,
-    "scala212" -> scala212,
-    sbtVersion
-  ),
-  buildInfoPackage := "scalafix",
-  buildInfoObject := "Versions"
-)
-
-lazy val allSettings = List(
-  version := version.value,
-  stableVersion := stableVersion.value,
-  resolvers += Resolver.sonatypeRepo("releases"),
-  triggeredMessage in ThisBuild := Watched.clearWhenTriggered,
-  scalacOptions ++= compilerOptions.value,
-  scalacOptions in (Compile, console) := compilerOptions.value :+ "-Yrepl-class-based",
-  libraryDependencies += scalatest.value % Test,
-  testOptions in Test += Tests.Argument("-oD"),
-  scalaVersion := ciScalaVersion.getOrElse(scala212),
-  crossScalaVersions := crossVersions,
-  updateOptions := updateOptions.value.withCachedResolution(true)
-)
-
-lazy val allJSSettings = List(
-  additionalNpmConfig.in(Compile) := Map("private" -> bool(true))
-)
-
-allSettings
-
-gitPushTag := {
-  val tag = s"v${version.value}"
-  assert(!tag.endsWith("SNAPSHOT"))
-  import sys.process._
-  Seq("git", "tag", "-a", tag, "-m", tag).!!
-  Seq("git", "push", "--tags").!!
-}
-
-lazy val reflect = project
-  .configure(setId)
+lazy val diff = crossProject
+  .in(file("scalafix-diff"))
   .settings(
-    allSettings,
-    publishSettings,
-    isFullCrossVersion,
-    libraryDependencies ++= Seq(
-      "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-      "org.scala-lang" % "scala-reflect" % scalaVersion.value
-    )
+    moduleName := "scalafix-diff",
+    description := "JVM/JS library to build unified diffs."
   )
-  .dependsOn(coreJVM)
+  .jvmSettings(
+    libraryDependencies += googleDiff
+  )
+  .jsSettings(
+    allJSSettings,
+    npmDependencies in Compile += "diff" -> "3.2.0"
+  )
+  .jsConfigure(_.enablePlugins(ScalaJSBundlerPlugin))
+lazy val diffJS = diff.js
+lazy val diffJVM = diff.jvm
 
 lazy val core = crossProject
   .in(file("scalafix-core"))
   .settings(
     moduleName := "scalafix-core",
-    allSettings,
-    publishSettings,
     buildInfoSettings,
     libraryDependencies ++= List(
       scalameta.value,
@@ -199,29 +45,20 @@ lazy val core = crossProject
 lazy val coreJS = core.js
 lazy val coreJVM = core.jvm
 
-lazy val diff = crossProject
-  .in(file("scalafix-diff"))
+lazy val reflect = project
+  .configure(setId)
   .settings(
-    moduleName := "scalafix-diff",
-    allSettings,
-    publishSettings
+    isFullCrossVersion,
+    libraryDependencies ++= Seq(
+      "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value
+    )
   )
-  .jvmSettings(
-    libraryDependencies += googleDiff
-  )
-  .jsSettings(
-    allJSSettings,
-    npmDependencies in Compile += "diff" -> "3.2.0"
-  )
-  .jsConfigure(_.enablePlugins(ScalaJSBundlerPlugin))
-lazy val diffJS = diff.js
-lazy val diffJVM = diff.jvm
+  .dependsOn(coreJVM)
 
 lazy val cli = project
   .configure(setId)
   .settings(
-    allSettings,
-    publishSettings,
     isFullCrossVersion,
     mainClass in assembly := Some("scalafix.cli.Cli"),
     assemblyJarName in assembly := "scalafix.jar",
@@ -241,11 +78,9 @@ lazy val cli = project
 lazy val `scalafix-sbt` = project
   .configs(IntegrationTest)
   .settings(
-    allSettings,
     is210Only,
-    publishSettings,
-    buildInfoSettings,
     Defaults.itSettings,
+    buildInfoSettings,
     ScriptedPlugin.scriptedSettings,
     commands += Command.command(
       "installCompletions",
@@ -280,9 +115,7 @@ lazy val `scalafix-sbt` = project
 lazy val testkit = project
   .configure(setId)
   .settings(
-    allSettings,
     isFullCrossVersion,
-    publishSettings,
     libraryDependencies ++= Seq(
       semanticdb,
       ammonite,
@@ -294,30 +127,6 @@ lazy val testkit = project
     coreJVM,
     reflect
   )
-
-lazy val testsDeps = List(
-  // integration property tests
-  "org.renucci" %% "scala-xml-quote" % "0.1.4",
-  "org.typelevel" %% "catalysts-platform" % "0.0.5",
-  "org.typelevel" %% "cats-core" % "0.9.0",
-  "com.typesafe.slick" %% "slick" % "3.2.0-M2",
-  "com.chuusai" %% "shapeless" % "2.3.2",
-  "org.scalacheck" %% "scalacheck" % "1.13.4"
-)
-
-lazy val coursierDeps = Seq(
-  "io.get-coursier" %% "coursier" % coursier.util.Properties.version,
-  "io.get-coursier" %% "coursier-cache" % coursier.util.Properties.version
-)
-
-lazy val semanticdbSettings = Seq(
-  scalacOptions ++= List(
-    "-Yrangepos",
-    "-Xplugin-require:semanticdb"
-  ),
-  addCompilerPlugin(
-    "org.scalameta" % "semanticdb-scalac" % scalametaV cross CrossVersion.full)
-)
 
 lazy val testsShared = project
   .in(file("scalafix-tests/shared"))
@@ -436,129 +245,13 @@ lazy val unit = project
     testkit
   )
 
-lazy val websiteSettings = Seq(
-  micrositeName := "scalafix",
-  micrositeDescription := "Rewrite and linting tool for Scala",
-  micrositeBaseUrl := "scalafix",
-  micrositeDocumentationUrl := "docs/users/installation",
-  micrositeHighlightTheme := "atom-one-light",
-  micrositeHomepage := "https://scalacenter.github.io/scalafix/",
-  micrositeOrganizationHomepage := "https://scala.epfl.ch/",
-  micrositeTwitterCreator := "@scala_lang",
-  micrositeGithubOwner := "scalacenter",
-  micrositeGithubRepo := "scalafix",
-  ghpagesNoJekyll := false,
-  micrositeGitterChannel := true,
-  micrositeFooterText := None,
-  micrositeFooterText := Some(
-    """
-      |<p>© 2017 <a href="https://github.com/scalacenter/scalafix#team">The Scalafix Maintainers</a></p>
-      |<p style="font-size: 80%; margin-top: 10px">Website built with <a href="https://47deg.github.io/sbt-microsites/">sbt-microsites © 2016 47 Degrees</a></p>
-      |""".stripMargin
-  ),
-  micrositePalette := Map(
-    "brand-primary" -> "#0D2B35",
-    "brand-secondary" -> "#203F4A",
-    "brand-tertiary" -> "#0D2B35",
-    "gray-dark" -> "#453E46",
-    "gray" -> "rgba(0,0,0,.8)",
-    "gray-light" -> "#E3E2E3",
-    "gray-lighter" -> "#F4F3F4",
-    "white-color" -> "#FFFFFF"
-  ),
-  micrositeConfigYaml := ConfigYml(
-    yamlCustomProperties = Map(
-      "githubOwner" -> micrositeGithubOwner.value,
-      "githubRepo" -> micrositeGithubRepo.value,
-      "docsUrl" -> "docs",
-      "callToActionText" -> "Get started",
-      "callToActionUrl" -> micrositeDocumentationUrl.value,
-      "scala212" -> scala212,
-      "scala211" -> scala211,
-      "stableVersion" -> stableVersion.value,
-      "scalametaVersion" -> scalametaV,
-      "supportedScalaVersions" -> supportedScalaVersions,
-      "coursierVersion" -> coursier.util.Properties.version
-    )
-  ),
-  fork in tut := true
-)
-
-lazy val docsMappingsAPIDir = settingKey[String](
-  "Name of subdirectory in site target directory for api docs")
-
-lazy val unidocSettings = Seq(
-  autoAPIMappings := true,
-  apiURL := Some(url("https://scalacenter.github.io/docs/api/")),
-  docsMappingsAPIDir := "docs/api",
-  addMappingsToSiteDir(
-    mappings in (ScalaUnidoc, packageDoc),
-    docsMappingsAPIDir),
-  unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(testkit, coreJVM),
-  scalacOptions in (ScalaUnidoc, unidoc) ++= Seq(
-    "-doc-source-url",
-    scmInfo.value.get.browseUrl + "/tree/master€{FILE_PATH}.scala",
-    "-sourcepath",
-    baseDirectory.in(LocalRootProject).value.getAbsolutePath,
-    "-skip-packages",
-    "ammonite:org:scala:scalafix.tests:scalafix.internal"
-  ),
-  fork in (ScalaUnidoc, unidoc) := true
-)
-
 lazy val website = project
   .enablePlugins(MicrositesPlugin)
   .enablePlugins(ScalaUnidocPlugin)
   .settings(
     noPublish,
     websiteSettings,
-    unidocSettings
+    unidocSettings,
+    unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(testkit, coreJVM)
   )
   .dependsOn(testkit, coreJVM, cli)
-
-lazy val is210Only = Seq(
-  scalaVersion := scala210,
-  crossScalaVersions := Seq(scala210),
-  scalacOptions -= warnUnusedImports
-)
-
-lazy val isFullCrossVersion = Seq(
-  crossVersion := CrossVersion.full
-)
-
-lazy val warnUnusedImports = "-Ywarn-unused-import"
-lazy val compilerOptions = Def.setting {
-  Seq(
-    "-deprecation",
-    "-encoding",
-    "UTF-8",
-    "-feature",
-    "-unchecked"
-  )
-}
-
-lazy val gitPushTag = taskKey[Unit]("Push to git tag")
-
-def setId(project: Project): Project = {
-  val newId = "scalafix-" + project.id
-  project
-    .copy(base = file(newId))
-    .settings(moduleName := newId)
-}
-
-def customScalafixVersion = sys.props.get("scalafix.version")
-
-inScope(Global)(
-  Seq(
-    credentials ++= (for {
-      username <- sys.env.get("SONATYPE_USERNAME")
-      password <- sys.env.get("SONATYPE_PASSWORD")
-    } yield
-      Credentials(
-        "Sonatype Nexus Repository Manager",
-        "oss.sonatype.org",
-        username,
-        password)).toSeq,
-    PgpKeys.pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toCharArray())
-  )
-)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,4 +23,19 @@ object Dependencies {
 
   def scalameta = Def.setting("org.scalameta" %%% "contrib" % scalametaV)
   def scalatest = Def.setting("org.scalatest" %%% "scalatest" % "3.0.0")
+
+  def testsDeps = List(
+    // integration property tests
+    "org.renucci" %% "scala-xml-quote" % "0.1.4",
+    "org.typelevel" %% "catalysts-platform" % "0.0.5",
+    "org.typelevel" %% "cats-core" % "0.9.0",
+    "com.typesafe.slick" %% "slick" % "3.2.0-M2",
+    "com.chuusai" %% "shapeless" % "2.3.2",
+    "org.scalacheck" %% "scalacheck" % "1.13.4"
+  )
+
+  def coursierDeps = Seq(
+    "io.get-coursier" %% "coursier" % coursier.util.Properties.version,
+    "io.get-coursier" %% "coursier-cache" % coursier.util.Properties.version
+  )
 }

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -1,0 +1,272 @@
+import Dependencies._
+import com.typesafe.sbt.pgp.PgpKeys
+import sbt._
+import sbt.Keys._
+import sbt.plugins.JvmPlugin
+import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
+import scalajsbundler.sbtplugin.ScalaJSBundlerPlugin.autoImport._
+import scalajsbundler.util.JSON._
+import tut.TutPlugin.autoImport._
+import microsites.MicrositesPlugin.autoImport._
+import sbtunidoc.BaseUnidocPlugin.autoImport._
+import sbtunidoc.ScalaUnidocPlugin.autoImport._
+import com.typesafe.sbt.site.SitePlugin.autoImport._
+import microsites.ConfigYml
+import sbtbuildinfo.BuildInfoKey
+import sbtbuildinfo.BuildInfoPlugin.autoImport._
+import com.typesafe.sbt.sbtghpages.GhpagesKeys
+import sbt.Def
+
+object ScalafixBuild extends AutoPlugin with GhpagesKeys {
+  override def trigger = allRequirements
+  override def requires = JvmPlugin
+  object autoImport {
+    lazy val stableVersion =
+      settingKey[String]("Version of latest release to Maven.")
+    lazy val noPublish = Seq(
+      mimaReportBinaryIssues := {},
+      mimaPreviousArtifacts := Set.empty,
+      publishArtifact := false,
+      publish := {},
+      publishLocal := {}
+    )
+    lazy val crossVersions = Seq(scala211, scala212)
+    lazy val supportedScalaVersions = List(scala211, scala212)
+    lazy val is210Only = Seq(
+      scalaVersion := scala210,
+      crossScalaVersions := Seq(scala210),
+      scalacOptions -= warnUnusedImports
+    )
+    lazy val isFullCrossVersion = Seq(
+      crossVersion := CrossVersion.full
+    )
+    lazy val allJSSettings = List(
+      additionalNpmConfig.in(Compile) := Map("private" -> bool(true))
+    )
+    lazy val warnUnusedImports = "-Ywarn-unused-import"
+    lazy val compilerOptions = Seq(
+      "-deprecation",
+      "-encoding",
+      "UTF-8",
+      "-feature",
+      "-unchecked"
+    )
+
+    // Sets scalafix- prefix to moduleName and base file
+    def setId(project: Project): Project = {
+      val newId = "scalafix-" + project.id
+      project
+        .copy(base = file(newId))
+        .settings(moduleName := newId)
+    }
+
+    lazy val buildInfoSettings: Seq[Def.Setting[_]] = Seq(
+      buildInfoKeys := Seq[BuildInfoKey](
+        name,
+        version,
+        stableVersion,
+        "coursier" -> coursier.util.Properties.version,
+        "nightly" -> version.value,
+        "scalameta" -> scalametaV,
+        "semanticdbSbt" -> semanticdbSbt,
+        scalaVersion,
+        "supportedScalaVersions" -> supportedScalaVersions,
+        "scala211" -> scala211,
+        "scala212" -> scala212,
+        sbtVersion
+      ),
+      buildInfoPackage := "scalafix",
+      buildInfoObject := "Versions"
+    )
+
+    lazy val semanticdbSettings = Seq(
+      scalacOptions ++= List(
+        "-Yrangepos",
+        "-Xplugin-require:semanticdb"
+      ),
+      addCompilerPlugin(
+        "org.scalameta" % "semanticdb-scalac" % scalametaV cross CrossVersion.full)
+    )
+
+    // =======
+    // Website
+    // =======
+    lazy val docsMappingsAPIDir = settingKey[String](
+      "Name of subdirectory in site target directory for api docs")
+    lazy val unidocSettings = Seq(
+      autoAPIMappings := true,
+      apiURL := Some(url("https://scalacenter.github.io/docs/api/")),
+      docsMappingsAPIDir := "docs/api",
+      addMappingsToSiteDir(
+        mappings in (ScalaUnidoc, packageDoc),
+        docsMappingsAPIDir
+      ),
+      scalacOptions in (ScalaUnidoc, unidoc) ++= Seq(
+        "-doc-source-url",
+        scmInfo.value.get.browseUrl + "/tree/master€{FILE_PATH}.scala",
+        "-sourcepath",
+        baseDirectory.in(LocalRootProject).value.getAbsolutePath,
+        "-skip-packages",
+        "ammonite:org:scala:scalafix.tests:scalafix.internal"
+      ),
+      fork in (ScalaUnidoc, unidoc) := true
+    )
+
+    lazy val websiteSettings = Seq(
+      micrositeName := "scalafix",
+      micrositeDescription := "Rewrite and linting tool for Scala",
+      micrositeBaseUrl := "scalafix",
+      micrositeDocumentationUrl := "docs/users/installation",
+      micrositeHighlightTheme := "atom-one-light",
+      micrositeHomepage := "https://scalacenter.github.io/scalafix/",
+      micrositeOrganizationHomepage := "https://scala.epfl.ch/",
+      micrositeTwitterCreator := "@scala_lang",
+      micrositeGithubOwner := "scalacenter",
+      micrositeGithubRepo := "scalafix",
+      ghpagesNoJekyll := false,
+      micrositeGitterChannel := true,
+      micrositeFooterText := None,
+      micrositeFooterText := Some(
+        """
+          |<p>© 2017 <a href="https://github.com/scalacenter/scalafix#team">The Scalafix Maintainers</a></p>
+          |<p style="font-size: 80%; margin-top: 10px">Website built with <a href="https://47deg.github.io/sbt-microsites/">sbt-microsites © 2016 47 Degrees</a></p>
+          |""".stripMargin
+      ),
+      micrositePalette := Map(
+        "brand-primary" -> "#0D2B35",
+        "brand-secondary" -> "#203F4A",
+        "brand-tertiary" -> "#0D2B35",
+        "gray-dark" -> "#453E46",
+        "gray" -> "rgba(0,0,0,.8)",
+        "gray-light" -> "#E3E2E3",
+        "gray-lighter" -> "#F4F3F4",
+        "white-color" -> "#FFFFFF"
+      ),
+      micrositeConfigYaml := ConfigYml(
+        yamlCustomProperties = Map(
+          "githubOwner" -> micrositeGithubOwner.value,
+          "githubRepo" -> micrositeGithubRepo.value,
+          "docsUrl" -> "docs",
+          "callToActionText" -> "Get started",
+          "callToActionUrl" -> micrositeDocumentationUrl.value,
+          "scala212" -> scala212,
+          "scala211" -> scala211,
+          "stableVersion" -> stableVersion.value,
+          "scalametaVersion" -> scalametaV,
+          "supportedScalaVersions" -> supportedScalaVersions,
+          "coursierVersion" -> coursier.util.Properties.version
+        )
+      ),
+      fork in tut := true
+    )
+  }
+  import autoImport._
+
+  // Custom settings to publish scalafix forks to alternative maven repo.
+  lazy val adhocRepoUri = sys.props("scalafix.repository.uri")
+  lazy val adhocRepoCredentials = sys.props("scalafix.repository.credentials")
+  lazy val isCustomRepository = adhocRepoUri != null && adhocRepoCredentials != null
+
+  override def globalSettings: Seq[Def.Setting[_]] = List(
+    version := sys.props
+      .get("scalafix.version")
+      .getOrElse(version.value.replace('+', '-')),
+    stableVersion := version.value.replaceAll("\\-.*", ""),
+    scalaVersion := ciScalaVersion.getOrElse(scala212),
+    crossScalaVersions := crossVersions,
+    scalacOptions ++= compilerOptions,
+    scalacOptions in (Compile, console) := compilerOptions :+ "-Yrepl-class-based",
+    libraryDependencies += scalatest.value % Test,
+    testOptions in Test += Tests.Argument("-oD"),
+    updateOptions := updateOptions.value.withCachedResolution(true),
+    resolvers += Resolver.sonatypeRepo("releases"),
+    triggeredMessage in ThisBuild := Watched.clearWhenTriggered,
+    commands += Command.command("ci-release") { s =>
+      "clean" ::
+        "very publishSigned" ::
+        "^^ 1.0.2 " ::
+        "scalafix-sbt/publishSigned" ::
+        "sonatypeReleaseAll" ::
+        s
+    },
+    commands += Command.command("ci-fast") { s =>
+      "test" ::
+        s
+    },
+    commands += Command.command("ci-slow") { s =>
+      "scalafix-sbt/it:test" ::
+        s
+    },
+    commands += Command.command("mima") { s =>
+      "very mimaReportBinaryIssues" ::
+        s
+    },
+    credentials ++= (for {
+      username <- sys.env.get("SONATYPE_USERNAME")
+      password <- sys.env.get("SONATYPE_PASSWORD")
+    } yield
+      Credentials(
+        "Sonatype Nexus Repository Manager",
+        "oss.sonatype.org",
+        username,
+        password)).toSeq,
+    PgpKeys.pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toCharArray()),
+    publishTo := {
+      if (isCustomRepository) Some("adhoc" at adhocRepoUri)
+      else {
+        val uri = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+        Some("Releases" at uri)
+      }
+    },
+    credentials ++= {
+      val credentialsFile = {
+        if (adhocRepoCredentials != null) new File(adhocRepoCredentials)
+        else null
+      }
+      if (credentialsFile != null) List(new FileCredentials(credentialsFile))
+      else Nil
+    },
+    publishArtifact in Test := false,
+    licenses := Seq(
+      "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+    homepage := Some(url("https://github.com/scalacenter/scalafix")),
+    autoAPIMappings := true,
+    apiURL := Some(url("https://scalacenter.github.io/scalafix/")),
+    scmInfo := Some(
+      ScmInfo(
+        url("https://github.com/scalacenter/scalafix"),
+        "scm:git:git@github.com:scalacenter/scalafix.git"
+      )
+    ),
+    organization := "ch.epfl.scala",
+    developers ++= List(
+      Developer(
+        "gabro",
+        "Gabriele Petronella",
+        "gabriele@buildo.io",
+        url("https://buildo.io")
+      ),
+      Developer(
+        "olafurpg",
+        "Ólafur Páll Geirsson",
+        "olafurpg@gmail.com",
+        url("https://geirsson.com")
+      )
+    )
+  )
+
+  override def projectSettings: Seq[Def.Setting[_]] = List(
+    mimaPreviousArtifacts := {
+      val previousArtifactVersion = "0.5.0"
+      // NOTE(olafur) shudder, can't figure out simpler way to do the same.
+      val binaryVersion =
+        if (crossVersion.value.isInstanceOf[CrossVersion.Full])
+          scalaVersion.value
+        else scalaBinaryVersion.value
+      Set(
+        organization.value % s"${moduleName.value}_$binaryVersion" % previousArtifactVersion
+      )
+    },
+    mimaBinaryIssueFilters ++= Mima.ignoredABIProblems
+  )
+}

--- a/scalafix-cli/src/main/scala/scalafix/internal/cli/ScalafixOptions.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/cli/ScalafixOptions.scala
@@ -58,13 +58,16 @@ case class ScalafixOptions(
         "semanticdb-scalac compiler plugin and are necessary for semantic rules " +
         "like ExplicitResultTypes to function."
     )
-    @ValueDescription("entry1.jar:entry2.jar:target/scala-2.12/classes")
+    @ValueDescription("entry1.jar:entry2.jar:target/scala-2.12/classes/")
     classpath: Option[String] = None,
     @HelpMessage(
       "Automatically infer --classpath starting from these directories. " +
         "Ignored if --classpath is provided.")
-    @ValueDescription("target:project/target")
     classpathAutoRoots: Option[String] = None,
+    @HelpMessage(
+      "Additional classpath to use when classloading/compiling rules")
+    @ValueDescription("entry1.jar:entry2.jar:target/scala-2.12/classes/")
+    toolClasspath: Option[String] = None,
     @HelpMessage("Disable validation when loading semanticdb files.")
     noStrictSemanticdb: Boolean = false,
     @HelpMessage(

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/LazySemanticdbIndex.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/LazySemanticdbIndex.scala
@@ -12,20 +12,20 @@ import org.langmeta.io.AbsolutePath
 // the moment we instantiate the rule.
 //type LazySemanticdbIndex = RuleKind => Option[SemanticdbIndex]
 class LazySemanticdbIndex(
-    f: RuleKind => Option[SemanticdbIndex],
-    val reporter: ScalafixReporter,
-    val workingDirectory: AbsolutePath
+    f: RuleKind => Option[SemanticdbIndex] = _ => None,
+    val reporter: ScalafixReporter = ScalafixReporter.default,
+    // The working directory when compiling file:relativepath/
+    val workingDirectory: AbsolutePath = AbsolutePath.workingDirectory,
+    // Additional classpath entries to use when compiling/classloading rules.
+    val toolClasspath: List[AbsolutePath] = Nil
 ) extends Function[RuleKind, Option[SemanticdbIndex]] {
   override def apply(v1: RuleKind): Option[SemanticdbIndex] = f(v1)
 }
 
 object LazySemanticdbIndex {
-  lazy val empty = new LazySemanticdbIndex(
-    _ => None,
-    ScalafixReporter.default,
-    AbsolutePath.workingDirectory)
+  lazy val empty = new LazySemanticdbIndex()
   def apply(
       f: RuleKind => Option[SemanticdbIndex],
       cwd: AbsolutePath = AbsolutePath.workingDirectory): LazySemanticdbIndex =
-    new LazySemanticdbIndex(f, ScalafixReporter.default, cwd)
+    new LazySemanticdbIndex(f, ScalafixReporter.default, cwd, Nil)
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/ClassloadRule.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/ClassloadRule.scala
@@ -115,7 +115,7 @@ class ClassloadRule[T](classLoader: ClassLoader)(implicit ev: ClassTag[T]) {
 }
 
 object ClassloadRule {
-  lazy val defaultClassloader = getClass.getClassLoader
+  def defaultClassloader: ClassLoader = getClass.getClassLoader
   def apply(
       fqn: String,
       args: Class[_] => Seq[AnyRef],

--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ScalafixToolbox.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ScalafixToolbox.scala
@@ -3,11 +3,13 @@ package scalafix.internal.reflect
 import java.io.File
 import java.net.URLClassLoader
 import java.net.URLDecoder
+import java.util.function
 import scala.meta.inputs.Input
 import scala.reflect.internal.util.AbstractFileClassLoader
 import scala.reflect.internal.util.BatchSourceFile
 import scala.tools.nsc.Global
 import scala.tools.nsc.Settings
+import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.io.VirtualDirectory
 import scala.tools.nsc.reporters.StoreReporter
 import scala.{meta => m}
@@ -15,6 +17,7 @@ import scalafix.internal.config.LazySemanticdbIndex
 import scalafix.internal.config.classloadRule
 import scalafix.internal.util.ClassloadRule
 import scalafix.rule.Rule
+import metaconfig.ConfDecoder
 import metaconfig.ConfError
 import metaconfig.Configured
 
@@ -22,7 +25,12 @@ object ScalafixToolbox extends ScalafixToolbox
 class ScalafixToolbox {
   private val ruleCache =
     new java.util.concurrent.ConcurrentHashMap[Input, Configured[Rule]]()
-  private val compiler = new Compiler()
+  private val compilerCache =
+    new java.util.concurrent.ConcurrentHashMap[String, RuleCompiler]()
+  private val newCompiler: function.Function[String, RuleCompiler] =
+    new function.Function[String, RuleCompiler] {
+      override def apply(classpath: String) = new RuleCompiler(classpath)
+    }
 
   def getRule(code: Input, index: LazySemanticdbIndex): Configured[Rule] =
     ruleCache.getOrDefault(code, {
@@ -39,6 +47,14 @@ class ScalafixToolbox {
       code: Input,
       index: LazySemanticdbIndex): Configured[Rule] =
     synchronized {
+      val cp = RuleCompiler.defaultClasspath + (
+        if (index.toolClasspath.isEmpty) ""
+        else {
+          File.pathSeparator +
+            index.toolClasspath.mkString(File.pathSeparator)
+        }
+      )
+      val compiler = compilerCache.computeIfAbsent(cp, newCompiler)
       (
         compiler.compile(code) |@|
           RuleInstrumentation.getRuleFqn(code)
@@ -55,36 +71,41 @@ class ScalafixToolbox {
     }
 }
 
-class Compiler() {
-  val target = new VirtualDirectory("(memory)", None)
+object RuleCompiler {
+  def defaultClasspath: String = {
+    getClass.getClassLoader match {
+      case u: URLClassLoader =>
+        val paths = u.getURLs.toList.map(u => {
+          if (u.getProtocol.startsWith("bootstrap")) {
+            import java.io._
+            import java.nio.file._
+            val stream = u.openStream
+            val tmp = File.createTempFile("bootstrap-" + u.getPath, ".jar")
+            Files.copy(
+              stream,
+              Paths.get(tmp.getAbsolutePath),
+              StandardCopyOption.REPLACE_EXISTING)
+            tmp.getAbsolutePath
+          } else {
+            URLDecoder.decode(u.getPath, "UTF-8")
+          }
+        })
+        paths.mkString(File.pathSeparator)
+      case _ => ""
+    }
+  }
+}
+
+class RuleCompiler(
+    classpath: String,
+    target: AbstractFile = new VirtualDirectory("(memory)", None)) {
   private val settings = new Settings()
   settings.deprecation.value = true // enable detailed deprecation warnings
   settings.unchecked.value = true // enable detailed unchecked warnings
   settings.outputDirs.setSingleOutput(target)
-  getClass.getClassLoader match {
-    case u: URLClassLoader =>
-      val paths = u.getURLs.toList.map(u => {
-        if (u.getProtocol.startsWith("bootstrap")) {
-          import java.io._
-          import java.nio.file._
-          val stream = u.openStream
-          val tmp = File.createTempFile("bootstrap-" + u.getPath, ".jar")
-          Files.copy(
-            stream,
-            Paths.get(tmp.getAbsolutePath),
-            StandardCopyOption.REPLACE_EXISTING)
-          tmp.getAbsolutePath
-        } else {
-          URLDecoder.decode(u.getPath, "UTF-8")
-        }
-      })
-      settings.classpath.value = paths.mkString(File.pathSeparator)
-    case _ => ""
-  }
+  settings.classpath.value = classpath
   lazy val reporter = new StoreReporter
-
   private val global = new Global(settings, reporter)
-
   private val classLoader =
     new AbstractFileClassLoader(target, this.getClass.getClassLoader)
 

--- a/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixJarFetcher.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixJarFetcher.scala
@@ -1,7 +1,7 @@
 package scalafix.internal.sbt
 
+import java.io.File
 import java.io.OutputStreamWriter
-import sbt.File
 
 private[scalafix] object ScalafixJarFetcher {
   def fetchJars(org: String, artifact: String, version: String): List[File] =

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/reflect/ToolClasspathTests.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/reflect/ToolClasspathTests.scala
@@ -1,0 +1,77 @@
+package scalafix.tests.reflect
+
+import java.io.File
+import java.nio.file.Files
+import scala.reflect.io.Directory
+import scala.reflect.io.PlainDirectory
+import scalafix.internal.config.LazySemanticdbIndex
+import scalafix.internal.config.ScalafixMetaconfigReaders
+import scalafix.internal.reflect.RuleCompiler
+import scalafix.internal.reflect.ScalafixCompilerDecoder
+import metaconfig.Conf
+import org.langmeta.inputs.Input
+import org.langmeta.io.AbsolutePath
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.FunSuite
+
+class ToolClasspathTests extends FunSuite with BeforeAndAfterAll {
+  var scalafmtClasspath: List[AbsolutePath] = _
+  override def beforeAll(): Unit = {
+    val scalaBinaryVersion =
+      scala.util.Properties.versionNumberString
+        .split("\\.")
+        .take(2)
+        .mkString(".")
+    val jars: List[File] = scalafix.internal.sbt.ScalafixJarFetcher.fetchJars(
+      "com.geirsson",
+      "scalafmt-core_" + scalaBinaryVersion,
+      "1.2.0"
+    )
+    scalafmtClasspath = jars.map(AbsolutePath(_))
+  }
+
+  test("--tool-classpath is respected when compiling from source") {
+    val scalafmtRewrite =
+      """
+        |import org.scalafmt._
+        |import scalafix._
+        |
+        |object FormatRule extends Rule("FormatRule") {
+        |  override def fix(ctx: RuleCtx): Patch = {
+        |    val formatted = Scalafmt.format(ctx.tokens.mkString).get
+        |    ctx.addLeft(ctx.tokens.last, formatted)
+        |  }
+        |}
+      """.stripMargin
+    val tmp = Files.createTempFile("scalafix", "FormatRule.scala")
+    Files.write(tmp, scalafmtRewrite.getBytes)
+    val index =
+      new LazySemanticdbIndex(toolClasspath = scalafmtClasspath)
+    val decoder = ScalafixCompilerDecoder.baseCompilerDecoder(index)
+    val obtained = decoder.read(Conf.Str(s"file:$tmp")).get
+    val expected = "FormatRule"
+    assert(obtained.name.value == expected)
+  }
+
+  test("--tool-classpath is respected during classloading") {
+    // Couldn't figure out how to test this.
+    val rewrite =
+      """package custom
+        |import scalafix._
+        |class CustomRule extends Rule("CustomRule")
+      """.stripMargin
+    val tmp = Files.createTempDirectory("scalafix")
+    val compiler = new RuleCompiler(
+      RuleCompiler.defaultClasspath,
+      new PlainDirectory(new Directory(tmp.toFile)))
+    compiler.compile(Input.VirtualFile("CustomRule.scala", rewrite))
+    val index =
+      new LazySemanticdbIndex(toolClasspath = AbsolutePath(tmp) :: Nil)
+    val decoder = ScalafixMetaconfigReaders.classloadRuleDecoder(index)
+    val obtained = decoder.read(Conf.Str(s"class:custom.CustomRule")).get
+    val expected = "CustomRule"
+    assert(obtained.name.value == expected)
+    assert(decoder.read(Conf.Str("class:does.not.Exist")).isNotOk)
+  }
+
+}


### PR DESCRIPTION
build.sbt was becoming unmaintainable, this PR moves non-project related settings to project/ScalafixBuild.scala and replaces allSettings with globalSettings. This should reduce the number of keys to resolve on every sbt reload as well as yield better incremental compilation on reload (sbt builds a compilation unit for each `def/val` in build.sbt). I'm still amazed at the complexity of the scalafix build even after this refactoring, it's almost 500 LOC, but this is at least some improvement (IMO)