### PR TITLE
Make DottyAutoTuplingFunctionArgs semantic

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/DottyAutoTuplingFunctionArgs.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/DottyAutoTuplingFunctionArgs.scala
@@ -1,0 +1,50 @@
+package scalafix.internal.rule
+
+import scala.meta._
+import scala.meta.tokens.Token._
+import scalafix.Patch
+import scalafix.rule.{Rule, RuleCtx}
+
+case object DottyAutoTuplingFunctionArgs
+    extends Rule("DottyAutoTuplingFunctionArgs") {
+  override def description: String =
+    "Rewrite that removes pattern-matching decomposition if function arguments can be automatically tupled in Dotty."
+
+  override def fix(ctx: RuleCtx): Patch =
+    ctx.tree.collect {
+      case Term.Apply((_, List(pf: Term.PartialFunction)))
+          if canBeAutoTupled(pf) =>
+        val pfTokens = pf.tokens
+
+        (for {
+          leftBrace <- pfTokens.headOption if leftBrace.is[LeftBrace]
+          rightBrace <- pfTokens.lastOption if rightBrace.is[RightBrace]
+          kwCase <- pfTokens.find(_.is[KwCase])
+        } yield {
+          val tkList = ctx.tokenList
+          val replacedBraces =
+            if (canReplaceBracesWithParens(pf)) {
+              ctx.replaceToken(leftBrace, "(") +
+                ctx.replaceToken(rightBrace, ")") +
+                ctx.removeTokens(tkList.leadingSpaces(leftBrace)) +
+                ctx.removeTokens(tkList.trailingSpaces(leftBrace)) +
+                ctx.removeTokens(tkList.leadingSpaces(rightBrace))
+            } else Patch.empty
+
+          replacedBraces +
+            ctx.removeToken(kwCase) +
+            ctx.removeTokens(tkList.trailingSpaces(kwCase))
+        }).asPatch
+    }.asPatch
+
+  private def canBeAutoTupled(pf: Term.PartialFunction): Boolean =
+    pf.cases match {
+      case Case(Pat.Tuple(args), None, _) :: Nil
+          if args.forall(a => a.is[Pat.Var] || a.is[Pat.Wildcard]) =>
+        true
+      case _ => false
+    }
+
+  private def canReplaceBracesWithParens(pf: Term.PartialFunction): Boolean =
+    pf.pos.startLine == pf.pos.endLine && pf.cases.head.stats.size == 1
+}

