### PR TITLE
Fix #535, remove trailing comma.

### DIFF
--- a/scalafix-tests/input/src/main/scala/test/RemoveUnusedImports2.scala
+++ b/scalafix-tests/input/src/main/scala/test/RemoveUnusedImports2.scala
@@ -1,0 +1,19 @@
+/*
+rule = RemoveUnusedImports
+ */
+package test
+
+import scala.sys.process.{
+  FileProcessLogger,
+  ProcessBuilder
+}
+import scala.math.{
+  Ordered,
+  Pi,
+  E
+}
+
+object RemoveUnusedImports2 {
+  val x: FileProcessLogger = ???
+  println(Ordered.orderingToOrdered(Pi))
+}

--- a/scalafix-tests/output/src/main/scala/test/RemoveUnusedImports.scala
+++ b/scalafix-tests/output/src/main/scala/test/RemoveUnusedImports.scala
@@ -7,9 +7,7 @@ import scala.util.{Success => Successful}
 import scala.concurrent.ExecutionContext
 import scala.runtime.{RichBoolean}
 import scala.concurrent.// formatting caveat
-
-
-  TimeoutException
+TimeoutException
 
 //import scala.concurrent.{
 //    CancellationException

--- a/scalafix-tests/output/src/main/scala/test/RemoveUnusedImports2.scala
+++ b/scalafix-tests/output/src/main/scala/test/RemoveUnusedImports2.scala
@@ -1,0 +1,14 @@
+package test
+
+import scala.sys.process.
+  FileProcessLogger
+
+import scala.math.{
+  Ordered,
+  Pi
+}
+
+object RemoveUnusedImports2 {
+  val x: FileProcessLogger = ???
+  println(Ordered.orderingToOrdered(Pi))
+}


### PR DESCRIPTION
Previously we never removed newlines, which meant that trailing commas
in grouped imports like after `b` in
```scala
import a.{
  b,
  c
}
```

were left behind, causing a syntax error (in <2.11 only).