### PR TITLE
Fix #331, make is easy to configure custom configurations in sbt-scalafix

### DIFF
--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/build.sbt
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/build.sbt
@@ -17,7 +17,13 @@ lazy val root = project
 
 lazy val scala210 = project.settings(scalaVersion := "2.10.5")
 lazy val scala211 = project.settings(scalaVersion := Versions.scala211)
-lazy val scala212 = project.settings(scalaVersion := Versions.scala212)
+lazy val scala212 = project
+  .configs(IntegrationTest)
+  .settings(
+    Defaults.itSettings,
+    scalafixConfigure(Test, Compile, IntegrationTest),
+    scalaVersion := Versions.scala212
+  )
 lazy val customSourceroot = project.settings(
   scalaVersion := Versions.scala212,
   scalafixSourceroot := sourceDirectory.value
@@ -44,7 +50,11 @@ TaskKey[Unit]("check") := {
       .replace("\"))", "\")")
 
   val results: Seq[Boolean] =
-    Seq(scala210, scala211, scala212, customSourceroot).flatMap { project =>
+    assertContentMatches(
+      "scala212/src/it/scala/Main.scala",
+      expected
+    ) +:
+      Seq(scala210, scala211, scala212, customSourceroot).flatMap { project =>
       val prefix = project.id
       Seq(
         assertContentMatches(

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/scala212/src/it/scala/Main.scala
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/scala212/src/it/scala/Main.scala
@@ -1,0 +1,7 @@
+object Main {
+  def foo(a: (Int, String)) = a
+  foo(1, "str")
+  def main(args: Array[String]) {
+    println(1)
+  }
+}

--- a/website/src/main/tut/docs/users/installation.md
+++ b/website/src/main/tut/docs/users/installation.md
@@ -27,6 +27,10 @@ scalacOptions ++= List(...) // change := to ++=
 scalacOptions := List(...)                    // keep unchanged
 scalacOptions ++= scalafixScalacOptions.value // add this line
 
+// enable scalafix in custom configurations, only Test and Compile are
+// enabled by default.
+scalafixConfigure(Compile, Test, IntegrationTest)
+
 // ===> sbt shell (example usage)
 > scalafix                               // Run .scalafix.conf rules
 > scalafix RemoveUnusedImports           // Run specific rule


### PR DESCRIPTION
This commit makes it possible to enable scalafix for custom configurations like this
```scala
scalafixConfigure(Compile, Test, IntegrationTest)
```

Previously it required more advanced workarounds.