### PR TITLE
Second stab at 2.12.4.

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,4 +1,5 @@
 -Dfile.encoding=UTF8
+-Xss8m
 -Xms1G
 -Xmx6G
 -XX:ReservedCodeCacheSize=250M

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   // https://travis-ci.org/scalacenter/scalafix/jobs/303142842#L4658
   // as well as https://github.com/scala/bug/issues/10609
   def scala211 = "2.11.11"
-  def scala212 = "2.12.3"
+  def scala212 = "2.12.4"
   val currentScalaVersion = scala212
 
   def sbt013 = "0.13.6"


### PR DESCRIPTION
Last time we upgraded to 2.12.4 the CI failed with a missing shapeless
implicit error from case-app. I can reproduce this error locally only on
the first `sbt compile`. Running the command the seconds time succeeds
compilation. I want to see if CI fails again, and investigate if
`-YdisableFlatCpCaching` can fix the error.

EDIT, `-YdisableFlatCpCaching` did not seem to fix the error. Let me try and remove ArgParserImplicits.