### PR TITLE
Clean up term display output.

### DIFF
--- a/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
+++ b/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
@@ -62,7 +62,7 @@ sealed abstract case class CliRunner(
     val display = new TermDisplay(
       new OutputStreamWriter(
         if (cli.stdout) cli.common.err else cli.common.out),
-      fallbackMode = cli.nonInteractive || TermDisplay.defaultFallbackMode)
+      fallbackMode = true)
     if (inputs.length > 10) display.init()
     val msg = cli.projectIdPrefix + s"Running ${rule.name}"
     display.startTask(msg, common.workingDirectoryFile)

--- a/scalafix-cli/src/main/scala/scalafix/internal/cli/TermDisplay.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/cli/TermDisplay.scala
@@ -489,7 +489,7 @@ class TermDisplay(
   }
 
   override def completedTask(url: String, success: Boolean): Unit =
-    updateThread.removeEntry(url, success, s"Downloaded $url\n")(x => x)
+    updateThread.removeEntry(url, success, s"Completed $url\n")(x => x)
 
   override def checkingUpdates(
       url: String,


### PR DESCRIPTION

- s/Downloaded/Completed/, fixes #471
- Use fallback mode by default. The non-fallback mode mixes with the
  buffers from reported linter messages.