### PR TITLE
Add methods for dealing with whitespaces

### DIFF
--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -24,11 +24,14 @@ object Mima {
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "scalafix.rule.RuleCtx.printLintMessage"),
       ProblemFilters.exclude[ReversedMissingMethodProblem](
-        "scalafix.rule.RuleCtx.filterLintMessage"
-      ),
+        "scalafix.rule.RuleCtx.filterLintMessage"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
-        "scalafix.cli.CliRunner.this"
-      )
+        "scalafix.cli.CliRunner.this"),
+      ProblemFilters.exclude[FinalClassProblem]("scalafix.util.TokenList"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "scalafix.util.TokenList.leadingSpaces"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "scalafix.util.TokenList.trailingSpaces")
     )
   }
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/RuleCtxImpl.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/RuleCtxImpl.scala
@@ -32,7 +32,7 @@ case class RuleCtxImpl(tree: Tree, config: ScalafixConfig) extends RuleCtx {
   override def toString: String = syntax
   def toks(t: Tree): Tokens = t.tokens(config.dialect)
   lazy val tokens: Tokens = tree.tokens(config.dialect)
-  lazy val tokenList: TokenList = new TokenList(tokens)
+  lazy val tokenList: TokenList = TokenList(tokens)
   lazy val matchingParens: MatchingParens = MatchingParens(tokens)
   lazy val comments: AssociatedComments = AssociatedComments(tokens)
   lazy val input: Input = tokens.head.input

--- a/scalafix-core/shared/src/main/scala/scalafix/util/TokenList.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/util/TokenList.scala
@@ -6,7 +6,7 @@ import scala.meta.tokens.Token
 import scala.meta.tokens.Tokens
 
 /** Helper to traverse tokens as a doubly linked list.  */
-class TokenList(tokens: Tokens) {
+final class TokenList private (tokens: Tokens) {
   def trailing(token: Token): SeqView[Token, IndexedSeq[Token]] =
     tokens.view(tok2idx(token), tokens.length).drop(1)
   def leading(token: Token): SeqView[Token, IndexedSeq[Token]] =
@@ -59,4 +59,13 @@ class TokenList(tokens: Tokens) {
     }
   }
 
+  def leadingSpaces(token: Token): SeqView[Token, IndexedSeq[Token]] =
+    leading(token).takeWhile(_.is[Token.Space])
+
+  def trailingSpaces(token: Token): SeqView[Token, IndexedSeq[Token]] =
+    trailing(token).takeWhile(_.is[Token.Space])
+}
+
+object TokenList {
+  def apply(tokens: Tokens): TokenList = new TokenList(tokens)
 }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/util/TokenListTest.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/util/TokenListTest.scala
@@ -6,21 +6,90 @@ import scalafix.util.TokenList
 
 class TokenListTest extends FunSuite {
 
-  val tokens = "".tokenize.get // this contains two tokens: beginningOfFile and endOfFile
-  val firstToken = tokens.head
-  val lastToken = tokens.last
-  val tokenList = new TokenList(tokens)
+  val emptyFileTokens = "".tokenize.get // this contains two tokens: BOF and EOF
+  val nonEmptyFileTokens =
+    """package foo
+      |
+      |object Bar {
+      | val baz   =   10
+      |}
+    """.stripMargin.tokenize.get
 
-  test("Prev returns the firstToken when is given the firstToken") {
-    assert(tokenList.prev(firstToken) == firstToken)
-    assert(tokenList.prev(tokens.last) == firstToken)
+  test("prev returns the preceding token") {
+    val tokenList = TokenList(emptyFileTokens)
+    assert(tokenList.prev(emptyFileTokens.last) == emptyFileTokens.head)
   }
 
-  test("Slice gives an empty list with same token as inputs") {
-    assert(tokenList.slice(firstToken, firstToken) == Seq())
+  test("prev returns self if there is no preceding token") {
+    val tokenList = TokenList(emptyFileTokens)
+    assert(tokenList.prev(emptyFileTokens.head) == emptyFileTokens.head)
   }
 
-  test("Next breaks gives the lastToken if it is given lastToken") {
-    assert(tokenList.next(lastToken) == lastToken)
+  test("next returns the following token") {
+    val tokenList = TokenList(emptyFileTokens)
+    assert(tokenList.next(emptyFileTokens.head) == emptyFileTokens.last)
+  }
+
+  test("next returns self if there is no following token") {
+    val tokenList = TokenList(emptyFileTokens)
+    assert(tokenList.next(emptyFileTokens.last) == emptyFileTokens.last)
+  }
+
+  test("slice returns an empty seq if there is no token in between") {
+    val tokenList = TokenList(emptyFileTokens)
+    assert(tokenList.slice(emptyFileTokens.head, emptyFileTokens.head) == Seq())
+  }
+
+  test("slice returns all tokens between from/to tokens") {
+    val Some(kwObject) = nonEmptyFileTokens.find(_.is[Token.KwObject])
+    val Some(leftBrace) = nonEmptyFileTokens.find(_.is[Token.LeftBrace])
+    val tokenList = TokenList(nonEmptyFileTokens)
+
+    val slice = tokenList.slice(kwObject, leftBrace)
+    assert(slice.size == 3)
+    val Seq(space1, bar, space2) = slice
+    assert(space1.is[Token.Space])
+    assert(bar.syntax.equals("Bar"))
+    assert(space2.is[Token.Space])
+  }
+
+  test("leadingSpaces returns all spaces preceding a token") {
+    val Some(equals) = nonEmptyFileTokens.find(_.is[Token.Equals])
+    val tokenList = TokenList(nonEmptyFileTokens)
+
+    val spaces = tokenList.leadingSpaces(equals)
+    assert(spaces.size == 3)
+    val Seq(s1, s2, s3) = spaces
+    assert(s1 == tokenList.prev(equals))
+    assert(s2 == tokenList.prev(s1))
+    assert(s3 == tokenList.prev(s2))
+  }
+
+  test(
+    "leadingSpaces returns an empty seq if there are no spaces preceding a token") {
+    val Some(kwPackage) = nonEmptyFileTokens.find(_.is[Token.KwPackage])
+    val tokenList = TokenList(nonEmptyFileTokens)
+
+    assert(tokenList.leadingSpaces(kwPackage) == Seq())
+  }
+
+  test("trailingSpaces returns all spaces following a token") {
+    val Some(equals) = nonEmptyFileTokens.find(_.is[Token.Equals])
+    val tokenList = TokenList(nonEmptyFileTokens)
+
+    val spaces = tokenList.trailingSpaces(equals)
+    assert(spaces.size == 3)
+    val Seq(s1, s2, s3) = spaces
+    assert(s1 == tokenList.next(equals))
+    assert(s2 == tokenList.next(s1))
+    assert(s3 == tokenList.next(s2))
+  }
+
+  test(
+    "trailingSpaces returns an empty seq if there are no spaces following a token") {
+    val Some(rightBrace) = nonEmptyFileTokens.find(_.is[Token.RightBrace])
+    val tokenList = TokenList(nonEmptyFileTokens)
+
+    assert(tokenList.trailingSpaces(rightBrace) == Seq())
   }
 }


### PR DESCRIPTION
When working on a scalafix rule for `scala/collection-strawman` I implemented my own logic to get rid of whitespaces. @olafurpg [mentioned in the review](https://github.com/scala/collection-strawman/pull/291/files#r149894285) that it would be nice to have such functionality supported by Scalafix. Later I realized that there was even an issue filed by @gabro to look into that: #370.

I explored a few alternatives to introduce the functionality. There might be better ways to achieve this, so I'd appreciate your feedback and will be willing to accept suggestions.

The code changes in this PR implement the approach that I personally prefer. There are other 2 alternatives available on separate branches (those need some polishing).

1 - `trimLeft` / `trimRight` / `trim` (https://github.com/scalacenter/scalafix/compare/master...marcelocenerine:trim):
These methods behave similarly to Java's `String.trim` in the sense that they eliminate not only spaces but newline tokens as well. This may not be flexible enough for users who just want to get rid of spaces/tabs and preserve blank lines.
The naming is based on what I originally suggested in the comment above as well as by @ShaneDelmore [here](https://github.com/scalacenter/scalafix/issues/370#issuecomment-331550417)

2 - `trimLeft` / `trimRight` / `trim` with a `includingNewline` parameter (code in the PR):
This is similar to the alternative above, except that the trimming methods take an optional parameter (set to `true` by default) that can be used to indicate when newlines should be preserved. This is based on @gabro's suggestion on #370

3 - `ctx.whitespaces.leftTo` / `rightTo` / `around` (https://github.com/scalacenter/scalafix/compare/master...marcelocenerine:trim_whitespaces):
`RuleCtx` already has ~30 methods and adding 3 more would make it more bloated (#380). This approach basically introduces an utility class that groups functions to find/select whitespaces (similar to `MatchingParens` and `AssociatedComments`). The output of its methods can be passed to `ctx.removeTokens` to perform the actual removal. Example:
```
ctx.removeTokens(ctx.whitespaces.leftTo(tk))
``` 