### PR TITLE
Include column number in linter messages

### DIFF
--- a/scalafix-core/shared/src/main/scala/org/langmeta/internal/ScalafixLangmetaHacks.scala
+++ b/scalafix-core/shared/src/main/scala/org/langmeta/internal/ScalafixLangmetaHacks.scala
@@ -11,8 +11,10 @@ object ScalafixLangmetaHacks {
       message: String): String = {
     if (pos != Position.None) {
       val input = pos.input
+      val startLine = pos.startLine + 1
+      val startColumn = pos.startColumn + 1
       val header =
-        s"${input.syntax}:${pos.startLine + 1}: $severity: $message"
+        s"${input.syntax}:$startLine:$startColumn $severity: $message"
       val line = {
         val start = input.lineToOffset(pos.startLine)
         val notEof = start < input.chars.length

--- a/scalafix-core/shared/src/main/scala/org/langmeta/internal/ScalafixLangmetaHacks.scala
+++ b/scalafix-core/shared/src/main/scala/org/langmeta/internal/ScalafixLangmetaHacks.scala
@@ -14,7 +14,7 @@ object ScalafixLangmetaHacks {
       val startLine = pos.startLine + 1
       val startColumn = pos.startColumn + 1
       val header =
-        s"${input.syntax}:$startLine:$startColumn $severity: $message"
+        s"${input.syntax}:$startLine:$startColumn: $severity: $message"
       val line = {
         val start = input.lineToOffset(pos.startLine)
         val notEof = start < input.chars.length

--- a/scalafix-testkit/src/test/scala/scalafix/testkit/AssertDeltaSuite.scala
+++ b/scalafix-testkit/src/test/scala/scalafix/testkit/AssertDeltaSuite.scala
@@ -10,7 +10,7 @@ import scala.meta.dialects.Scala212
 
 import scalafix.lint.{LintMessage, LintSeverity}
 
-class AssertDeltaSuite() extends FunSuite {
+class AssertDeltaSuite() extends FunSuite with DiffAssertions {
   test("associate assert and reported message") {
     val input = Input.VirtualFile(
       path = "foo/bar/Disable.scala",
@@ -66,8 +66,6 @@ class AssertDeltaSuite() extends FunSuite {
 
     val obtained = diff.toString
 
-    // println(obtained)
-
     val expected =
       """|===========> Mismatch  <===========
          |
@@ -75,7 +73,7 @@ class AssertDeltaSuite() extends FunSuite {
          |Option.get is the root of all evils
          |  Option(1).get /* assert: Disable.get
          |            ^
-         |Expected: foo/bar/Disable.scala:2:13: error:
+         |Expected: foo/bar/Disable.scala:2:14: error:
          |Option.get is the root of all evils
          |  Option(1).get /* assert: Disable.get
          |             ^
@@ -91,7 +89,7 @@ class AssertDeltaSuite() extends FunSuite {
          |Option.get is the root of all evils
          |  Option(2).get // assert: Disable.foo
          |            ^
-         |Expected: foo/bar/Disable.scala:7:13: error:
+         |Expected: foo/bar/Disable.scala:7:17: error:
          |  Option(2).get // assert: Disable.foo
          |                ^
          |Diff:
@@ -138,12 +136,6 @@ class AssertDeltaSuite() extends FunSuite {
          |    ^
          |""".stripMargin
 
-    val diffStr =
-      DiffAssertions.compareContents(
-        expected,
-        obtained
-      )
-
-    assert(diffStr.isEmpty)
+    assertNoDiff(expected, obtained.replaceAllLiterally(" \n", "\n"))
   }
 }

--- a/scalafix-testkit/src/test/scala/scalafix/testkit/AssertDeltaSuite.scala
+++ b/scalafix-testkit/src/test/scala/scalafix/testkit/AssertDeltaSuite.scala
@@ -71,27 +71,27 @@ class AssertDeltaSuite() extends FunSuite {
     val expected =
       """|===========> Mismatch  <===========
          |
-         |Obtained: foo/bar/Disable.scala:2: error: [Disable.get]: 
+         |Obtained: foo/bar/Disable.scala:2:13 error: [Disable.get]:
          |Option.get is the root of all evils
          |  Option(1).get /* assert: Disable.get
          |            ^
-         |Expected: foo/bar/Disable.scala:2: error: 
+         |Expected: foo/bar/Disable.scala:2:13 error:
          |Option.get is the root of all evils
          |  Option(1).get /* assert: Disable.get
          |             ^
          |Diff:
-         |  Option(1).get 
+         |  Option(1).get
          |             ^-- asserted
          |            ^-- reported
          |
          |
          |---------------------------------------
          |
-         |Obtained: foo/bar/Disable.scala:7: error: [Disable.get]: 
+         |Obtained: foo/bar/Disable.scala:7:13 error: [Disable.get]:
          |Option.get is the root of all evils
          |  Option(2).get // assert: Disable.foo
          |            ^
-         |Expected: foo/bar/Disable.scala:7: error: 
+         |Expected: foo/bar/Disable.scala:7:13 error:
          |  Option(2).get // assert: Disable.foo
          |                ^
          |Diff:
@@ -100,40 +100,40 @@ class AssertDeltaSuite() extends FunSuite {
          |
          |===========> Unexpected <===========
          |
-         |foo/bar/Disable.scala:11: error: [Disable.get]: 
+         |foo/bar/Disable.scala:11:13 error: [Disable.get]:
          |Option.get is the root of all evils
          |  Option(4).get
          |            ^
          |
          |---------------------------------------
          |
-         |foo/bar/Disable.scala:15: error: [Disable.get]: 
+         |foo/bar/Disable.scala:15:13 error: [Disable.get]:
          |Option.get is the root of all evils
          |  Option(6).get
          |            ^
          |
          |---------------------------------------
          |
-         |foo/bar/Disable.scala:19: error: [Disable.get]: 
+         |foo/bar/Disable.scala:19:13 error: [Disable.get]:
          |Option.get is the root of all evils
          |  Option(8).get
          |            ^
          |
          |===========> Unreported <===========
          |
-         |foo/bar/Disable.scala:9: error: 
+         |foo/bar/Disable.scala:9:5 error:
          |  3 // assert: Disable.get
          |    ^
          |
          |---------------------------------------
          |
-         |foo/bar/Disable.scala:13: error: 
+         |foo/bar/Disable.scala:13:5 error:
          |  5 // assert: Disable.get
          |    ^
          |
          |---------------------------------------
          |
-         |foo/bar/Disable.scala:17: error: 
+         |foo/bar/Disable.scala:17:5 error:
          |  7 // assert: Disable.get
          |    ^
          |""".stripMargin

--- a/scalafix-testkit/src/test/scala/scalafix/testkit/AssertDeltaSuite.scala
+++ b/scalafix-testkit/src/test/scala/scalafix/testkit/AssertDeltaSuite.scala
@@ -71,11 +71,11 @@ class AssertDeltaSuite() extends FunSuite {
     val expected =
       """|===========> Mismatch  <===========
          |
-         |Obtained: foo/bar/Disable.scala:2:13 error: [Disable.get]:
+         |Obtained: foo/bar/Disable.scala:2:13: error: [Disable.get]:
          |Option.get is the root of all evils
          |  Option(1).get /* assert: Disable.get
          |            ^
-         |Expected: foo/bar/Disable.scala:2:13 error:
+         |Expected: foo/bar/Disable.scala:2:13: error:
          |Option.get is the root of all evils
          |  Option(1).get /* assert: Disable.get
          |             ^
@@ -87,11 +87,11 @@ class AssertDeltaSuite() extends FunSuite {
          |
          |---------------------------------------
          |
-         |Obtained: foo/bar/Disable.scala:7:13 error: [Disable.get]:
+         |Obtained: foo/bar/Disable.scala:7:13: error: [Disable.get]:
          |Option.get is the root of all evils
          |  Option(2).get // assert: Disable.foo
          |            ^
-         |Expected: foo/bar/Disable.scala:7:13 error:
+         |Expected: foo/bar/Disable.scala:7:13: error:
          |  Option(2).get // assert: Disable.foo
          |                ^
          |Diff:
@@ -100,40 +100,40 @@ class AssertDeltaSuite() extends FunSuite {
          |
          |===========> Unexpected <===========
          |
-         |foo/bar/Disable.scala:11:13 error: [Disable.get]:
+         |foo/bar/Disable.scala:11:13: error: [Disable.get]:
          |Option.get is the root of all evils
          |  Option(4).get
          |            ^
          |
          |---------------------------------------
          |
-         |foo/bar/Disable.scala:15:13 error: [Disable.get]:
+         |foo/bar/Disable.scala:15:13: error: [Disable.get]:
          |Option.get is the root of all evils
          |  Option(6).get
          |            ^
          |
          |---------------------------------------
          |
-         |foo/bar/Disable.scala:19:13 error: [Disable.get]:
+         |foo/bar/Disable.scala:19:13: error: [Disable.get]:
          |Option.get is the root of all evils
          |  Option(8).get
          |            ^
          |
          |===========> Unreported <===========
          |
-         |foo/bar/Disable.scala:9:5 error:
+         |foo/bar/Disable.scala:9:5: error:
          |  3 // assert: Disable.get
          |    ^
          |
          |---------------------------------------
          |
-         |foo/bar/Disable.scala:13:5 error:
+         |foo/bar/Disable.scala:13:5: error:
          |  5 // assert: Disable.get
          |    ^
          |
          |---------------------------------------
          |
-         |foo/bar/Disable.scala:17:5 error:
+         |foo/bar/Disable.scala:17:5: error:
          |  7 // assert: Disable.get
          |    ^
          |""".stripMargin

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSyntacticTests.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSyntacticTests.scala
@@ -102,7 +102,10 @@ class CliSyntacticTests extends BaseCliTest {
     ),
     expectedLayout = s"""/foobar.scala
                         |$original""".stripMargin,
-    expectedExit = ExitStatus.LinterError
+    expectedExit = ExitStatus.LinterError,
+    outputAssert = { out =>
+      assert(out.contains("foobar.scala:1:1"))
+    }
   )
 
   check(


### PR DESCRIPTION
This makes it easy to extract the exact position from the cli to
display in the editor.

Fixes #460 

Review @fommil