### PR TITLE
Fix #493, handle synthetics and symbol signatures in Disable.

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/Disable.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/Disable.scala
@@ -30,21 +30,34 @@ final case class Disable(index: SemanticdbIndex, config: DisableConfig)
       .getOrElse("disable", "Disable")(DisableConfig.default)
       .map(Disable(index, _))
 
-  override def check(ctx: RuleCtx): Seq[LintMessage] =
-    ctx.index.names.collect {
+  override def check(ctx: RuleCtx): Seq[LintMessage] = {
+    val buffer = List.newBuilder[LintMessage]
+    def add(name: ResolvedName): Unit = name match {
       case ResolvedName(
           pos,
           disabledSymbol(symbol @ Symbol.Global(_, signature)),
-          false) => {
-
-        val message =
-          config
-            .customMessage(symbol)
-            .getOrElse(s"${signature.name} is disabled")
-
-        errorCategory
+          false) =>
+        val (details, caret) = pos.input match {
+          case synthetic @ Input.Synthetic(_, input, start, end) =>
+            // For synthetics the caret should point to the original position
+            // but display the inferred code.
+            s" and it got inferred as `${synthetic.text}`" ->
+              Position.Range(input, start, end)
+          case _ =>
+            "" -> pos
+        }
+        val message = config
+          .customMessage(symbol)
+          .getOrElse(s"${signature.name} is disabled$details")
+        buffer += errorCategory
           .copy(id = signature.name)
-          .at(message, pos)
-      }
+          .at(message, caret)
+      case _ =>
     }
+    ctx.index.documents.foreach { document =>
+      document.names.foreach(add)
+      document.synthetics.foreach(_.names.foreach(add))
+    }
+    buffer.result()
+  }
 }

--- a/scalafix-tests/input/src/main/scala/test/Disable.scala
+++ b/scalafix-tests/input/src/main/scala/test/Disable.scala
@@ -13,9 +13,13 @@ Disable.symbols = [
          |...
          |// scalafix:on Option.get"""
   }
+  "scala.collection.mutable.ListBuffer"
+  "scala.Predef.any2stringadd"
 ]
 */
 package test
+
+import scala.collection.mutable.ListBuffer
 
 case object Disable {
 
@@ -52,4 +56,10 @@ If you must Option.get, wrap the code block with
 ...
 // scalafix:on Option.get
 */
+  val l: ListBuffer[Int] =
+    scala.collection.mutable.ListBuffer.empty[Int] // scalafix:ok Disable.ListBuffer
+  List(1) + "any2stringadd" /* assert: Disable.any2stringadd
+  ^
+any2stringadd is disabled and it got inferred as `scala.Predef.any2stringadd[List[Int]](*)`
+  */
 }

--- a/scalafix-tests/input/src/main/scala/test/Disable.scala
+++ b/scalafix-tests/input/src/main/scala/test/Disable.scala
@@ -56,8 +56,7 @@ If you must Option.get, wrap the code block with
 ...
 // scalafix:on Option.get
 */
-  val l: ListBuffer[Int] =
-    scala.collection.mutable.ListBuffer.empty[Int] // scalafix:ok Disable.ListBuffer
+  val l: ListBuffer[Int] = scala.collection.mutable.ListBuffer.empty[Int] // assert: Disable.ListBuffer
   List(1) + "any2stringadd" /* assert: Disable.any2stringadd
   ^
 any2stringadd is disabled and it got inferred as `scala.Predef.any2stringadd[List[Int]](*)`


### PR DESCRIPTION
Previously, Disable reported an error on the positions of any
ResolvedName to a disabled symbol, including Input.Synthetic and
Input.Denotation which are invisible and don't appear in the source
file. Now Disable ignores symbol signatures and for synthetics it
points a caret at the position where the synthetic got expanded
and includes the pretty-printed representation of the synthetic
to help make sense of the error message.

Review @vovapolu