### PR TITLE
Fix #452, use flexible scala dialect.

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/ScalafixConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/ScalafixConfig.scala
@@ -4,7 +4,7 @@ package internal.config
 import java.io.OutputStream
 import java.io.PrintStream
 import scala.meta._
-import scala.meta.dialects.Scala211
+import scala.meta.dialects.Scala212
 import scala.meta.parsers.Parse
 import metaconfig._
 
@@ -15,7 +15,7 @@ case class ScalafixConfig(
     fatalWarnings: Boolean = true,
     reporter: ScalafixReporter = ScalafixReporter.default,
     patches: ConfigRulePatches = ConfigRulePatches.default,
-    dialect: Dialect = Scala211,
+    dialect: Dialect = ScalafixConfig.DefaultDialect,
     lint: LintConfig = LintConfig.default
 ) {
 
@@ -68,6 +68,35 @@ object ScalafixConfig {
   lazy val default = ScalafixConfig()
   implicit lazy val ScalafixConfigDecoder: ConfDecoder[ScalafixConfig] =
     default.reader
+
+  val DefaultDialect: Dialect = Scala212.copy(
+    // Are `&` intersection types supported by this dialect?
+    allowAndTypes = true,
+    // Are extractor varargs specified using ats, i.e. is `case Extractor(xs @ _*)` legal or not?
+    allowAtForExtractorVarargs = true,
+    // Are extractor varargs specified using colons, i.e. is `case Extractor(xs: _*)` legal or not?
+    allowColonForExtractorVarargs = true,
+    // Are inline vals and defs supported by this dialect?
+    allowInlineMods = true,
+    // Are literal types allowed, i.e. is `val a : 42 = 42` legal or not?
+    allowLiteralTypes = true,
+    // Are `|` (union types) supported by this dialect?
+    allowOrTypes = true,
+    // Are trailing commas allowed? SIP-27.
+    allowTrailingCommas = true,
+    // Are trait allowed to have parameters?
+    // They are in Dotty, but not in Scala 2.12 or older.
+    allowTraitParameters = true,
+    // Are view bounds supported by this dialect?
+    // Removed in Dotty.
+    allowViewBounds = true,
+    // Are `with` intersection types supported by this dialect?
+    allowWithTypes = true,
+    // Are XML literals supported by this dialect?
+    // We plan to deprecate XML literal syntax, and some dialects
+    // might go ahead and drop support completely.
+    allowXmlLiterals = true
+  )
 
   /** Returns config from current working directory, if .scalafix.conf exists. */
   def auto(workingDirectory: AbsolutePath): Option[Input] = {

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/ScalafixMetaconfigReaders.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/ScalafixMetaconfigReaders.scala
@@ -40,7 +40,17 @@ trait ScalafixMetaconfigReaders {
   }
   implicit lazy val dialectReader: ConfDecoder[Dialect] = {
     import scala.meta.dialects._
-    ReaderUtil.oneOf[Dialect](Scala211, Sbt0137, Dotty, Paradise211)
+    import ScalafixConfig.{DefaultDialect => Default}
+    ReaderUtil.oneOf[Dialect](
+      Default,
+      Scala211,
+      Scala212,
+      Sbt0137,
+      Sbt1,
+      Dotty,
+      Paradise211,
+      Paradise212
+    )
   }
 
   object UriRuleString {


### PR DESCRIPTION
Scalafmt uses the same dialect with the only difference that we don't
treat `inline` as a keyword here (I think that was a premature choice in
scalafmt)