### PR TITLE
Enable scalafix in the scalafix build.

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,4 +1,9 @@
 rules = [
   RemoveUnusedImports
   RemoveUnusedTerms
+  ExplicitResultTypes
 ]
+
+ExplicitResultTypes {
+  unsafeShortenNames = true
+}

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,4 @@
+rules = [
+  RemoveUnusedImports
+  RemoveUnusedTerms
+]

--- a/build.sbt
+++ b/build.sbt
@@ -201,6 +201,7 @@ lazy val `scalafix-sbt` = project
     scriptedBufferLog := false
   )
   .enablePlugins(BuildInfoPlugin)
+  .disablePlugins(ScalafixPlugin)
 
 val testkit = MultiScalaProject(
   "testkit",
@@ -254,7 +255,10 @@ val testsOutput = TestProject(
   _.settings(
     noPublish,
     semanticdbSettings,
-    scalacOptions -= warnUnusedImports,
+    scalacOptions --= List(
+      warnUnusedImports,
+      "-Xlint"
+    ),
     testsInputOutputSetting
   ))
 
@@ -272,6 +276,7 @@ lazy val testsOutputDotty = project
     libraryDependencies := libraryDependencies.value.map(_.withDottyCompat()),
     scalacOptions := Nil
   )
+  .disablePlugins(ScalafixPlugin)
 
 lazy val testsInputSbt = project
   .in(file("scalafix-tests/input-sbt"))
@@ -290,6 +295,7 @@ lazy val testsInputSbt = project
     addCompilerPlugin(
       "org.scalameta" % "semanticdb-sbt" % semanticdbSbt cross CrossVersion.full)
   )
+  .disablePlugins(ScalafixPlugin)
 
 lazy val testsOutputSbt = project
   .in(file("scalafix-tests/output-sbt"))
@@ -297,6 +303,7 @@ lazy val testsOutputSbt = project
     noPublish,
     sbtPlugin := true
   )
