### PR TITLE
Fix broken CI publish.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -256,3 +256,18 @@ lazy val website = project
     unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(testkit, coreJVM)
   )
   .dependsOn(testkit, coreJVM, cli)
+
+inScope(Global)(
+  Seq(
+    credentials ++= (for {
+      username <- sys.env.get("SONATYPE_USERNAME")
+      password <- sys.env.get("SONATYPE_PASSWORD")
+    } yield
+      Credentials(
+        "Sonatype Nexus Repository Manager",
+        "oss.sonatype.org",
+        username,
+        password)).toSeq,
+    PgpKeys.pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toCharArray())
+  )
+)

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -199,16 +199,6 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
       "very mimaReportBinaryIssues" ::
         s
     },
-    credentials ++= (for {
-      username <- sys.env.get("SONATYPE_USERNAME")
-      password <- sys.env.get("SONATYPE_PASSWORD")
-    } yield
-      Credentials(
-        "Sonatype Nexus Repository Manager",
-        "oss.sonatype.org",
-        username,
-        password)).toSeq,
-    PgpKeys.pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toCharArray()),
     publishTo := {
       if (isCustomRepository) Some("adhoc" at adhocRepoUri)
       else {


### PR DESCRIPTION
For some reason it seems that globalSettings is not respected for
pgpPassphrase, which breaks the publish on tag push from Travis.
This commit moves the settings back to build.sbt and I've manually
confirmed this fixes the issue.