### PR TITLE
Bring scalafix-sbt parser up to par with the cli #518

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -154,7 +154,7 @@ val cli = MultiScalaProject(
       "com.github.alexarchambault" %% "case-app" % "1.2.0",
       "org.typelevel" %% "paiges-core" % "0.2.0",
       "com.martiansoftware" % "nailgun-server" % "0.9.1",
-      "org.eclipse.jgit" % "org.eclipse.jgit" % "4.5.4.201711221230-r",
+      jgit,
       "ch.qos.logback" % "logback-classic" % "1.2.3"
     )
   )
@@ -182,7 +182,7 @@ lazy val `scalafix-sbt` = project
       }
     },
     sbtPlugin := true,
-    libraryDependencies ++= coursierDeps,
+    libraryDependencies ++= jgit +: coursierDeps,
     testQuick := {}, // these test are slow.
     // scripted tests needs scalafix 2.12
     // semanticdb-scala will generate the semantic db for both scala 2.11 and scala 2.12

--- a/build.sbt
+++ b/build.sbt
@@ -159,10 +159,13 @@ val cli = MultiScalaProject(
     )
   )
 )
-lazy val cli211 = cli(scala211, _.dependsOn(core211JVM, reflect211, testkit211 % Test))
-lazy val cli212 = cli(scala212, _.dependsOn(core212JVM, reflect212, testkit212 % Test))
+lazy val cli211 =
+  cli(scala211, _.dependsOn(core211JVM, reflect211, testkit211 % Test))
+lazy val cli212 =
+  cli(scala212, _.dependsOn(core212JVM, reflect212, testkit212 % Test))
 
-val scalafixSbt = MultiSbtProject("sbt",
+val scalafixSbt = MultiSbtProject(
+  "sbt",
   _.settings(
     buildInfoSettings,
     ScriptedPlugin.scriptedSettings,
@@ -200,14 +203,16 @@ val scalafixSbt = MultiSbtProject("sbt",
       "-Xss2m"
     ),
     scriptedBufferLog := false
-  )
-  .enablePlugins(BuildInfoPlugin)
-  .disablePlugins(ScalafixPlugin)
+  ).enablePlugins(BuildInfoPlugin)
+    .disablePlugins(ScalafixPlugin)
 )
-lazy val scalafixSbt1 = scalafixSbt(scala212, sbt1, _.dependsOn(testUtils212 % Test))
-lazy val scalafixSbt013 = scalafixSbt(scala210, sbt013, _.dependsOn(testUtils210 % Test))
+lazy val scalafixSbt1 =
+  scalafixSbt(scala212, sbt1, _.dependsOn(testUtils212 % Test))
+lazy val scalafixSbt013 =
+  scalafixSbt(scala210, sbt013, _.dependsOn(testUtils210 % Test))
 
-val testUtils = MultiScalaProject("test-utils", _.settings( libraryDependencies += jgit ))
+val testUtils =
+  MultiScalaProject("test-utils", _.settings(libraryDependencies += jgit))
 lazy val testUtils210 = testUtils(scala210)
 lazy val testUtils211 = testUtils(scala211)
 lazy val testUtils212 = testUtils(scala212)
@@ -338,7 +343,9 @@ def unit(
         javaOptions := Nil,
         buildInfoPackage := "scalafix.tests",
         buildInfoObject := "BuildInfo",
-        sources.in(Test) += (baseDirectory.in(ThisBuild)).value / "scalafix-sbt" / "src" / "main" / "scala" / "scalafix" / "internal" / "sbt" / "ScalafixJarFetcher.scala",
+        sources.in(Test) += (baseDirectory
+          .in(ThisBuild))
+          .value / "scalafix-sbt" / "src" / "main" / "scala" / "scalafix" / "internal" / "sbt" / "ScalafixJarFetcher.scala",
         libraryDependencies ++= coursierDeps ++ testsDeps
       ).enablePlugins(BuildInfoPlugin)
     )
@@ -434,6 +441,7 @@ lazy val website = project
       core212JVM)
   )
   .dependsOn(testkit212, core212JVM, cli212)
