### PR TITLE
Fix several ExplicitResultTypes bugs.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 /* scalafmt: { maxColumn = 120 }*/
 
 object Dependencies {
-  val scalametaV = "2.1.6"
+  val scalametaV = "2.1.7"
   val metaconfigV = "0.5.4"
   def semanticdbSbt = "0.4.0"
   def dotty = "0.1.1-bin-20170530-f8f52cc-NIGHTLY"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 /* scalafmt: { maxColumn = 120 }*/
 
 object Dependencies {
-  val scalametaV = "2.1.2"
+  val scalametaV = "2.1.6"
   val metaconfigV = "0.5.4"
   def semanticdbSbt = "0.4.0"
   def dotty = "0.1.1-bin-20170530-f8f52cc-NIGHTLY"
@@ -11,7 +11,7 @@ object Dependencies {
   // NOTE(olafur) downgraded from 2.11.12 and 2.12.4 because of non-reproducible error
   // https://travis-ci.org/scalacenter/scalafix/jobs/303142842#L4658
   // as well as https://github.com/scala/bug/issues/10609
-  def scala211 = "2.11.11"
+  def scala211 = "2.11.12"
   def scala212 = "2.12.4"
   val currentScalaVersion = scala212
 

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -250,6 +250,7 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
       else if (isSnapshot.value) Opts.resolver.sonatypeSnapshots
       else Opts.resolver.sonatypeStaging
     },
+    resolvers += Opts.resolver.sonatypeSnapshots,
     scmInfo := Some(
       ScmInfo(
         url("https://github.com/scalacenter/scalafix"),

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -250,7 +250,6 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
       else if (isSnapshot.value) Opts.resolver.sonatypeSnapshots
       else Opts.resolver.sonatypeStaging
     },
-    resolvers += Opts.resolver.sonatypeSnapshots,
     scmInfo := Some(
       ScmInfo(
         url("https://github.com/scalacenter/scalafix"),

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/TypeSyntax.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/TypeSyntax.scala
@@ -13,7 +13,7 @@ object TypeSyntax {
       implicit index: SemanticdbIndex): (Type, Patch) = {
 
     val functionN: SymbolMatcher = SymbolMatcher.exact(
-      1.to(22).map(i => Symbol(s"_root_.scala.Function$i#")): _*
+      0.to(22).map(i => Symbol(s"_root_.scala.Function$i#")): _*
     )
     val tupleN: SymbolMatcher = SymbolMatcher.exact(
       1.to(22).map(i => Symbol(s"_root_.scala.Tuple$i#")): _*
@@ -33,7 +33,7 @@ object TypeSyntax {
       }
     }
 
-    def stableRef(sym: Symbol): (Patch, Tree) = {
+    def stableRef(sym: Symbol.Global): (Patch, Tree) = {
       var patch = Patch.empty
       def loop[T: ClassTag](symbol: Symbol): T = {
         val result = symbol match {
@@ -87,10 +87,12 @@ object TypeSyntax {
         case Type.Apply(tupleN(_), args) =>
           val rargs = apply_![Type](args)
           Type.Tuple(rargs)
-        case Name(_) :&&: index.Symbol(sym) =>
+        case Name(_) :&&: index.Symbol(sym: Symbol.Global) =>
           val (addImport, t) = stableRef(sym)
           patch += addImport
           t
+        case Type.Select(Term.This(_), _) =>
+          tree
         case Type.Select(qual, name) =>
           Type.Select(apply_![Term.Ref](qual), name)
         case els =>

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/TypeSyntax.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/TypeSyntax.scala
@@ -95,6 +95,8 @@ object TypeSyntax {
           tree
         case Type.Select(qual, name) =>
           Type.Select(apply_![Term.Ref](qual), name)
+        case Type.Project(qual, name) =>
+          Type.Project(apply_![Type](qual), name)
         case els =>
           super.apply(els)
       }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/TypeSyntax.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/TypeSyntax.scala
@@ -33,21 +33,33 @@ object TypeSyntax {
       }
     }
 
-    def stableRef(sym: Symbol.Global): (Patch, Tree) = {
+    /**
+      * Returns a scala.meta.Tree given a scala.meta.Symbol.
+      *
+      * Before: _root_.scala.Predef.Set#
+      * After: Type.Select(Term.Select(Term.Name("scala"), Term.Name("Predef")),
+      *                    Type.Name("Set"))
+      */
+    def symbolToTree(sym: Symbol.Global): (Patch, Tree) = {
       var patch = Patch.empty
       def loop[T: ClassTag](symbol: Symbol): T = {
         val result = symbol match {
+          // base case, symbol `_root_.`  becomes `_root_` term
           case Symbol.Global(Symbol.None, Signature.Term(name)) =>
             Term.Name(name)
+          // symbol `A#B#`  becomes `A#B` type
           case Symbol.Global(owner @ SymbolType(), Signature.Type(name)) =>
             Type.Project(loop[Type](owner), Type.Name(name))
+          // symbol `A#B#`  becomes `A#B` type
           case Symbol.Global(owner, Signature.Term(name)) =>
+            // TODO(olafur) implement lookup utility to query what symbol signature resolves to.
             if (shortenNames && isStable(owner)) {
               patch += ctx.addGlobalImport(symbol)
               Term.Name(name)
             } else {
               Term.Select(loop[Term.Ref](owner), Term.Name(name))
             }
+          // symbol `a.B#`  becomes `a.B` type
           case Symbol.Global(owner, Signature.Type(name)) =>
             if (shortenNames && isStable(owner)) {
               patch += ctx.addGlobalImport(symbol)
@@ -81,20 +93,39 @@ object TypeSyntax {
           case els => typeMismatch(els, ev)
         }
       override def apply(tree: Tree): Tree = tree match {
+        // before: Function2[A, B]
+        // after: A => B
         case Type.Apply(functionN(_), args) =>
           val rargs = apply_![Type](args)
           Type.Function(rargs.init, rargs.last)
+        // before: Tuple[A, B]
+        // after: (A, B)
         case Type.Apply(tupleN(_), args) =>
           val rargs = apply_![Type](args)
           Type.Tuple(rargs)
+        // before: HashSet (which resolves to _root_.scala.collection.mutable.HashSet in SemanticdbIndex)
+        // after (if shortenNames=false):
+        //   _root_.scala.collection.mutable.HashSet
+        // after (if shortenNames=true):
+        //   import scala.collection.mutable.HashSet
+        //   HashSet
         case Name(_) :&&: index.Symbol(sym: Symbol.Global) =>
-          val (addImport, t) = stableRef(sym)
+          val (addImport, t) = symbolToTree(sym)
           patch += addImport
           t
+        // before: A.this.B
+        // after: A.this.B
         case Type.Select(Term.This(_), _) =>
           tree
+        // Given:
+        //   val term: com.Bar
+        //   val x: term.Tpe = ???
+        // avoid `term.com.Bar#Tpe` by not recursing on Tpe.
         case Type.Select(qual, name) =>
           Type.Select(apply_![Term.Ref](qual), name)
+        // Given:
+        //   val x: A#B = ???
+        // don't recurse on B
         case Type.Project(qual, name) =>
           Type.Project(apply_![Type](qual), name)
         case els =>

--- a/scalafix-tests/input/src/main/scala/test/explicitResultTypes/ExplicitResultTypesBase.scala
+++ b/scalafix-tests/input/src/main/scala/test/explicitResultTypes/ExplicitResultTypesBase.scala
@@ -15,6 +15,7 @@ object ExplicitResultTypesBase {
   protected val d = 1.0f
   protected def e(a: Int, b: Double) = a + b
   protected var f = (x: Int) => x + 1
+  val f0 = () => 42
   private val g = 1
   private def h(a: Int) = ""
   private var i = 22

--- a/scalafix-tests/input/src/main/scala/test/explicitResultTypes/ExplicitResultTypesPathDependent.scala
+++ b/scalafix-tests/input/src/main/scala/test/explicitResultTypes/ExplicitResultTypesPathDependent.scala
@@ -11,4 +11,9 @@ object ExplicitResultTypesPathDependent {
     def gimme(yy: x.C) = ???; gimme(y)
   }
   implicit val b = new Path().x
+  trait Foo[T] {
+    type Self
+    def bar: Self
+  }
+  implicit def foo[T] = null.asInstanceOf[Foo[T]].bar
 }

--- a/scalafix-tests/output/src/main/scala/test/explicitResultTypes/ExplicitResultTypesBase.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitResultTypes/ExplicitResultTypesBase.scala
@@ -10,6 +10,7 @@ object ExplicitResultTypesBase {
   protected val d = 1.0f
   protected def e(a: Int, b: Double): _root_.scala.Double = a + b
   protected var f: _root_.scala.Int => _root_.scala.Int = (x: Int) => x + 1
+  val f0: () => _root_.scala.Int = () => 42
   private val g = 1
   private def h(a: Int) = ""
   private var i = 22

--- a/scalafix-tests/output/src/main/scala/test/explicitResultTypes/ExplicitResultTypesPathDependent.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitResultTypes/ExplicitResultTypesPathDependent.scala
@@ -3,7 +3,7 @@ package test.explicitResultTypes
 object ExplicitResultTypesPathDependent {
   class Path {
     class B { class C }
-    implicit val x: _root_.test.explicitResultTypes.ExplicitResultTypesPathDependent.Path#B = new B
+    implicit val x: Path.this.B = new B
     implicit val y: x.C = new x.C
     def gimme(yy: x.C) = ???; gimme(y)
   }

--- a/scalafix-tests/output/src/main/scala/test/explicitResultTypes/ExplicitResultTypesPathDependent.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitResultTypes/ExplicitResultTypesPathDependent.scala
@@ -8,4 +8,9 @@ object ExplicitResultTypesPathDependent {
     def gimme(yy: x.C) = ???; gimme(y)
   }
   implicit val b: _root_.test.explicitResultTypes.ExplicitResultTypesPathDependent.Path#B = new Path().x
+  trait Foo[T] {
+    type Self
+    def bar: Self
+  }
+  implicit def foo[T]: _root_.test.explicitResultTypes.ExplicitResultTypesPathDependent.Foo[T]#Self = null.asInstanceOf[Foo[T]].bar
 }


### PR DESCRIPTION
- unary functions were printed as Function0[T] instead of () => T
- local symbols caused MatchError in TypeSyntax.prettify
- upgrade to scalameta 2.1.6 to to enjoy https://github.com/scalameta/scalameta/pull/1216

These fixes combined make ExplicitResultTypes safe to run on over 60k loc in
the akka build. It still has some bugs left, see
https://github.com/scalameta/scalameta/issues/1222