+  .disablePlugins(ScalafixPlugin)
 
 def unit(
     scalav: String,

--- a/project/MultiScalaProject.scala
+++ b/project/MultiScalaProject.scala
@@ -55,8 +55,8 @@ class MultiScalaCrossProject(
     extends MultiScala {
   def apply(
       scalaV: String,
-      configurePerScala: CrossProject => CrossProject = x => x)
-    : CrossProject = {
+      configurePerScala: CrossProject => CrossProject = x => x
+  ): CrossProject = {
     val projectId = projectIdPerScala(name, scalaV)
     val fullName = s"scalafix-$name"
     val src = srcCross(fullName) _
@@ -126,7 +126,7 @@ object TestProject {
     MultiScalaProject(
       s"tests${sub.capitalize}",
       base(sub),
-      configure
+      configure.andThen(_.disablePlugins(scalafix.sbt.ScalafixPlugin))
     )
 
 }

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -39,6 +39,7 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
     )
     lazy val warnUnusedImports = "-Ywarn-unused-import"
     lazy val compilerOptions = Seq(
+      "-Xlint",
       "-deprecation",
       "-encoding",
       "UTF-8",
@@ -189,6 +190,7 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
     },
     commands += Command.command("ci-fast-212") { s =>
       "scalafix/test" ::
+        "scalafix/scalafixTest" :: // run scalafix checks
         s
     },
     commands += Command.command("ci-fast-211") { s =>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,6 +12,7 @@ addSbtPlugin(
   "com.eed3si9n" % "sbt-assembly" % "0.14.5" exclude ("org.apache.maven", "maven-plugin-api"))
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.9.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.7")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.15")
 addSbtPlugin("com.47deg" % "sbt-microsites" % "0.7.4")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.1")

--- a/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
+++ b/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
@@ -1,8 +1,7 @@
 package scalafix
 package cli
 
-import java.io.{File, OutputStreamWriter, InputStream}
-import java.lang.ProcessBuilder
+import java.io.{File, OutputStreamWriter}
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.Path
@@ -39,7 +38,6 @@ import scalafix.reflect.ScalafixReflect
 import scalafix.syntax._
 import metaconfig.Configured.Ok
 import metaconfig._
-import org.scalameta.logger
 
 sealed abstract case class CliRunner(
     sourceroot: AbsolutePath,

--- a/scalafix-cli/src/main/scala/scalafix/internal/jgit/DiffDisable.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/jgit/DiffDisable.scala
@@ -3,13 +3,10 @@ package scalafix.internal.jgit
 import metaconfig.Configured
 
 import java.nio.file.Path
-import java.io.InputStream
 
 import org.langmeta.inputs.Input
 
 import scala.collection.mutable.StringBuilder
-
-import scala.io.Source
 
 import scalafix.internal.util.IntervalSet
 import scalafix.LintMessage

--- a/scalafix-cli/src/main/scala/scalafix/internal/jgit/JGitDiff.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/jgit/JGitDiff.scala
@@ -5,8 +5,6 @@ import java.nio.file.Path
 import org.eclipse.jgit.util.FS
 import org.eclipse.jgit.lib.RepositoryCache
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
-import org.eclipse.jgit.api.Git
-import org.eclipse.jgit.api.errors.GitAPIException
 import org.eclipse.jgit.diff.DiffEntry.ChangeType._
 import org.eclipse.jgit.diff.DiffFormatter
 import org.eclipse.jgit.errors.AmbiguousObjectException
@@ -14,14 +12,8 @@ import org.eclipse.jgit.errors.IncorrectObjectTypeException
 import org.eclipse.jgit.errors.RevisionSyntaxException
 import org.eclipse.jgit.errors.MissingObjectException
 import org.eclipse.jgit.patch.FileHeader
-import org.eclipse.jgit.lib.ObjectReader
-import org.eclipse.jgit.lib.Ref
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.lib.ObjectId
-import org.eclipse.jgit.lib.ProgressMonitor
-import org.eclipse.jgit.dircache.DirCacheIterator
-import org.eclipse.jgit.revwalk.RevCommit
-import org.eclipse.jgit.revwalk.RevTree
 import org.eclipse.jgit.revwalk.RevWalk
 import org.eclipse.jgit.treewalk.AbstractTreeIterator
 import org.eclipse.jgit.treewalk.CanonicalTreeParser

--- a/scalafix-core/js/src/main/scala/scalafix/internal/config/MetaconfigParser.scala
+++ b/scalafix-core/js/src/main/scala/scalafix/internal/config/MetaconfigParser.scala
@@ -1,5 +1,6 @@
 package scalafix.internal.config
 
 object MetaconfigParser {
-  implicit val parser = metaconfig.hocon.hoconMetaconfigParser
+  implicit val parser: metaconfig.MetaconfigParser =
+    metaconfig.hocon.hoconMetaconfigParser
 }

--- a/scalafix-core/jvm/src/main/scala/scalafix/internal/config/MetaconfigParser.scala
+++ b/scalafix-core/jvm/src/main/scala/scalafix/internal/config/MetaconfigParser.scala
@@ -1,6 +1,6 @@
 package scalafix.internal.config
 
 object MetaconfigParser {
-  implicit val parser =
+  implicit val parser: metaconfig.MetaconfigParser =
     metaconfig.typesafeconfig.typesafeConfigMetaconfigParser
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/config/CustomMessage.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/config/CustomMessage.scala
@@ -1,11 +1,7 @@
 package scalafix
 package config
 
-import metaconfig.{Conf, ConfError, ConfDecoder, Configured, Metaconfig}
-import org.langmeta._
-import scalafix.internal.config.MetaconfigPendingUpstream.XtensionConfScalafix
-
-import scala.language.implicitConversions
+import metaconfig.{Conf, ConfDecoder}
 
 class CustomMessage[T](
     val value: T,

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/ConfigRulePatches.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/ConfigRulePatches.scala
@@ -25,5 +25,5 @@ case class ConfigRulePatches(
 }
 
 object ConfigRulePatches {
-  val default = ConfigRulePatches()
+  val default: ConfigRulePatches = ConfigRulePatches()
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/DisableConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/DisableConfig.scala
@@ -7,7 +7,7 @@ import org.langmeta.Symbol
 import scalafix.internal.util.SymbolOps
 
 case class DisableConfig(symbols: List[CustomMessage[Symbol.Global]] = Nil) {
-  def allSymbols = symbols.map(_.value)
+  def allSymbols: List[Symbol.Global] = symbols.map(_.value)
 
   private val messageBySymbol: Map[String, CustomMessage[Symbol.Global]] =
     symbols
@@ -28,6 +28,6 @@ case class DisableConfig(symbols: List[CustomMessage[Symbol.Global]] = Nil) {
 }
 
 object DisableConfig {
-  val default = DisableConfig()
+  val default: DisableConfig = DisableConfig()
   implicit val reader: ConfDecoder[DisableConfig] = default.reader
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/DisableSyntaxConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/DisableSyntaxConfig.scala
@@ -2,7 +2,6 @@ package scalafix
 package internal.config
 
 import metaconfig.{Conf, ConfError, ConfDecoder, Configured}
-import org.langmeta._
 import MetaconfigPendingUpstream.XtensionConfScalafix
 
 import scala.meta.tokens.Token

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/DisableSyntaxConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/DisableSyntaxConfig.scala
@@ -47,7 +47,7 @@ case class DisableSyntaxConfig(
 }
 
 object DisableSyntaxConfig {
-  val default = DisableSyntaxConfig()
+  val default: DisableSyntaxConfig = DisableSyntaxConfig()
   implicit val reader: ConfDecoder[DisableSyntaxConfig] = default.reader
 }
 
@@ -60,7 +60,7 @@ object Keyword {
       None
     }
   }
-  val all = List(
+  val all: List[String] = List(
     "abstract",
     "case",
     "catch",
@@ -103,7 +103,7 @@ object Keyword {
     "with",
     "yield"
   )
-  val set = all.toSet
+  val set: Set[String] = all.toSet
   private val kwSet = all.map(kw => s"Kw${kw.capitalize}").toSet
 }
 

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/ExplicitResultTypesConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/ExplicitResultTypesConfig.scala
@@ -29,7 +29,7 @@ case class ExplicitResultTypesConfig(
 }
 
 object ExplicitResultTypesConfig {
-  val default = ExplicitResultTypesConfig()
+  val default: ExplicitResultTypesConfig = ExplicitResultTypesConfig()
   implicit val reader: ConfDecoder[ExplicitResultTypesConfig] = default.reader
 }
 
@@ -38,7 +38,8 @@ object MemberVisibility {
   case object Public extends MemberVisibility
   case object Protected extends MemberVisibility
   case object Private extends MemberVisibility
-  def all = List(Public, Protected, Private)
+  def all: List[MemberVisibility] =
+    List(Public, Protected, Private)
   implicit val readerMemberVisibility: ConfDecoder[MemberVisibility] =
     ReaderUtil.fromMap(all.map(x => x.toString -> x).toMap)
 }
@@ -48,7 +49,8 @@ object MemberKind {
   case object Def extends MemberKind
   case object Val extends MemberKind
   case object Var extends MemberKind
-  def all = List(Def, Val, Var)
+  def all: List[MemberKind] =
+    List(Def, Val, Var)
   implicit val readerMemberKind: ConfDecoder[MemberKind] =
     ReaderUtil.fromMap(all.map(x => x.toString -> x).toMap)
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/FilterMatcher.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/FilterMatcher.scala
@@ -31,8 +31,10 @@ case class FilterMatcher(
 }
 
 object FilterMatcher {
-  lazy val matchEverything = new FilterMatcher(".*".r, mkRegexp(Nil))
-  lazy val matchNothing = new FilterMatcher(mkRegexp(Nil), mkRegexp(Nil))
+  lazy val matchEverything: FilterMatcher =
+    new FilterMatcher(".*".r, mkRegexp(Nil))
+  lazy val matchNothing: FilterMatcher =
+    new FilterMatcher(mkRegexp(Nil), mkRegexp(Nil))
   implicit val reader: ConfDecoder[FilterMatcher] = matchEverything.reader
 
   def mkRegexp(filters: Seq[String]): Regex =

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/LazySemanticdbIndex.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/LazySemanticdbIndex.scala
@@ -23,7 +23,7 @@ class LazySemanticdbIndex(
 }
 
 object LazySemanticdbIndex {
-  lazy val empty = new LazySemanticdbIndex()
+  lazy val empty: LazySemanticdbIndex = new LazySemanticdbIndex()
   def apply(
       f: RuleKind => Option[SemanticdbIndex],
       cwd: AbsolutePath = AbsolutePath.workingDirectory): LazySemanticdbIndex =

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/LintConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/LintConfig.scala
@@ -32,5 +32,5 @@ case class LintConfig(
 }
 
 object LintConfig {
-  lazy val default = LintConfig()
+  lazy val default: LintConfig = LintConfig()
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/LogContext.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/LogContext.scala
@@ -12,5 +12,5 @@ object LogContext {
       implicit line: sourcecode.Line,
       file: sourcecode.File,
       enclosing: sourcecode.Enclosing
-  ) = LogContext(line, file, enclosing)
+  ): LogContext = LogContext(line, file, enclosing)
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/NoInferConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/NoInferConfig.scala
@@ -13,6 +13,6 @@ case class NoInferConfig(symbols: List[Symbol.Global] = Nil) {
 }
 
 object NoInferConfig {
-  val default = NoInferConfig()
+  val default: NoInferConfig = NoInferConfig()
   implicit val reader: ConfDecoder[NoInferConfig] = default.reader
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/PrintStreamReporter.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/PrintStreamReporter.scala
@@ -2,7 +2,6 @@ package scalafix.internal.config
 
 import java.io.OutputStream
 import scala.meta.Position
-import scala.meta.internal.inputs.XtensionPositionFormatMessage
 import java.io.PrintStream
 import java.util.concurrent.atomic.AtomicInteger
 import scalafix.internal.util.Severity

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/ScalafixConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/ScalafixConfig.scala
@@ -65,7 +65,7 @@ case class ScalafixConfig(
 
 object ScalafixConfig {
 
-  lazy val default = ScalafixConfig()
+  lazy val default: ScalafixConfig = ScalafixConfig()
   implicit lazy val ScalafixConfigDecoder: ConfDecoder[ScalafixConfig] =
     default.reader
 

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/ScalafixConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/ScalafixConfig.scala
@@ -1,8 +1,6 @@
 package scalafix
 package internal.config
 
-import scala.language.existentials
-
 import java.io.OutputStream
 import java.io.PrintStream
 import scala.meta._

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/ScalafixMetaconfigReaders.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/ScalafixMetaconfigReaders.scala
@@ -1,7 +1,6 @@
 package scalafix
 package internal.config
 
-import java.io.File
 import scala.meta.Ref
 import scala.meta._
 import scala.meta.parsers.Parse
@@ -15,7 +14,6 @@ import scalafix.internal.util.ClassloadRule
 import java.io.OutputStream
 import java.io.PrintStream
 import java.net.URI
-import java.net.URL
 import java.net.URLClassLoader
 import java.util.regex.Pattern
 import scala.collection.immutable.Seq
@@ -28,7 +26,6 @@ import metaconfig.Configured.Ok
 import scalafix.internal.config.MetaconfigParser.{parser => hoconParser}
 import scalafix.internal.rule.ConfigRule
 import scalafix.patch.TreePatch
-import org.scalameta.logger
 
 object ScalafixMetaconfigReaders extends ScalafixMetaconfigReaders
 // A collection of metaconfig.Reader instances that are shared across

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/patch/EscapeHatch.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/patch/EscapeHatch.scala
@@ -209,8 +209,6 @@ object EscapeHatch {
         rules: String,
         toogle: Toogle,
         anchorPosition: AnchorPosition): Unit = {
-      val toogledRules = splitRules(rules)
-
       toogle match {
         case Toogle.Disable =>
           currentlyDisabledRules = currentlyDisabledRules ++ splitRules(rules)

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/patch/ImportPatchOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/patch/ImportPatchOps.scala
@@ -16,10 +16,10 @@ import scala.meta._
 
 object ImportPatchOps {
   object symbols {
-    val Scala = Symbol("_root_.scala.")
-    val Predef = Symbol("_root_.scala.Predef.")
-    val Java = Symbol("_root_.java.lang.")
-    val Immutable = Symbol("_root_.scala.collection.immutable.")
+    val Scala: Symbol = Symbol("_root_.scala.")
+    val Predef: Symbol = Symbol("_root_.scala.Predef.")
+    val Java: Symbol = Symbol("_root_.java.lang.")
+    val Immutable: Symbol = Symbol("_root_.scala.collection.immutable.")
   }
 
   def isPredef(symbol: Symbol): Boolean = {

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/patch/ImportPatchOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/patch/ImportPatchOps.scala
@@ -13,7 +13,6 @@ import scalafix.rule.RuleCtx
 import scalafix.syntax._
 import scalafix.util.Newline
 import scala.meta._
-import org.scalameta.logger
 
 object ImportPatchOps {
   object symbols {

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/Disable.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/Disable.scala
@@ -7,7 +7,6 @@ import scalafix.lint.LintCategory
 import scalafix.lint.LintMessage
 import scalafix.rule.SemanticRule
 import scalafix.rule.{Rule, RuleCtx}
-import scalafix.syntax._
 import scalafix.util.SemanticdbIndex
 import scalafix.util.SymbolMatcher
 

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
@@ -1,15 +1,11 @@
 package scalafix.internal.rule
 
 import scala.meta._
-import scala.meta.tokens.Token.Comment
 import metaconfig.{Conf, Configured}
 import scalafix.rule.{Rule, RuleCtx}
 import scalafix.lint.LintMessage
 import scalafix.lint.LintCategory
-import scalafix.util.SymbolMatcher
-import scalafix.internal.util.IntervalSet
 import scalafix.internal.config.{DisableSyntaxConfig, Keyword}
-import scalafix.syntax._
 
 final case class DisableSyntax(
     config: DisableSyntaxConfig = DisableSyntaxConfig())

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/ExplicitUnit.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/ExplicitUnit.scala
@@ -4,7 +4,6 @@ import scala.meta._
 import scalafix.Patch
 import scalafix.rule.Rule
 import scalafix.rule.RuleCtx
-import scalafix.rule.RuleName
 
 case object ExplicitUnit extends Rule("ExplicitUnit") {
   override def description: String =

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/NoFinalize.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/NoFinalize.scala
@@ -1,9 +1,7 @@
 package scalafix.internal.rule
 
 import scala.meta._
-import scala.meta.contrib._
 
-import metaconfig.{Conf, Configured}
 import scalafix.rule.Rule
 import scalafix.rule.RuleCtx
 import scalafix.lint.LintMessage

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/RemoveXmlLiterals.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/RemoveXmlLiterals.scala
@@ -5,6 +5,7 @@ import scala.meta._
 import scalafix.Patch
 import scalafix.rule.Rule
 import scalafix.rule.RuleCtx
+import scalafix.lint.LintCategory
 
 /* Rule Xml literals to Xml interpolators.
  *
@@ -27,7 +28,7 @@ case object RemoveXmlLiterals extends Rule("RemoveXmlLiterals") {
   override def description: String =
     "Rewrite that converts xml literals into interpolators for use with densh/scala-xml-quote"
 
-  val singleBracesEscape = LintCategory.warning(
+  val singleBracesEscape: LintCategory = LintCategory.warning(
     "singleBracesEscape",
     """Single braces don't need be escaped with {{ and }} inside xml interpolators, unlike xml literals.
       |For example <x>{{</x> is identical to xml"<x>{</x>". This Rule will replace all occurrences of

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/RuleCtxImpl.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/RuleCtxImpl.scala
@@ -35,7 +35,7 @@ case class RuleCtxImpl(tree: Tree, config: ScalafixConfig) extends RuleCtx {
   lazy val matchingParens: MatchingParens = MatchingParens(tokens)
   lazy val comments: AssociatedComments = AssociatedComments(tokens)
   lazy val input: Input = tokens.head.input
-  lazy val escapeHatch = EscapeHatch(tree, comments)
+  lazy val escapeHatch: EscapeHatch = EscapeHatch(tree, comments)
 
   // Debug utilities
   def index(implicit index: SemanticdbIndex): SemanticdbIndex =

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/RuleCtxImpl.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/RuleCtxImpl.scala
@@ -8,7 +8,6 @@ import scalafix._
 import scalafix.internal.config.ScalafixConfig
 import scalafix.internal.config.ScalafixMetaconfigReaders
 import scalafix.internal.patch.EscapeHatch
-import scalafix.internal.util.Severity
 import scalafix.internal.util.SymbolOps.Root
 import scalafix.patch.LintPatch
 import scalafix.patch.TokenPatch

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/DenotationOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/DenotationOps.scala
@@ -1,9 +1,10 @@
 package scalafix.internal.util
 
 import scala.meta._
+import scala.meta.Dialect
 
 object DenotationOps {
-  val defaultDialect =
+  val defaultDialect: Dialect =
     dialects.Scala212.copy(allowMethodTypes = true, allowTypeLambdas = true)
 
   def resultType(

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/SymbolGlobal.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/SymbolGlobal.scala
@@ -3,7 +3,6 @@ package scalafix.internal.util
 import scala.language.experimental.macros
 
 import scala.reflect.macros.blackbox.Context
-import scala.util.control.NonFatal
 import scala.{meta => m}
 import scalafix.internal.config.ScalafixMetaconfigReaders
 import metaconfig.Conf

--- a/scalafix-core/shared/src/main/scala/scalafix/patch/Patch.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/patch/Patch.scala
@@ -13,10 +13,8 @@ import scalafix.internal.patch.ImportPatchOps
 import scalafix.internal.patch.ReplaceSymbolOps
 import scalafix.internal.util.Failure
 import scalafix.internal.util.TokenOps
-import scalafix.internal.rule.RuleCtxImpl
 import scalafix.lint.LintMessage
 import scalafix.patch.TreePatch.ReplaceSymbol
-import scalafix.rule.RuleName
 import org.scalameta.logger
 
 /** A data structure that can produce a .patch file.

--- a/scalafix-core/shared/src/main/scala/scalafix/rule/RuleIdentifier.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/rule/RuleIdentifier.scala
@@ -11,6 +11,6 @@ final case class RuleIdentifier(
 }
 
 object RuleIdentifier {
-  def apply(value: String) =
+  def apply(value: String): RuleIdentifier =
     new RuleIdentifier(value, None)
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/rule/RuleName.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/rule/RuleName.scala
@@ -53,6 +53,6 @@ object RuleName {
       "Write the name explicitly as a string instead.",
     "0.5.0")
   implicit def generate(name: sourcecode.Name): RuleName = RuleName(name.value)
-  final val empty = new RuleName(Nil)
-  def apply(name: String) = new RuleName(RuleIdentifier(name) :: Nil)
+  final val empty: RuleName = new RuleName(Nil)
+  def apply(name: String): RuleName = new RuleName(RuleIdentifier(name) :: Nil)
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/syntax/package.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/syntax/package.scala
@@ -1,8 +1,5 @@
 package scalafix
 
-import scala.language.experimental.macros
-
-import scala.collection.immutable.Seq
 import scala.meta._
 import scala.meta.semanticdb.Symbol
 import scala.compat.Platform.EOL

--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ScalafixCompilerDecoder.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ScalafixCompilerDecoder.scala
@@ -1,6 +1,5 @@
 package scalafix.internal.reflect
 
-import java.io.File
 import java.io.FileNotFoundException
 import java.net.URL
 import java.nio.file.Files

--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ScalafixToolbox.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ScalafixToolbox.scala
@@ -17,7 +17,6 @@ import scalafix.internal.config.LazySemanticdbIndex
 import scalafix.internal.config.classloadRule
 import scalafix.internal.util.ClassloadRule
 import scalafix.rule.Rule
-import metaconfig.ConfDecoder
 import metaconfig.ConfError
 import metaconfig.Configured
 

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
@@ -1,7 +1,6 @@
 package scalafix
 package testkit
 
-import scala.collection.mutable
 import scalafix.syntax._
 import scala.meta._
 import scalafix.internal.util.EagerInMemorySemanticdbIndex
@@ -9,9 +8,6 @@ import org.scalameta.logger
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FunSuite
 import org.scalatest.exceptions.TestFailedException
-
-import scalafix.rule.RuleName
-import org.langmeta.internal.ScalafixLangmetaHacks
 
 import scala.util.matching.Regex
 

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliGitDiffTests.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliGitDiffTests.scala
@@ -1,19 +1,15 @@
 package scalafix.tests.cli
 
-import java.lang.ProcessBuilder
 import java.io.ByteArrayOutputStream
-import java.io.File
 import java.io.PrintStream
 import java.nio.charset.StandardCharsets
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Paths, Path, StandardOpenOption}
+import java.nio.file.{Files, Path, StandardOpenOption}
 
-import org.scalactic.source.Position
 import org.scalatest._
 import org.scalatest.FunSuite
 
 import scala.collection.immutable.Seq
-import scala.util._
 import scalafix.cli
 import scalafix.internal.cli.CommonOptions
 import scalafix.testkit.DiffAssertions
@@ -321,7 +317,7 @@ class CliGitDiffTests() extends FunSuite with DiffAssertions {
     def run(args: List[String]): String = {
       val baos = new ByteArrayOutputStream()
       val ps = new PrintStream(baos)
-      val exit = cli.Cli.runMain(
+      cli.Cli.runMain(
         args.to[Seq],
         CommonOptions(
           workingDirectory = workingDirectory.toAbsolutePath.toString,

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/reflect/ToolClasspathTests.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/reflect/ToolClasspathTests.scala
@@ -51,7 +51,6 @@ class ToolClasspathTests extends FunSuite with BeforeAndAfterAll {
     val decoder = ScalafixCompilerDecoder.baseCompilerDecoder(index)
     val obtained = decoder.read(Conf.Str(s"file:$tmp")).get
     val expectedName = "FormatRule"
-    val expectedDescription = "FormatRuleDescription"
     assert(obtained.name.value == expectedName)
   }
 
@@ -72,7 +71,6 @@ class ToolClasspathTests extends FunSuite with BeforeAndAfterAll {
     val decoder = ScalafixMetaconfigReaders.classloadRuleDecoder(index)
     val obtained = decoder.read(Conf.Str(s"class:custom.CustomRule")).get
     val expectedName = "CustomRule"
-    val expectedDescription = ""
     assert(obtained.name.value == expectedName)
     assert(decoder.read(Conf.Str("class:does.not.Exist")).isNotOk)
   }


### PR DESCRIPTION
I think long overdue to bootstrap and start using scalafix to develop scalafix 😄 We can start with remove unused imports and terms and then add more as we go. I found NoInfer to be too noisy, I will soon have a PR making it possible to tweak the noise by excluding certain symbols.