### PR TITLE
Publish SNAPSHOT on merge.

### DIFF
--- a/bin/ci-publish.sh
+++ b/bin/ci-publish.sh
@@ -26,10 +26,13 @@ set-up-jekyll() {
 if [[ "$TRAVIS_SECURE_ENV_VARS" == true && "$CI_PUBLISH" == true ]]; then
   echo "Publishing..."
   git log | head -n 20
+  echo "$PGP_SECRET" | base64 --decode | gpg --import
   if [ -n "$TRAVIS_TAG" ]; then
-    echo "$PGP_SECRET" | base64 --decode | gpg --import
-    echo "Tag push, publishing release to Sonatype."
+    echo "Tag push, publishing stable release to Sonatype."
     sbt ci-release sonatypeReleaseAll
+  else
+    echo "Merge, publishing snapshot to Sonatype."
+    sbt -Dscalafix.snapshot=true ci-release
   fi
   set-up-ssh
   set-up-jekyll

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,10 @@ import sbt.ScriptedPlugin._
 import Dependencies._
 
 version.in(ThisBuild) ~= { old: String =>
-  sys.props.getOrElse("scalafix.version", old.replace('+', '-'))
+  val suffix =
+    if (sys.props.contains("scalafix.snapshot")) "-SNAPSHOT"
+    else ""
+  sys.props.getOrElse("scalafix.version", old.replace('+', '-') + suffix)
 }
 
 lazy val scalaFixedProjects: List[ProjectReference] =

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -176,7 +176,6 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
         "scalafix211/publishSigned" ::
         "scalafix-sbt/publishSigned" ::
         s"^^ $sbt1 scalafix-sbt/publishSigned" ::
-        "sonatypeReleaseAll" ::
         s
     },
     commands += Command.command("ci-sbt") { s =>
@@ -245,12 +244,10 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
   )
 
   override def projectSettings: Seq[Def.Setting[_]] = List(
-    publishTo := {
-      if (isCustomRepository) Some("adhoc" at adhocRepoUri)
-      else {
-        val uri = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-        Some("Releases" at uri)
-      }
+    publishTo := Some {
+      if (isCustomRepository) "adhoc" at adhocRepoUri
+      else if (isSnapshot.value) Opts.resolver.sonatypeSnapshots
+      else Opts.resolver.sonatypeStaging
     },
     scmInfo := Some(
       ScmInfo(


### PR DESCRIPTION
To make it easier to try out pre-releases, this commit configures the
CI to publish a -SNAPSHOT to sonatype on every merge.