+  .disablePlugins(ScalafixPlugin)
 
 inScope(Global)(
   Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,8 +15,9 @@ object Dependencies {
   def scala212 = "2.12.4"
   val currentScalaVersion = scala212
 
-  def sbt013 = "0.13.6"
+  def sbt013 = "0.13.16"
   def sbt1 = "1.0.4"
+  val currentSbtVersion = sbt1
 
   val jgit = "org.eclipse.jgit" % "org.eclipse.jgit" % "4.5.4.201711221230-r"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,6 +18,8 @@ object Dependencies {
   def sbt013 = "0.13.6"
   def sbt1 = "1.0.4"
 
+  val jgit = "org.eclipse.jgit" % "org.eclipse.jgit" % "4.5.4.201711221230-r"
+
   var testClasspath: String = "empty"
   def semanticdb: ModuleID = "org.scalameta" % "semanticdb-scalac" % scalametaV cross CrossVersion.full
   def metaconfig: ModuleID = "com.geirsson" %% "metaconfig-typesafe-config" % metaconfigV

--- a/project/MultiScalaProject.scala
+++ b/project/MultiScalaProject.scala
@@ -118,10 +118,8 @@ object MultiSbtProject {
     new MultiSbtProject(name, s"scalafix-$name", configure)
 }
 
-class MultiSbtProject(
-    name: String,
-    base: String,
-    configure: Project => Project) extends MultiScala {
+class MultiSbtProject(name: String, base: String, configure: Project => Project)
+    extends MultiScala {
 
   def srcMain: String = s"$base/src/main"
   def apply(

--- a/project/MultiScalaProject.scala
+++ b/project/MultiScalaProject.scala
@@ -113,6 +113,39 @@ class MultiScalaProject(
   }
 }
 
+object MultiSbtProject {
+  def apply(name: String, configure: Project => Project): MultiSbtProject =
+    new MultiSbtProject(name, s"scalafix-$name", configure)
+}
+
+class MultiSbtProject(
+    name: String,
+    base: String,
+    configure: Project => Project) extends MultiScala {
+
+  def srcMain: String = s"$base/src/main"
+  def apply(
+      scalaV: String,
+      sbtV: String,
+      configurePerSbt: Project => Project = x => x): Project = {
+    val fullName = s"scalafix-$name"
+    val projectId: String =
+      if (sbtV != Dependencies.currentSbtVersion) {
+        s"$fullName${majorMinor(sbtV)}"
+      } else fullName
+    val resultingProject =
+      Project(id = projectId, base = file(s".cross/$projectId"))
+        .settings(
+          scalaVersion := scalaV,
+          sbtVersion in pluginCrossBuild := sbtV,
+          moduleName := fullName
+        )
+        .settings(srcFull(base))
+
+    configurePerSbt(configure(resultingProject))
+  }
+}
+
 object TestProject {
   private def base(sub: String): String =
     s"scalafix-tests/$sub"

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -174,17 +174,18 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
       "clean" ::
         "scalafix/publishSigned" ::
         "scalafix211/publishSigned" ::
+        "scalafix-sbt013/publishSigned" ::
         "scalafix-sbt/publishSigned" ::
-        s"^^ $sbt1 scalafix-sbt/publishSigned" ::
+        "sonatypeReleaseAll" ::
         s
     },
     commands += Command.command("ci-sbt") { s =>
       // scripted tests don't work in sbt 1.0 yet because we run Sbt1
-      s"^^ $sbt1 scalafix-sbt/publishLocal" ::
+      "scalafix-sbt/publishLocal" ::
         s
     },
     commands += Command.command("ci-sbt-sbt013") { s =>
-      "scalafix-sbt/scripted" ::
+      "scalafix-sbt013/scripted" ::
         s
     },
     commands += Command.command("ci-fast-212") { s =>

--- a/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
+++ b/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
@@ -484,7 +484,7 @@ object CliRunner {
         case (rule, _) =>
           if (rule.name.isEmpty)
             ConfError
-              .msg("No rule was provided! Use --rule to specify a rule.")
+              .msg("No rule was provided! Use --rules to specify a rule.")
               .notOk
           else Ok(rule)
       }

--- a/scalafix-sbt/src/main/scala/scalafix/internal/sbt/JGitCompletions.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/internal/sbt/JGitCompletions.scala
@@ -1,0 +1,31 @@
+package scalafix.internal.sbt
+
+import java.nio.file.Path
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.RefDatabase
+import org.eclipse.jgit.lib.Repository
+import org.eclipse.jgit.util.GitDateFormatter
+import scala.collection.JavaConverters._
+
+class JGitCompletion(cwd: Path) {
+  private val builder = new FileRepositoryBuilder()
+  private val repo = builder.readEnvironment().setWorkTree(cwd.toFile).build()
+  private val refList = repo.getRefDatabase().getRefs(RefDatabase.ALL).asScala
+  private val git = new Git(repo)
+  private val refs = git.log().setMaxCount(20).call().asScala.toList
+  private val dateFormatter = new GitDateFormatter(
+    GitDateFormatter.Format.RELATIVE)
+
+  val branchesAndTags: List[String] =
+    refList.map { case (a, b) => Repository.shortenRefName(a) }.toList
+
+  val last20Commits: List[(String, String)] =
+    refs.map { ref =>
+      val relativeCommitTime =
+        dateFormatter.formatDate(refs.head.getCommitterIdent)
+      val abrev = ref.abbreviate(8).name
+      val short = ref.getShortMessage
+      (s"$abrev -- $short ($relativeCommitTime)", abrev)
+    }
+}

--- a/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
@@ -92,7 +92,7 @@ object ScalafixCompletions {
     )
   }
 
-  def parser(cwd: Path): Parser[Seq[String]] = {
+  def parser(cwd: Path, compat: Boolean): Parser[Seq[String]] = {
     val pathParser: P = token(filepathParser(cwd))
     val pathRegexParser: P = mapOrFail(pathParser) { regex =>
       Pattern.compile(regex); regex
@@ -131,7 +131,7 @@ object ScalafixCompletions {
     val verbose: P = "--verbose"
     val zsh: P = "--zsh"
 
-    val all =
+    val base =
       bash |
         classpath |
         classpathAutoRoots |
@@ -157,6 +157,12 @@ object ScalafixCompletions {
         version |
         verbose |
         zsh
+
+    val rest =
+      if (compat) ruleParser
+      else filepathParser(cwd)
+
+    val all = base | rest
 
     (token(Space) ~> all).* <~ SpaceClass.*
   }

--- a/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
@@ -169,14 +169,15 @@ object ScalafixCompletions {
         verbose |
         zsh
 
-    val rest =
-      if (compat) ruleParser
-      else filepathParser(cwd)
-
-    (((token(Space) ~> base).* ~ (token(Space) ~> rest).?)).map {
-      case a ~ b => {
-        (a ++ b.toSeq).flatMap(_.split(" ").toSeq)
-      }
+    if (compat) {
+      (token(Space) ~> token(ruleParser)).* <~ SpaceClass.*
+    } else {
+      (((token(Space) ~> base).* ~ (token(Space) ~> filepathParser(cwd)).?))
+        .map {
+          case a ~ b => {
+            (a ++ b.toSeq).flatMap(_.split(" ").toSeq)
+          }
+        }
     }
   }
 }

--- a/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixCompletions.scala
@@ -3,62 +3,161 @@ package scalafix.internal.sbt
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
-import sbt.complete.DefaultParsers
+import java.util.regex.Pattern
+
+import scala.util.control.NonFatal
+
+import sbt.complete._
 import sbt.complete.DefaultParsers._
-import sbt.complete.FileExamples
-import sbt.complete.Parser
 
 object ScalafixCompletions {
-  private val names = ScalafixRuleNames.all
-
-  private def toAbsolutePath(path: Path, cwd: Path): Path = {
-    if (path.isAbsolute) path
-    else cwd.resolve(path)
-  }.normalize()
-
-  // Extend FileExamples to tab complete when the prefix is an absolute path or `..`
-  private class AbsolutePathExamples(cwd: Path, prefix: String = "")
-      extends FileExamples(cwd.toFile, prefix) {
-    override def withAddedPrefix(addedPrefix: String): FileExamples = {
-      val nextPrefix =
-        if (addedPrefix.startsWith(".")) addedPrefix
-        else prefix + addedPrefix
-      val (b, p) = AbsolutePathCompleter.mkBase(nextPrefix, cwd)
-      new AbsolutePathExamples(b, p)
-    }
-  }
-  private object AbsolutePathCompleter {
-    def mkBase(prefix: String, fallback: Path): (Path, String) = {
-      val path = toAbsolutePath(Paths.get(prefix), fallback)
-      if (prefix.endsWith(File.separator)) path -> ""
-      else path.getParent -> path.getFileName.toString
-    }
-  }
-
-  private def fileRule(cwd: Path): Parser[String] =
-    token("file:") ~>
-      StringBasic
-        .examples(new AbsolutePathExamples(cwd))
-        .map { f =>
-          val path = toAbsolutePath(Paths.get(f), cwd).toString
-          "file:" + path
-        }
-
-  private def uri(protocol: String) =
-    token(protocol + ":") ~> NotQuoted.map(x => s"$protocol:$x")
+  private type P = Parser[String]
+  private val space: P = token(Space).map(_.toString)
+  private val string: P = StringBasic
+  private def repsep(rep: P, sep: String): P =
+    DefaultParsers.repsep(rep, sep: P).map(_.mkString(sep))
+  private def arg(key: String, value: P): P =
+    (key ~ space ~ value).map { case a ~ b ~ c => a + b + c }
+  private def mapOrFail[S, T](p: Parser[S])(f: S => T): Parser[T] =
+    p.flatMap(s =>
+      try { success(f(s)) } catch { case NonFatal(e) => failure(e.toString) })
 
   private val namedRule: Parser[String] =
-    names.map(literal).reduceLeft(_ | _)
+    ScalafixRuleNames.all.map(literal).reduceLeft(_ | _)
+  private def uri(protocol: String) =
+    token(protocol + ":") ~> NotQuoted.map(x => s"$protocol:$x")
+  private def filepathParser(cwd: Path): P = {
+    def toAbsolutePath(path: Path, cwd: Path): Path = {
+      if (path.isAbsolute) path
+      else cwd.resolve(path)
+    }.normalize()
+
+    // Extend FileExamples to tab complete when the prefix is an absolute path or `..`
+    class AbsolutePathExamples(cwd: Path, prefix: String = "")
+        extends FileExamples(cwd.toFile, prefix) {
+      override def withAddedPrefix(addedPrefix: String): FileExamples = {
+
+        val nextPrefix =
+          if (addedPrefix.startsWith(".")) addedPrefix
+          else prefix + addedPrefix
+        val (b, p) = AbsolutePathCompleter.mkBase(nextPrefix, cwd)
+        new AbsolutePathExamples(b, p)
+      }
+    }
+    object AbsolutePathCompleter {
+      def mkBase(prefix: String, fallback: Path): (Path, String) = {
+        val path = toAbsolutePath(Paths.get(prefix), fallback)
+        if (prefix.endsWith(File.separator)) path -> ""
+        else path.getParent -> path.getFileName.toString
+      }
+    }
+
+    string
+      .examples(new AbsolutePathExamples(cwd))
+      .map { f =>
+        toAbsolutePath(Paths.get(f), cwd).toString
+      }
+  }
+  private def gitDiffParser(cwd: Path): P = {
+    val jgitCompletion = new JGitCompletion(cwd)
+    token(
+      NotQuoted,
+      TokenCompletions.fixed(
+        (seen, level) => {
+          val last20Commits =
+            jgitCompletion.last20Commits
+              .filter { case (_, sha1) => sha1.startsWith(seen) }
+              .zipWithIndex
+              .map {
+                case ((log, sha1), i) => {
+                  val j = i + 1
+                  val idx = if (j < 10) " " + j.toString else j.toString
+                  new Token(
+                    display = s"|$idx| $log",
+                    append = sha1.stripPrefix(seen))
+                }
+              }
+              .toSet
+
+          val branchesAndTags =
+            jgitCompletion.branchesAndTags
+              .filter(info => info.startsWith(seen))
+              .map(info =>
+                new Token(display = info, append = info.stripPrefix(seen)))
+              .toSet
+
+          Completions.strict(last20Commits ++ branchesAndTags)
+        }
+      )
+    )
+  }
 
   def parser(cwd: Path): Parser[Seq[String]] = {
+    val pathParser: P = token(filepathParser(cwd))
+    val pathRegexParser: P = mapOrFail(pathParser) { regex =>
+      Pattern.compile(regex); regex
+    }
+    val classpathParser: P = repsep(pathParser, File.pathSeparator)
+    val fileRule: P = (token("file:") ~ pathParser.map("file:" + _)).map {
+      case a ~ b => a + b
+    }
+    val ruleParser = token(
+      namedRule | fileRule | uri("github") | uri("replace") | uri("http") | uri(
+        "https") | uri("scala"))
+
+    val bash: P = "--bash"
+    val classpath: P = arg("--classpath", classpathParser)
+    val classpathAutoRoots: P = arg("--classpath-auto-roots", classpathParser)
+    val config: P = arg("--config", pathParser)
+    val configStr: P = arg("--config-str", string.examples())
+    val diff: P = "--diff"
+    val diffBase: P = arg("--diff-base", gitDiffParser(cwd))
+    val exclude: P = arg("--exclude", pathRegexParser)
+    val noStrictSemanticdb: P = "--no-strict-semanticdb"
+    val noSysExit: P = "--no-sys-exit"
+    val nonInteractive: P = "--non-interactive"
+    val outFrom: P = arg("--out-from", pathRegexParser)
+    val outTo: P = arg("--out-to", pathRegexParser)
+    val quietParseErrors: P = "--quiet-parse-errors"
+    val rules: P = arg("--rules", ruleParser)
+    val singleThread: P = "--single-thread"
+    val sourceroot: P = arg("--sourceroot", pathParser)
+    val stdout: P = "--stdout"
+    val test: P = "--test"
+    val toolClasspath: P = arg("--tool-classpath", classpathParser)
+    val usage: P = "--usage"
+    val help: P = "--help"
+    val version: P = "--version"
+    val verbose: P = "--verbose"
+    val zsh: P = "--zsh"
+
     val all =
-      namedRule |
-        fileRule(cwd) |
-        uri("github") |
-        uri("replace") |
-        uri("http") |
-        uri("https") |
-        uri("scala")
-    (token(Space) ~> token(all)).* <~ SpaceClass.*
+      bash |
+        classpath |
+        classpathAutoRoots |
+        config |
+        configStr |
+        diff |
+        diffBase |
+        exclude |
+        noStrictSemanticdb |
+        noSysExit |
+        nonInteractive |
+        outFrom |
+        outTo |
+        quietParseErrors |
+        rules |
+        singleThread |
+        sourceroot |
+        stdout |
+        test |
+        toolClasspath |
+        usage |
+        help |
+        version |
+        verbose |
+        zsh
+
+    (token(Space) ~> all).* <~ SpaceClass.*
   }
 }

--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -1,7 +1,5 @@
 package scalafix.sbt
 
-import scala.language.reflectiveCalls
-
 import scalafix.Versions
 import sbt.File
 import sbt.Keys._
@@ -9,7 +7,6 @@ import sbt._
 import sbt.plugins.JvmPlugin
 import scalafix.internal.sbt.ScalafixCompletions
 import scalafix.internal.sbt.ScalafixJarFetcher
-import org.scalameta.BuildInfo
 import sbt.Def
 
 object ScalafixPlugin extends AutoPlugin {
@@ -138,12 +135,6 @@ object ScalafixPlugin extends AutoPlugin {
   private def workingDirectory = file(sys.props("user.dir"))
   private val scalafixParser =
     ScalafixCompletions.parser(workingDirectory.toPath)
-  private object logger {
-    def warn(msg: String): Unit = {
-      println(
-        s"[${scala.Console.YELLOW}warn${scala.Console.RESET}] scalafix - $msg")
-    }
-  }
   private val isSupportedScalaVersion = Def.setting {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 11 | 12)) => true
@@ -274,6 +265,7 @@ object ScalafixPlugin extends AutoPlugin {
           verbose ++
             config ++
             inputArgs ++
+            baseArgs ++
             options ++
             List(
               "--sourceroot",

--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -268,16 +268,12 @@ object ScalafixPlugin extends AutoPlugin {
             scalafixConfig.value
               .map(x => "--config" :: x.getAbsolutePath :: Nil)
               .getOrElse(Nil)
-          val ruleArgs =
-            if (inputArgs.nonEmpty)
-              inputArgs.flatMap("-r" :: _ :: Nil)
-            else Nil
+
           val sourceroot = scalafixSourceroot.value.getAbsolutePath
           // only fix unmanaged sources, skip code generated files.
           verbose ++
             config ++
-            ruleArgs ++
-            baseArgs ++
+            inputArgs ++
             options ++
             List(
               "--sourceroot",

--- a/scalafix-sbt/src/test/scala/scalafix/internal/sbt/ScalafixCompletionsTest.scala
+++ b/scalafix-sbt/src/test/scala/scalafix/internal/sbt/ScalafixCompletionsTest.scala
@@ -3,21 +3,153 @@ package scalafix.internal.sbt
 import java.nio.file.Paths
 import org.scalatest.FunSuite
 import sbt.complete.Parser
+import sbt.complete.Completion
+
+import org.eclipse.jgit.lib.AbbreviatedObjectId
 
 class ScalafixCompletionsTest extends FunSuite {
   val cwd = Paths.get("").toAbsolutePath
-  println(cwd)
   val parser = ScalafixCompletions.parser(cwd)
-  val expected = Set("-diff", "-testkit", "-sbt", "-core", "-cli")
-  def check(path: String): Unit = {
-    test(path) {
-      val completions = Parser.completions(parser, " file:" + path, 0)
-      val obtained = completions.get.map(_.append).intersect(expected)
-      assert(obtained == expected)
+  val space = " "
+
+  def check(name: String)(assertCompletions: List[Completion] => Unit): Unit = {
+    val option =
+      if (name == "all") ""
+      else name
+
+    test(name) {
+      val completions = Parser.completions(parser, " " + option, 0).get
+      assertCompletions(completions.toList.sortBy(_.display))
     }
   }
 
-  check("scalafix") // relative path
-  check(cwd.resolve("scalafix").toString) // absolute path
-  check(Paths.get("..").resolve("scalafix").resolve("scalafix").toString)
+  def check2(name: String)(
+      assertCompletions: (List[String], List[String]) => Unit): Unit = {
+    check(name) { completions =>
+      val appends = completions.map(_.append)
+      val displays = completions.map(_.display)
+
+      assertCompletions(appends, displays)
+    }
+  }
+
+  def isSha1(in: String): Boolean =
+    AbbreviatedObjectId.isId(in)
+
+  check("all") { completions =>
+    val obtained = completions.map(_.display)
+    val expected = List(
+      "",
+      "--bash",
+      "--classpath",
+      "--classpath-auto-roots",
+      "--config",
+      "--config-str",
+      "--diff",
+      "--diff-base",
+      "--exclude",
+      "--help",
+      "--no-strict-semanticdb",
+      "--no-sys-exit",
+      "--non-interactive",
+      "--out-from",
+      "--out-to",
+      "--quiet-parse-errors",
+      "--rules",
+      "--single-thread",
+      "--sourceroot",
+      "--stdout",
+      "--test",
+      "--tool-classpath",
+      "--usage",
+      "--verbose",
+      "--version",
+      "--zsh"
+    )
+
+    assert(obtained == expected)
+  }
+  check2("--classpath scalafix-co") { (appends, displays) =>
+    assert(displays.contains("scalafix-core"))
+    assert(appends.contains("re"))
+  }
+  check2("--classpath scalafix-core") { (appends, displays) =>
+    assert(displays.contains(":"))
+    assert(appends.contains(":"))
+  }
+  check2("--classpath scalafix-core:") { (appends, displays) =>
+    assert(displays.contains("scalafix-cli"))
+    assert(appends.contains("scalafix-cli"))
+  }
+  check2("--classpath-auto-roots" + space) { (appends, displays) =>
+    assert(displays.contains("scalafix-cli"))
+    assert(appends.contains("scalafix-cli"))
+  }
+  check2("--config" + space) { (appends, displays) =>
+    assert(displays.contains(".scalafmt.conf"))
+  }
+  check("""--config-str="ExplicitResult"""") { completions =>
+    assert(completions.isEmpty)
+  }
+  check("--diff-base" + space) { completions =>
+    val displays = completions.map(_.display)
+
+    // branches
+    assert(displays.contains("master"))
+
+    // tag
+    assert(displays.contains("v0.5.0"))
+
+    // last 20 commits
+    completions.reverse.take(20).foreach { completion =>
+      assert(isSha1(completion.append))
+      assert(completion.display.contains(completion.append))
+      assert(completion.display.endsWith("ago)"))
+    }
+  }
+  check2("--exclude" + space) { (appends, displays) =>
+    assert(displays.contains("scalafix-cli"))
+    assert(appends.contains("scalafix-cli"))
+  }
+  check2("--out-from" + space) { (appends, displays) =>
+    assert(displays.contains("scalafix-cli"))
+    assert(appends.contains("scalafix-cli"))
+  }
+  check2("--out-to" + space) { (appends, displays) =>
+    assert(displays.contains("scalafix-cli"))
+    assert(appends.contains("scalafix-cli"))
+  }
+  check2("--rules" + space) { (_, displays) =>
+    // built-in
+    assert(displays.contains("NoInfer"))
+
+    // protocols
+    assert(displays.contains("file:"))
+    assert(displays.contains("github:"))
+    assert(displays.contains("http:"))
+    assert(displays.contains("https:"))
+    assert(displays.contains("replace:"))
+    assert(displays.contains("scala:"))
+  }
+  check2("--rules file:scalafix/../") { (appends, displays) =>
+    // resolve parent directories
+    assert(appends.contains("scalafix-cli"))
+    assert(displays.contains("scalafix/../scalafix-cli"))
+  }
+  check2("--sourceroot" + space) { (appends, displays) =>
+    assert(displays.contains("scalafix-cli"))
+    assert(appends.contains("scalafix-cli"))
+  }
+  check2("--tool-classpath scalafix-co") { (appends, displays) =>
+    assert(displays.contains("scalafix-core"))
+    assert(appends.contains("re"))
+  }
+  check2("--tool-classpath scalafix-core") { (appends, displays) =>
+    assert(displays.contains(":"))
+    assert(appends.contains(":"))
+  }
+  check2("--tool-classpath scalafix-core:") { (appends, displays) =>
+    assert(displays.contains("scalafix-cli"))
+    assert(appends.contains("scalafix-cli"))
+  }
 }

--- a/scalafix-sbt/src/test/scala/scalafix/internal/sbt/ScalafixCompletionsTest.scala
+++ b/scalafix-sbt/src/test/scala/scalafix/internal/sbt/ScalafixCompletionsTest.scala
@@ -6,10 +6,26 @@ import sbt.complete.Parser
 import sbt.complete.Completion
 
 import org.eclipse.jgit.lib.AbbreviatedObjectId
+import scalafix.internal.tests.utils.{Fs, Git}
 
 class ScalafixCompletionsTest extends FunSuite {
-  val cwd = Paths.get("").toAbsolutePath
-  val parser = ScalafixCompletions.parser(cwd)
+  val fs = new Fs()
+  val git = new Git(fs.workingDirectory)
+  fs.mkdir("foo")
+  fs.add("foo/f.scala", "object F")
+  fs.mkdir("bar")
+  fs.add("bar/b.scala", "object B")
+  fs.mkdir("buzz")
+  fs.add("my.conf", "conf.file = []")
+  git.commit()
+  // create at least 20 commits for diff-base log
+  (1 to 20).foreach { i =>
+    fs.add(s"f$i", s"f$i")
+    git.commit()
+  }
+  git.tag("v0.1.0")
+
+  val parser = ScalafixCompletions.parser(fs.workingDirectory.toAbsolutePath)
   val space = " "
 
   def check(name: String)(assertCompletions: List[Completion] => Unit): Unit = {
@@ -69,27 +85,24 @@ class ScalafixCompletionsTest extends FunSuite {
 
     assert(obtained == expected)
   }
-  check2("--classpath scalafix-co") { (appends, displays) =>
-    assert(displays.contains("scalafix-core"))
-    assert(appends.contains("re"))
+  check2("--classpath ba") { (appends, displays) =>
+    assert(displays.contains("bar"))
+    assert(appends.contains("r"))
   }
-  check2("--classpath scalafix-core") { (appends, displays) =>
+  check2("--classpath bar") { (appends, displays) =>
     assert(displays.contains(":"))
     assert(appends.contains(":"))
   }
-  check2("--classpath scalafix-core:") { (appends, displays) =>
-    assert(displays.contains("scalafix-cli"))
-    assert(appends.contains("scalafix-cli"))
+  check2("--classpath bar:") { (appends, displays) =>
+    assert(displays.contains("foo"))
+    assert(appends.contains("foo"))
   }
   check2("--classpath-auto-roots" + space) { (appends, displays) =>
-    assert(displays.contains("scalafix-cli"))
-    assert(appends.contains("scalafix-cli"))
+    assert(displays.contains("foo"))
+    assert(appends.contains("foo"))
   }
   check2("--config" + space) { (appends, displays) =>
-    assert(displays.contains(".scalafmt.conf"))
-  }
-  check("""--config-str="ExplicitResult"""") { completions =>
-    assert(completions.isEmpty)
+    assert(displays.contains("my.conf"))
   }
   check("--diff-base" + space) { completions =>
     val displays = completions.map(_.display)
@@ -98,7 +111,7 @@ class ScalafixCompletionsTest extends FunSuite {
     assert(displays.contains("master"))
 
     // tag
-    assert(displays.contains("v0.5.0"))
+    assert(displays.contains("v0.1.0"))
 
     // last 20 commits
     completions.reverse.take(20).foreach { completion =>
@@ -108,16 +121,16 @@ class ScalafixCompletionsTest extends FunSuite {
     }
   }
   check2("--exclude" + space) { (appends, displays) =>
-    assert(displays.contains("scalafix-cli"))
-    assert(appends.contains("scalafix-cli"))
+    assert(displays.contains("foo"))
+    assert(appends.contains("foo"))
   }
   check2("--out-from" + space) { (appends, displays) =>
-    assert(displays.contains("scalafix-cli"))
-    assert(appends.contains("scalafix-cli"))
+    assert(displays.contains("foo"))
+    assert(appends.contains("foo"))
   }
   check2("--out-to" + space) { (appends, displays) =>
-    assert(displays.contains("scalafix-cli"))
-    assert(appends.contains("scalafix-cli"))
+    assert(displays.contains("foo"))
+    assert(appends.contains("foo"))
   }
   check2("--rules" + space) { (_, displays) =>
     // built-in
@@ -131,25 +144,25 @@ class ScalafixCompletionsTest extends FunSuite {
     assert(displays.contains("replace:"))
     assert(displays.contains("scala:"))
   }
-  check2("--rules file:scalafix/../") { (appends, displays) =>
+  check2("--rules file:bar/../") { (appends, displays) =>
     // resolve parent directories
-    assert(appends.contains("scalafix-cli"))
-    assert(displays.contains("scalafix/../scalafix-cli"))
+    assert(appends.contains("foo"))
+    assert(displays.contains("bar/../foo"))
   }
   check2("--sourceroot" + space) { (appends, displays) =>
-    assert(displays.contains("scalafix-cli"))
-    assert(appends.contains("scalafix-cli"))
+    assert(displays.contains("bar"))
+    assert(appends.contains("bar"))
   }
-  check2("--tool-classpath scalafix-co") { (appends, displays) =>
-    assert(displays.contains("scalafix-core"))
-    assert(appends.contains("re"))
+  check2("--tool-classpath ba") { (appends, displays) =>
+    assert(displays.contains("bar"))
+    assert(appends.contains("r"))
   }
-  check2("--tool-classpath scalafix-core") { (appends, displays) =>
+  check2("--tool-classpath bar") { (appends, displays) =>
     assert(displays.contains(":"))
     assert(appends.contains(":"))
   }
-  check2("--tool-classpath scalafix-core:") { (appends, displays) =>
-    assert(displays.contains("scalafix-cli"))
-    assert(appends.contains("scalafix-cli"))
+  check2("--tool-classpath bar:") { (appends, displays) =>
+    assert(displays.contains("buzz"))
+    assert(appends.contains("buzz"))
   }
 }

--- a/scalafix-sbt/src/test/scala/scalafix/internal/sbt/ScalafixCompletionsTest.scala
+++ b/scalafix-sbt/src/test/scala/scalafix/internal/sbt/ScalafixCompletionsTest.scala
@@ -62,6 +62,21 @@ class ScalafixCompletionsTest extends FunSuite {
     assert(obtained.exists(_.display.startsWith("file:")))
   }
 
+  test("compat multiple") {
+    val parser = ScalafixCompletions.parser(
+      fs.workingDirectory.toAbsolutePath,
+      compat = true)
+    val completions =
+      Parser.completions(parser, " RemoveUnusedImports Remo", 0).get
+    val obtained = completions.toList.map(_.display).toSet
+    val expected = Set(
+      "RemoveUnusedImports",
+      "RemoveUnusedTerms",
+      "RemoveXmlLiterals"
+    )
+    assert((expected -- obtained).isEmpty)
+  }
+
   check("all") { completions =>
     val obtained = completions.map(_.display).toSet
     val expected = Set(

--- a/scalafix-sbt/src/test/scala/scalafix/internal/sbt/ScalafixCompletionsTest.scala
+++ b/scalafix-sbt/src/test/scala/scalafix/internal/sbt/ScalafixCompletionsTest.scala
@@ -76,7 +76,6 @@ class ScalafixCompletionsTest extends FunSuite {
       "--exclude",
       "--help",
       "--no-strict-semanticdb",
-      "--no-sys-exit",
       "--non-interactive",
       "--out-from",
       "--out-to",

--- a/scalafix-test-utils/src/main/scala/scalafix/internal/tests/utils/Fs.scala
+++ b/scalafix-test-utils/src/main/scala/scalafix/internal/tests/utils/Fs.scala
@@ -1,0 +1,45 @@
+package scalafix.internal.tests.utils
+
+import java.nio.file.{Files, Path, StandardOpenOption}
+import scala.collection.JavaConverters._
+
+class Fs() {
+
+  val workingDirectory: Path =
+    Files.createTempDirectory("scalafix")
+
+  workingDirectory.toFile.deleteOnExit()
+
+  def add(filename: String, content: String): Unit =
+    write(filename, content, StandardOpenOption.CREATE_NEW)
+
+  def append(filename: String, content: String): Unit =
+    write(filename, content, StandardOpenOption.APPEND)
+
+  def replace(filename: String, content: String): Unit = {
+    rm(filename)
+    add(filename, content)
+  }
+
+  def read(src: String): String =
+    Files.readAllLines(path(src)).asScala.mkString("\n")
+
+  def rm(filename: String): Unit =
+    Files.delete(path(filename))
+
+  def mv(src: String, dst: String): Unit =
+    Files.move(path(src), path(dst))
+
+  def absPath(filename: String): String =
+    path(filename).toAbsolutePath.toString
+
+  private def write(
+      filename: String,
+      content: String,
+      op: StandardOpenOption): Unit = {
+    Files.write(path(filename), content.getBytes, op)
+  }
+
+  private def path(filename: String): Path =
+    workingDirectory.resolve(filename)
+}

--- a/scalafix-test-utils/src/main/scala/scalafix/internal/tests/utils/Fs.scala
+++ b/scalafix-test-utils/src/main/scala/scalafix/internal/tests/utils/Fs.scala
@@ -4,11 +4,13 @@ import java.nio.file.{Files, Path, StandardOpenOption}
 import scala.collection.JavaConverters._
 
 class Fs() {
-
   val workingDirectory: Path =
     Files.createTempDirectory("scalafix")
 
   workingDirectory.toFile.deleteOnExit()
+
+  def mkdir(dirname: String): Unit =
+    Files.createDirectory(path(dirname))
 
   def add(filename: String, content: String): Unit =
     write(filename, content, StandardOpenOption.CREATE_NEW)

--- a/scalafix-test-utils/src/main/scala/scalafix/internal/tests/utils/Git.scala
+++ b/scalafix-test-utils/src/main/scala/scalafix/internal/tests/utils/Git.scala
@@ -1,0 +1,30 @@
+package scalafix.internal.tests.utils
+
+import java.nio.file.Path
+
+class Git(workingDirectory: Path) {
+  import org.eclipse.jgit.api.{Git => JGit}
+
+  private val git = JGit.init().setDirectory(workingDirectory.toFile).call()
+  private var revision = 0
+
+  def add(filename: String): Unit =
+    git.add().addFilepattern(filename).call()
+
+  def rm(filename: String): Unit =
+    git.rm().addFilepattern(filename).call()
+
+  def checkout(branch: String): Unit =
+    git.checkout().setCreateBranch(true).setName(branch).call()
+
+  def tag(name: String, message: String): Unit =
+    git.tag().setName(name).setMessage(message).call()
+
+  def deleteBranch(branch: String): Unit =
+    git.branchDelete().setBranchNames(branch).call()
+
+  def commit(): Unit = {
+    git.commit().setMessage(s"r$revision").call()
+    revision += 1
+  }
+}

--- a/scalafix-test-utils/src/main/scala/scalafix/internal/tests/utils/Git.scala
+++ b/scalafix-test-utils/src/main/scala/scalafix/internal/tests/utils/Git.scala
@@ -17,8 +17,8 @@ class Git(workingDirectory: Path) {
   def checkout(branch: String): Unit =
     git.checkout().setCreateBranch(true).setName(branch).call()
 
-  def tag(name: String, message: String): Unit =
-    git.tag().setName(name).setMessage(message).call()
+  def tag(name: String): Unit =
+    git.tag().setName(name).call()
 
   def deleteBranch(branch: String): Unit =
     git.branchDelete().setBranchNames(branch).call()

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/DiffAssertions.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/DiffAssertions.scala
@@ -92,9 +92,4 @@ trait DiffAssertions extends FunSuiteLike {
       format.format(new Date(0L))
     }
   }
-  import scala.collection.mutable.{HashMap => _}
-//  import scala.collection.mutable.{HashMap => _}
-//  import scala.collection.mutable._
-  import Predef.{any2stringadd => _}
-  any2stringadd("")
 }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliGitDiffTests.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliGitDiffTests.scala
@@ -4,13 +4,12 @@ import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.nio.charset.StandardCharsets
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path, StandardOpenOption}
+import java.nio.file.Path
 
 import org.scalatest._
 import org.scalatest.FunSuite
 
 import scala.collection.immutable.Seq
-import scala.util._
 
 import scalafix.cli
 import scalafix.internal.cli.CommonOptions


### PR DESCRIPTION
This is still pretty raw, but I think it is really important to get a good user experience on sbt. This creates some code duplication between the cli parser generated by caseapp and the sbt parser.

I jumped on that issue because I'm not comfortable using the cli tool like you did in https://github.com/scalacenter/scalafix/pull/511#issuecomment-352814243. I think the most natural way is to run it from the sbt plugin.

The workflow with the cli is not clear in the documentation. I think it would be good to expend this section: https://scalacenter.github.io/scalafix/docs/users/installation#run-scalafix-cli
before running, `scalafix` don't you need to generate the semantic-db?

What is the content of your `scalafix-nightly`? If a user navigates on GitHub and finds this comment https://github.com/scalacenter/scalafix/pull/511#issuecomment-352814243 I think he/she will be confused. Should we provide a nightly binary?
