### PR TITLE
Simplify ci-slow.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,10 +78,8 @@ lazy val cli = project
   )
 
 lazy val `scalafix-sbt` = project
-  .configs(IntegrationTest)
   .settings(
     is210Only,
-    Defaults.itSettings,
     buildInfoSettings,
     ScriptedPlugin.scriptedSettings,
     commands += Command.command(
@@ -95,12 +93,13 @@ lazy val `scalafix-sbt` = project
     crossSbtVersions := Vector(sbt013, sbt1),
     libraryDependencies ++= coursierDeps,
     testQuick := {}, // these test are slow.
-    test.in(IntegrationTest) := {
-      RunSbtCommand(
-        s"; plz $scala212 publishLocal " +
-          "; very scalafix-sbt/scripted"
-      )(state.value)
-    },
+    publishLocal := publishLocal
+      .dependsOn(
+        publishLocal in diffJVM,
+        publishLocal in coreJVM,
+        publishLocal in reflect,
+        publishLocal in cli)
+      .value,
     moduleName := "sbt-scalafix",
     mimaPreviousArtifacts := Set.empty,
     scriptedLaunchOpts ++= Seq(

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -192,7 +192,7 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
         s
     },
     commands += Command.command("ci-slow") { s =>
-      "scalafix-sbt/it:test" ::
+      "scalafix-sbt/scripted" ::
         s
     },
     commands += Command.command("mima") { s =>


### PR DESCRIPTION
The CI failed while publishing v0.5.4, I'm not able to reproduce the
compile error in cli/doc so I suspect the problem is related to the
hairy ci-slow command, which triggered commands from the `it:test` task.
This commit removes that part and uses sbt more idiomatically, making
ci-slow stay within the task graph.