--- a/scalafix-core/shared/src/main/scala/scalafix/rule/ScalafixRules.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/rule/ScalafixRules.scala
@@ -14,6 +14,7 @@ object ScalafixRules {
     NoFinalize,
     DottyKeywords,
     DottyVarArgPattern,
+    DottyAutoTuplingFunctionArgs,
     DisableSyntax()
   )
   def semantic(index: SemanticdbIndex): List[Rule] = List(

--- a/scalafix-core/shared/src/main/scala/scalafix/rule/ScalafixRules.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/rule/ScalafixRules.scala
@@ -14,7 +14,6 @@ object ScalafixRules {
     NoFinalize,
     DottyKeywords,
     DottyVarArgPattern,
-    DottyAutoTuplingFunctionArgs,
     DisableSyntax()
   )
   def semantic(index: SemanticdbIndex): List[Rule] = List(
@@ -24,6 +23,7 @@ object ScalafixRules {
     RemoveUnusedImports(index),
     RemoveUnusedTerms(index),
     NoAutoTupling(index),
+    DottyAutoTuplingFunctionArgs(index),
     Disable(index, DisableConfig.default),
     DisableUnless(index, DisableUnlessConfig.default)
   )

--- a/scalafix-tests/input/src/main/scala/test/DottyAutoTuplingFunctionArgs.scala
+++ b/scalafix-tests/input/src/main/scala/test/DottyAutoTuplingFunctionArgs.scala
@@ -1,0 +1,36 @@
+/*
+rules = DottyAutoTuplingFunctionArgs
+ */
+package test
+
+object DottyAutoTuplingFunctionArgs {
+  Some((1, 2)).map { case (a, b) => a + b }
+  List((1, 2, 3), (4, 5, 6)).map { case (a, b, c) => println(a); a + b + c }
+  List((1, 2), (3, 4)).foreach { case (a, b) => { val c = a + b; println(c) } }
+  Set((1, 2, 3)).map { case (a, b, c) =>
+    println(a + b + c)
+  }
+  List((1, 1, 1, 1, 1), (2, 2, 2, 2, 2)).flatMap{
+    case (_, _, _, _, n) => List(n)
+  }
+  val xs = List("3", "1", "0").zipWithIndex
+  xs.filter { case (w, i) => w == i.toString }
+
+  // should not rewrite the below
+  xs.map { case (w, i) if i > 1 => s"$w-$i" } // case with guards
+  List((Some(1), Some(1))).map { case (Some(a), Some(b)) => a + b } // extraction
+  xs.map {
+    case (a, b) => a + b
+    case _ => 0
+  } // multiple cases
+  xs.find { case (_, x @ b) => x - b == 0 } // binding
+  xs.map { case ("0", 0) => "zero" } // literals
+  List(("a", 1, false, 1.0), ("b", 2, true, 2.0)).exists{
+    case (_: String, _: Int, c: Boolean, _: Double) => c
+  } // typed parameters
+  class A
+  class B extends A
+  def foo(xs: List[(A, A)]) = xs.map {
+    case (x: B, y: A) => 1
+  } // typed parameters not matching tuple element types
+}

--- a/scalafix-tests/input/src/main/scala/test/DottyAutoTuplingFunctionArgs.scala
+++ b/scalafix-tests/input/src/main/scala/test/DottyAutoTuplingFunctionArgs.scala
@@ -33,4 +33,8 @@ object DottyAutoTuplingFunctionArgs {
   def foo(xs: List[(A, A)]) = xs.map {
     case (x: B, y: A) => 1
   } // typed parameters not matching tuple element types
+  def any(xs: List[Any]): List[Int] = xs.map { case (x, y) => 1 }
+  def anyIntPair(xs: List[(Int, Any)]): List[Int] = xs.map { case (x, y) => 1 }
+  def anyAnyPair(xs: List[(Any, Any)]): List[Int] = xs.map { case (x, y) => 1 } // false negative
+  def tparam[T](xs: List[T]): List[Int] = xs.map { case (x, y) => 1 }
 }

--- a/scalafix-tests/output-dotty/src/main/scala/test/DottyAutoTuplingFunctionArgs.scala
+++ b/scalafix-tests/output-dotty/src/main/scala/test/DottyAutoTuplingFunctionArgs.scala
@@ -30,4 +30,8 @@ object DottyAutoTuplingFunctionArgs {
   def foo(xs: List[(A, A)]) = xs.map {
     case (x: B, y: A) => 1
   } // typed parameters not matching tuple element types
+  def any(xs: List[Any]): List[Int] = xs.map { case (x, y) => 1 }
+  def anyIntPair(xs: List[(Int, Any)]): List[Int] = xs.map((x, y) => 1)
+  def anyAnyPair(xs: List[(Any, Any)]): List[Int] = xs.map { case (x, y) => 1 } // false negative
+  def tparam[T](xs: List[T]): List[Int] = xs.map { case (x, y) => 1 }
 }

--- a/scalafix-tests/output-dotty/src/main/scala/test/DottyAutoTuplingFunctionArgs.scala
+++ b/scalafix-tests/output-dotty/src/main/scala/test/DottyAutoTuplingFunctionArgs.scala
@@ -1,0 +1,33 @@
+package test
+
+object DottyAutoTuplingFunctionArgs {
+  Some((1, 2)).map((a, b) => a + b)
+  List((1, 2, 3), (4, 5, 6)).map { (a, b, c) => println(a); a + b + c }
+  List((1, 2), (3, 4)).foreach { (a, b) => { val c = a + b; println(c) } }
+  Set((1, 2, 3)).map { (a, b, c) =>
+    println(a + b + c)
+  }
+  List((1, 1, 1, 1, 1), (2, 2, 2, 2, 2)).flatMap{
+    (_, _, _, _, n) => List(n)
+  }
+  val xs = List("3", "1", "0").zipWithIndex
+  xs.filter((w, i) => w == i.toString)
+
+  // should not rewrite the below
+  xs.map { case (w, i) if i > 1 => s"$w-$i" } // case with guards
+  List((Some(1), Some(1))).map { case (Some(a), Some(b)) => a + b } // extraction
+  xs.map {
+    case (a, b) => a + b
+    case _ => 0
+  } // multiple cases
+  xs.find { case (_, x @ b) => x - b == 0 } // binding
+  xs.map { case ("0", 0) => "zero" } // literals
+  List(("a", 1, false, 1.0), ("b", 2, true, 2.0)).exists{
+    case (_: String, _: Int, c: Boolean, _: Double) => c
+  } // typed parameters
+  class A
+  class B extends A
+  def foo(xs: List[(A, A)]) = xs.map {
+    case (x: B, y: A) => 1
+  } // typed parameters not matching tuple element types
+}

--- a/website/src/main/resources/microsite/data/rules.yml
+++ b/website/src/main/resources/microsite/data/rules.yml
@@ -6,6 +6,7 @@ rules:
 - DottyVolatileLazyVal
 - ExplicitUnit
 - DottyVarArgPattern
+- DottyAutoTuplingFunctionArgs
 - NoAutoTupling
 - NoValInForComprehension
 - Sbt1

--- a/website/src/main/tut/docs/rules/DottyAutoTuplingFunctionArgs.md
+++ b/website/src/main/tut/docs/rules/DottyAutoTuplingFunctionArgs.md
@@ -10,10 +10,11 @@ _Since v0.5.8_
 Removes pattern-matching decomposition if function arguments can be automatically tupled. See [http://dotty.epfl.ch/docs/reference/auto-parameter-tupling.html](http://dotty.epfl.ch/docs/reference/auto-parameter-tupling.html)
 
 ```scala
+val ranges: List[(Int, Int)] = ((1, 5), (9, 11))
 // before
-xs.map { case (x, y) => x + y }
+ranges.map { case (start, end) => end - start }
 // after
-xs.map((x, y) => x + y)
+ranges.map((start, end) => end - start)
 ```
 
 Auto-tupling is a language feature only supported in Dotty. Therefore, the code produced by this rewrite does not compile with Scala 2.x.

--- a/website/src/main/tut/docs/rules/DottyAutoTuplingFunctionArgs.md
+++ b/website/src/main/tut/docs/rules/DottyAutoTuplingFunctionArgs.md
@@ -1,0 +1,23 @@
+---
+layout: docs
+title: DottyAutoTuplingFunctionArgs
+---
+
+_Since v0.5.8_
+
+# DottyAutoTuplingFunctionArgs
+
+Removes pattern-matching decomposition if function arguments can be automatically tupled. See [http://dotty.epfl.ch/docs/reference/auto-parameter-tupling.html](http://dotty.epfl.ch/docs/reference/auto-parameter-tupling.html)
+
+```scala
+// before
+xs.map { case (x, y) => x + y }
+// after
+xs.map((x, y) => x + y)
+```
+
+Auto-tupling is a language feature only supported in Dotty. Therefore, the code produced by this rewrite does not compile with Scala 2.x.
+
+## Caveats
+
+- [#521](https://github.com/scalacenter/scalafix/issues/521) - the rewrite has false positives, be sure to manually verify that the sources compile with Dotty after running the rewrite.

--- a/website/src/main/tut/docs/rules/DottyAutoTuplingFunctionArgs.md
+++ b/website/src/main/tut/docs/rules/DottyAutoTuplingFunctionArgs.md
@@ -20,4 +20,4 @@ Auto-tupling is a language feature only supported in Dotty. Therefore, the code 
 
 ## Caveats
 
-- [#521](https://github.com/scalacenter/scalafix/issues/521) - the rewrite has false positives, be sure to manually verify that the sources compile with Dotty after running the rewrite.
+- the rewrite has false negatives, meaning it may not trigger for cases where the rewrite would still be safe. In particular, the rewrite ignores cases when all deconstructed arguments are `Any`.


### PR DESCRIPTION
Fixes #521. While thinking about the problem more I realized we are able to tell with the current API if all of the deconstructed arguments are `scala.Any`. This is sufficient for us to guard against the cases where `Any` or a tparam `T` is pattern matched into `(Any, Any)`. 

Review @marcelocenerine 