### PR TITLE
Make 'from' parameter in TokenList.slice/find inclusive

### DIFF
--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -31,7 +31,9 @@ object Mima {
       ProblemFilters.exclude[ReversedMissingMethodProblem](
         "scalafix.util.TokenList.leadingSpaces"),
       ProblemFilters.exclude[ReversedMissingMethodProblem](
-        "scalafix.util.TokenList.trailingSpaces")
+        "scalafix.util.TokenList.trailingSpaces"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "scalafix.util.TokenList.slice")
     )
   }
 }

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -31,9 +31,7 @@ object Mima {
       ProblemFilters.exclude[ReversedMissingMethodProblem](
         "scalafix.util.TokenList.leadingSpaces"),
       ProblemFilters.exclude[ReversedMissingMethodProblem](
-        "scalafix.util.TokenList.trailingSpaces"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem](
-        "scalafix.util.TokenList.slice")
+        "scalafix.util.TokenList.trailingSpaces")
     )
   }
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/util/TokenList.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/util/TokenList.scala
@@ -9,8 +9,10 @@ import scala.meta.tokens.Tokens
 final class TokenList private (tokens: Tokens) {
   def trailing(token: Token): SeqView[Token, IndexedSeq[Token]] =
     tokens.view(tok2idx(token) + 1, tokens.length)
+
   def leading(token: Token): SeqView[Token, IndexedSeq[Token]] =
     tokens.view(0, tok2idx(token)).reverse
+
   private[this] val tok2idx = {
     val map = Map.newBuilder[Token, Int]
     var i = 0
@@ -21,20 +23,11 @@ final class TokenList private (tokens: Tokens) {
     map
       .result()
       .withDefault(t =>
-        throw new NoSuchElementException("token not found: " + t))
+        throw new NoSuchElementException(s"token not found: $t"))
   }
 
-  def find(start: Token)(f: Token => Boolean): Option[Token] = {
-    def loop(curr: Token): Option[Token] = {
-      if (f(curr)) Option(curr)
-      else {
-        val iter = next(curr)
-        if (iter == curr) None // reached EOF
-        else loop(iter)
-      }
-    }
-    loop(next(start))
-  }
+  def find(start: Token)(p: Token => Boolean): Option[Token] =
+    tokens.drop(tok2idx(start)).find(p)
 
   def slice(from: Token, to: Token): SeqView[Token, IndexedSeq[Token]] =
     tokens.view(tok2idx(from), tok2idx(to))

--- a/scalafix-core/shared/src/main/scala/scalafix/util/TokenList.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/util/TokenList.scala
@@ -18,7 +18,10 @@ final class TokenList private (tokens: Tokens) {
       map += (tok -> i)
       i += 1
     }
-    map.result()
+    map
+      .result()
+      .withDefault(t =>
+        throw new NoSuchElementException("token not found: " + t))
   }
 
   def find(start: Token)(f: Token => Boolean): Option[Token] = {
@@ -33,15 +36,8 @@ final class TokenList private (tokens: Tokens) {
     loop(next(start))
   }
 
-  def slice(from: Token, to: Token): Seq[Token] = {
-    val builder = Seq.newBuilder[Token]
-    var curr = next(from)
-    while (curr.start < to.start) {
-      builder += curr
-      curr = next(curr)
-    }
-    builder.result()
-  }
+  def slice(from: Token, to: Token): SeqView[Token, IndexedSeq[Token]] =
+    tokens.view(tok2idx(from), tok2idx(to))
 
   def next(token: Token): Token = {
     tok2idx.get(token) match {

--- a/scalafix-core/shared/src/main/scala/scalafix/util/TokenList.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/util/TokenList.scala
@@ -29,7 +29,7 @@ final class TokenList private (tokens: Tokens) {
   def find(start: Token)(p: Token => Boolean): Option[Token] =
     tokens.drop(tok2idx(start)).find(p)
 
-  def slice(from: Token, to: Token): SeqView[Token, IndexedSeq[Token]] =
+  def slice(from: Token, to: Token): Seq[Token] =
     tokens.view(tok2idx(from), tok2idx(to))
 
   def next(token: Token): Token = {

--- a/scalafix-core/shared/src/main/scala/scalafix/util/TokenList.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/util/TokenList.scala
@@ -8,9 +8,9 @@ import scala.meta.tokens.Tokens
 /** Helper to traverse tokens as a doubly linked list.  */
 final class TokenList private (tokens: Tokens) {
   def trailing(token: Token): SeqView[Token, IndexedSeq[Token]] =
-    tokens.view(tok2idx(token), tokens.length).drop(1)
+    tokens.view(tok2idx(token) + 1, tokens.length)
   def leading(token: Token): SeqView[Token, IndexedSeq[Token]] =
-    tokens.view(0, tok2idx(token)).drop(1).reverse
+    tokens.view(0, tok2idx(token)).reverse
   private[this] val tok2idx = {
     val map = Map.newBuilder[Token, Int]
     var i = 0

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/util/TokenListTest.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/util/TokenListTest.scala
@@ -16,6 +16,48 @@ class TokenListTest extends FunSuite {
       |}""".stripMargin.tokenize.get
   val tokenList = TokenList(tokens)
 
+  test("leading returns all preceding tokens") {
+    val Some(bar) = tokens.find {
+      case Token.Ident(name) if name == "Bar" => true
+      case _ => false
+    }
+
+    val leading = tokenList.leading(bar)
+    assert(leading.size == 8)
+    for ((a, b) <- tokens.zip(leading.reverse)) assert(a == b)
+  }
+
+  test("leading returns empty seq if there is no preceding tokens") {
+    assert(tokenList.leading(tokens.head).isEmpty)
+  }
+
+  test("leading fails if input token does not exist") {
+    assertThrows[NoSuchElementException] {
+      tokenList.leading(new Token.EOF(Input.None, Scala211))
+    }
+  }
+
+  test("trailing returns all following tokens") {
+    val Some(baz) = tokens.find {
+      case Token.Ident(name) if name == "baz" => true
+      case _ => false
+    }
+
+    val trailing = tokenList.trailing(baz)
+    assert(trailing.size == 11)
+    for ((a, b) <- tokens.reverse.zip(trailing.reverse)) assert(a == b)
+  }
+
+  test("trailing returns empty seq if there is no following tokens") {
+    assert(tokenList.trailing(tokens.last).isEmpty)
+  }
+
+  test("trailing fails if input token does not exist") {
+    assertThrows[NoSuchElementException] {
+      tokenList.trailing(new Token.EOF(Input.None, Scala211))
+    }
+  }
+
   test("prev returns the preceding token") {
     assert(tokenList.prev(tokens(1)) == tokens.head)
   }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/util/TokenListTest.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/util/TokenListTest.scala
@@ -16,9 +16,11 @@ class TokenListTest extends FunSuite {
       |}""".stripMargin.tokenize.get
   val tokenList = TokenList(tokens)
 
+  val unknownToken = new Token.EOF(Input.None, Scala211)
+
   test("leading returns all preceding tokens") {
     val Some(bar) = tokens.find {
-      case Token.Ident(name) if name == "Bar" => true
+      case Token.Ident("Bar") => true
       case _ => false
     }
 
@@ -28,18 +30,18 @@ class TokenListTest extends FunSuite {
   }
 
   test("leading returns empty seq if there is no preceding tokens") {
-    assert(tokenList.leading(tokens.head).isEmpty)
+    assert(tokenList.leading(tokens.head) == Seq())
   }
 
   test("leading fails if input token does not exist") {
     assertThrows[NoSuchElementException] {
-      tokenList.leading(new Token.EOF(Input.None, Scala211))
+      tokenList.leading(unknownToken)
     }
   }
 
   test("trailing returns all following tokens") {
     val Some(baz) = tokens.find {
-      case Token.Ident(name) if name == "baz" => true
+      case Token.Ident("baz") => true
       case _ => false
     }
 
@@ -49,12 +51,30 @@ class TokenListTest extends FunSuite {
   }
 
   test("trailing returns empty seq if there is no following tokens") {
-    assert(tokenList.trailing(tokens.last).isEmpty)
+    assert(tokenList.trailing(tokens.last) == Seq())
   }
 
   test("trailing fails if input token does not exist") {
     assertThrows[NoSuchElementException] {
-      tokenList.trailing(new Token.EOF(Input.None, Scala211))
+      tokenList.trailing(unknownToken)
+    }
+  }
+
+  test("find returns first token following `start` matching the predicate") {
+    assert(tokenList.find(tokens.head)(_.is[Token.EOF]) == Some(tokens.last))
+  }
+
+  test("find returns `start` token if it matches predicate") {
+    assert(tokenList.find(tokens.head)(_.is[Token.BOF]) == Some(tokens.head))
+  }
+
+  test("find returns none if token matching predicate comes before `start`") {
+    assert(tokenList.find(tokens.last)(_.is[Token.BOF]) == None)
+  }
+
+  test("find fails if `start` token does not exist") {
+    assertThrows[NoSuchElementException] {
+      tokenList.find(unknownToken)(_.is[Token.BOF])
     }
   }
 
@@ -79,22 +99,22 @@ class TokenListTest extends FunSuite {
   }
 
   test("slice returns empty seq if `from` and `to` tokens are the same object") {
-    assert(tokenList.slice(tokens.head, tokens.head).isEmpty)
+    assert(tokenList.slice(tokens.head, tokens.head) == Seq())
   }
 
   test("slice returns empty seq if `from` comes after `to`") {
-    assert(tokenList.slice(tokens.last, tokens.head).isEmpty)
+    assert(tokenList.slice(tokens.last, tokens.head) == Seq())
   }
 
   test("slice fails if `from` token does not exist") {
     assertThrows[NoSuchElementException] {
-      tokenList.slice(tokens.head, new Token.EOF(Input.None, Scala211))
+      tokenList.slice(tokens.head, unknownToken)
     }
   }
 
   test("slice fails if `to` token does not exist") {
     assertThrows[NoSuchElementException] {
-      tokenList.slice(new Token.EOF(Input.None, Scala211), tokens.last)
+      tokenList.slice(unknownToken, tokens.last)
     }
   }
 


### PR DESCRIPTION
- Addresses #516. The original goal was to do this only for `TokenList.slice` but then I realized that `find` was also inconsistent.
  * `find` is not used anywhere in the repo
  * `slice` is used in 2 places: `ProcedureSyntax` & `ExplicitResultTypes`. For both of them this change won't cause any harm.

- Fixes a bug in `TokenList.leading` that was causing the first element in the token list (usually `Token.BOF`) being incorrectly dropped.

