### PR TITLE
Add missing backquote breaking doc

### DIFF
--- a/website/src/main/tut/docs/users/installation.md
+++ b/website/src/main/tut/docs/users/installation.md
@@ -200,7 +200,7 @@ scalafix --rules RemoveUnusedImports --sourceroot /path/to/somepath/scalaProject
 
 But if you compiled at `moduleA` level only, you will need to use: 
 
-``
+```
 scalafix --rules RemoveUnusedImports --sourceroot /path/to/somepath/scalaProject/moduleA
 ```
 


### PR DESCRIPTION
This missing backquote has dire consequences and break the whole remaining parts of the page. 