### PR TITLE
Downgrade to Scala 2.11.11 and 2.12.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ jdk:
 env:
   matrix:
   - CI_TEST: ci-fast
-    CI_SCALA_VERSION: 2.11.12
+    CI_SCALA_VERSION: 2.11.11
   - CI_TEST: ci-fast
-    CI_SCALA_VERSION: 2.12.4
+    CI_SCALA_VERSION: 2.12.3
     CI_PUBLISH: true
   - CI_TEST: ci-slow
-    CI_SCALA_VERSION: 2.12.4
+    CI_SCALA_VERSION: 2.12.3
   - CI_TEST: scalafmt
   - CI_TEST: mima
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,8 +8,11 @@ object Dependencies {
   def semanticdbSbt = "0.4.0"
   def dotty = "0.1.1-bin-20170530-f8f52cc-NIGHTLY"
   def scala210 = "2.10.6"
-  def scala211 = "2.11.12"
-  def scala212 = "2.12.4"
+  // NOTE(olafur) downgraded from 2.11.12 and 2.12.4 because of non-reproducible error
+  // https://travis-ci.org/scalacenter/scalafix/jobs/303142842#L4658
+  // as well as https://github.com/scala/bug/issues/10609
+  def scala211 = "2.11.11"
+  def scala212 = "2.12.3"
   def sbt013 = "0.13.6"
   def sbt1 = "1.0.2"
   def ciScalaVersion = sys.env.get("CI_SCALA_VERSION")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.19")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC10")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.20")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC13")
 unmanagedSources.in(Compile) += baseDirectory.value / ".." / "Dependencies.scala"


### PR DESCRIPTION
After upgrading to 2.12.4 and 2.11.12, we started getting irregular
compile errors in CI, only when the cache is not clean. I don't think
we are doing anything weird with the cache, this commit is to verify if
this regression is caused by misconfiguration in the scalafix builds or
the 2.12.4/2.11.12 upgrade.