### PR TITLE
Upgrade to metaconfig v0.6 with generic derivation for decoders.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -436,6 +436,7 @@ lazy val website = project
     noPublish,
     websiteSettings,
     unidocSettings,
+    libraryDependencies += "com.geirsson" %% "metaconfig-docs" % metaconfigV,
     unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(
       testkit212,
       core212JVM)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 
 object Dependencies {
   val scalametaV = "2.1.7"
-  val metaconfigV = "0.5.4"
+  val metaconfigV = "0.6.0-RC1"
   def semanticdbSbt = "0.4.0"
   def dotty = "0.1.1-bin-20170530-f8f52cc-NIGHTLY"
   def scala210 = "2.10.6"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.9.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.7")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.15")
-addSbtPlugin("com.47deg" % "sbt-microsites" % "0.7.4")
+addSbtPlugin("com.47deg" % "sbt-microsites" % "0.7.15")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.1")
 
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value

--- a/scalafix-cli/src/main/scala/scalafix/internal/jgit/JGitDiff.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/jgit/JGitDiff.scala
@@ -61,13 +61,13 @@ object JGitDiff {
 
               Configured.Ok(DiffDisable(diffs))
             }
-            case Left(msg) => ConfError.msg(msg).notOk
+            case Left(msg) => ConfError.message(msg).notOk
           }
         }
-        case Left(msg) => ConfError.msg(msg).notOk
+        case Left(msg) => ConfError.message(msg).notOk
       }
     } else {
-      ConfError.msg(s"$workingDir is not a git repository").notOk
+      ConfError.message(s"$workingDir is not a git repository").notOk
     }
   }
 

--- a/scalafix-core/shared/src/main/scala/scalafix/config/CustomMessage.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/config/CustomMessage.scala
@@ -2,6 +2,8 @@ package scalafix
 package config
 
 import metaconfig.{Conf, ConfDecoder}
+import scala.meta.Symbol
+import scalafix.internal.config.ScalafixMetaconfigReaders._
 
 class CustomMessage[T](
     val value: T,
@@ -9,6 +11,8 @@ class CustomMessage[T](
     val id: Option[String])
 
 object CustomMessage {
+  implicit val SymbolDecoder: ConfDecoder[CustomMessage[Symbol.Global]] =
+    decoder[Symbol.Global](field = "symbol")
   def decoder[T](field: String)(
       implicit ev: ConfDecoder[T]): ConfDecoder[CustomMessage[T]] =
     ConfDecoder.instance[CustomMessage[T]] {

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/Class2Hocon.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/Class2Hocon.scala
@@ -1,7 +1,19 @@
 package scalafix.internal.config
 
 import metaconfig.HasFields
-import metaconfig.String2AnyMap
+
+object String2AnyMap {
+  def unapply(arg: Any): Option[Map[String, Any]] = arg match {
+    case someMap: Map[_, _] =>
+      try {
+        Some(someMap.asInstanceOf[Map[String, Any]])
+      } catch {
+        case _: ClassCastException =>
+          None
+      }
+    case _ => None
+  }
+}
 
 object Class2Hocon {
 

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/ConfigRulePatches.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/ConfigRulePatches.scala
@@ -5,25 +5,22 @@ import scalafix.patch.TreePatch.AddGlobalImport
 import scalafix.patch.TreePatch.ReplaceSymbol
 import scalafix.patch.TreePatch.RemoveGlobalImport
 import metaconfig.ConfDecoder
+import metaconfig.generic
+import metaconfig.generic.Surface
 
 case class ConfigRulePatches(
     replaceSymbols: List[ReplaceSymbol] = Nil,
     addGlobalImports: List[AddGlobalImport] = Nil,
     removeGlobalImports: List[RemoveGlobalImport] = Nil
 ) {
-  val reader: ConfDecoder[ConfigRulePatches] =
-    ConfDecoder.instanceF[ConfigRulePatches] { conf =>
-      import conf._
-      (
-        getOrElse("replaceSymbols")(replaceSymbols) |@|
-          getOrElse("addGlobalImports")(addGlobalImports) |@|
-          getOrElse("removeGlobalImports")(removeGlobalImports)
-      ).map { case ((a, b), c) => ConfigRulePatches(a, b, c) }
-    }
   def all: List[Patch] =
     replaceSymbols ++ addGlobalImports ++ removeGlobalImports
 }
 
 object ConfigRulePatches {
+  implicit val surface: Surface[ConfigRulePatches] =
+    generic.deriveSurface[ConfigRulePatches]
   val default: ConfigRulePatches = ConfigRulePatches()
+  implicit val configRuleDecoder: ConfDecoder[ConfigRulePatches] =
+    generic.deriveDecoder[ConfigRulePatches](default)
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/DebugConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/DebugConfig.scala
@@ -1,5 +1,12 @@
 package scalafix.internal.config
 
+import metaconfig.generic
+
 case class DebugConfig(
     printSymbols: Boolean = false
 )
+object DebugConfig {
+  implicit val surface = generic.deriveSurface[DebugConfig]
+  val default = DebugConfig()
+  implicit val decoder = generic.deriveDecoder[DebugConfig](default)
+}

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/DebugConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/DebugConfig.scala
@@ -1,12 +1,16 @@
 package scalafix.internal.config
 
 import metaconfig.generic
+import metaconfig.ConfDecoder
+import metaconfig.generic.Surface
 
 case class DebugConfig(
     printSymbols: Boolean = false
 )
 object DebugConfig {
-  implicit val surface = generic.deriveSurface[DebugConfig]
+  implicit val surface: Surface[DebugConfig] =
+    generic.deriveSurface[DebugConfig]
   val default = DebugConfig()
-  implicit val decoder = generic.deriveDecoder[DebugConfig](default)
+  implicit val decoder: ConfDecoder[DebugConfig] =
+    generic.deriveDecoder[DebugConfig](default)
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/DisableConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/DisableConfig.scala
@@ -2,9 +2,10 @@ package scalafix
 package internal.config
 
 import metaconfig.ConfDecoder
-import MetaconfigPendingUpstream.XtensionConfScalafix
 import org.langmeta.Symbol
 import scalafix.internal.util.SymbolOps
+import metaconfig.generic
+import metaconfig.generic.Surface
 
 case class DisableConfig(symbols: List[CustomMessage[Symbol.Global]] = Nil) {
   def allSymbols: List[Symbol.Global] = symbols.map(_.value)
@@ -17,17 +18,12 @@ case class DisableConfig(symbols: List[CustomMessage[Symbol.Global]] = Nil) {
   def customMessage(
       symbol: Symbol.Global): Option[CustomMessage[Symbol.Global]] =
     messageBySymbol.get(SymbolOps.normalize(symbol).syntax)
-
-  implicit val customMessageReader: ConfDecoder[CustomMessage[Symbol.Global]] =
-    CustomMessage.decoder(field = "symbol")
-
-  implicit val reader: ConfDecoder[DisableConfig] =
-    ConfDecoder.instanceF[DisableConfig](
-      _.getField(symbols).map(DisableConfig(_))
-    )
 }
 
 object DisableConfig {
   val default: DisableConfig = DisableConfig()
-  implicit val reader: ConfDecoder[DisableConfig] = default.reader
+  implicit val surface: Surface[DisableConfig] =
+    generic.deriveSurface[DisableConfig]
+  implicit val decoder: ConfDecoder[DisableConfig] =
+    generic.deriveDecoder[DisableConfig](default)
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/DisableConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/DisableConfig.scala
@@ -4,10 +4,29 @@ package internal.config
 import metaconfig.ConfDecoder
 import org.langmeta.Symbol
 import scalafix.internal.util.SymbolOps
+import metaconfig.annotation.Description
+import metaconfig.annotation.ExampleValue
 import metaconfig.generic
 import metaconfig.generic.Surface
 
-case class DisableConfig(symbols: List[CustomMessage[Symbol.Global]] = Nil) {
+case class DisableConfig(
+    @Description("The list of symbols to disable.")
+    @ExampleValue(
+      """[
+        |  # With custom message (recommended)
+        |  {
+        |    symbol = "scala.Predef.any2stringadd"
+        |    message = "Use explicit toString before calling +"
+        |  }
+        |  {
+        |    symbol = "scala.Any"
+        |    message = "Explicitly type annotate Any if this is intentional"
+        |  }
+        |  # Without custom message (discouraged)
+        |  "com.Lib.implicitConversion"
+        |]""".stripMargin)
+    symbols: List[CustomMessage[Symbol.Global]] = Nil
+) {
   def allSymbols: List[Symbol.Global] = symbols.map(_.value)
 
   private val messageBySymbol: Map[String, CustomMessage[Symbol.Global]] =

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/DisableSyntaxConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/DisableSyntaxConfig.scala
@@ -39,7 +39,7 @@ case class DisableSyntaxConfig(
         Configured.Ok(Pattern.compile(pattern, Pattern.MULTILINE))
       } catch {
         case ex: PatternSyntaxException =>
-          Configured.NotOk(ConfError.msg(ex.getMessage))
+          Configured.NotOk(ConfError.message(ex.getMessage))
     })
   }
 
@@ -144,7 +144,7 @@ object DisabledKeyword {
       if (relativeDistance < 0.20) s" (Did you mean: $closestKeyword?)"
       else ""
 
-    ConfError.msg(s"$keyword is not in our supported keywords.$didYouMean")
+    ConfError.message(s"$keyword is not in our supported keywords.$didYouMean")
   }
 
   /** Levenshtein distance. Implementation based on Wikipedia's algorithm. */

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/DisableUnlessConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/DisableUnlessConfig.scala
@@ -22,7 +22,7 @@ object UnlessConfig {
           c.get[List[CustomMessage[Symbol.Global]]]("symbols")).map {
           case (a, b) => UnlessConfig(a, b)
         }
-      case _ => Configured.NotOk(ConfError.msg("Wrong config format"))
+      case _ => Configured.NotOk(ConfError.message("Wrong config format"))
     }
 }
 

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/DisableUnlessConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/DisableUnlessConfig.scala
@@ -12,9 +12,8 @@ case class UnlessConfig(
     symbols: List[CustomMessage[Symbol.Global]])
 
 object UnlessConfig {
-  implicit val customMessageReader: ConfDecoder[CustomMessage[Symbol.Global]] =
-    CustomMessage.decoder(field = "symbol")
-
+  // NOTE(olafur): metaconfig.generic.deriveDecoder requires a default base values.
+  // Here we require all fields to be provided by the user so we write the decoder manually.
   implicit val reader: ConfDecoder[UnlessConfig] =
     ConfDecoder.instanceF[UnlessConfig] {
       case c: Conf.Obj =>

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/ExplicitResultTypesConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/ExplicitResultTypesConfig.scala
@@ -1,36 +1,37 @@
 package scalafix.internal.config
 
 import metaconfig._
-import MetaconfigPendingUpstream.XtensionConfScalafix
+import metaconfig.generic.Surface
+import metaconfig.annotation._
 
 case class ExplicitResultTypesConfig(
+    @Description("Enable/disable this rule for defs, vals or vars.")
+    @ExampleValue("[Def, Val, Var]")
     memberKind: List[MemberKind] = Nil,
+    @Description("Enable/disable this rule for private/protected members.")
+    @ExampleValue("[Public, Protected]")
     memberVisibility: List[MemberVisibility] = Nil,
+    @Description(
+      "If false, insert explicit result types even for simple definitions like `val x = 2`")
     skipSimpleDefinitions: Boolean = true,
+    @Description(
+      "If false, insert explicit result types even for locally defined implicit vals")
     skipLocalImplicits: Boolean = true,
     // Experimental, still blocked by https://github.com/scalameta/scalameta/issues/1099
     // to work for defs. May insert names that conflicts with existing names in scope.
     // Use at your own risk.
+    @Description(
+      "If true, does a best-effort at inserting short names and add missing imports. " +
+        "WARNING. This feature is currently implemented in a naive way and it contains many bugs.")
     unsafeShortenNames: Boolean = false
-) {
-  implicit val reader: ConfDecoder[ExplicitResultTypesConfig] =
-    ConfDecoder.instanceF[ExplicitResultTypesConfig] { c =>
-      (
-        c.getField(memberKind) |@|
-          c.getField(memberVisibility) |@|
-          c.getField(skipSimpleDefinitions) |@|
-          c.getField(skipLocalImplicits) |@|
-          c.getField(unsafeShortenNames)
-      ).map {
-        case ((((a, b), c), d), e) =>
-          ExplicitResultTypesConfig(a, b, c, d, e)
-      }
-    }
-}
+)
 
 object ExplicitResultTypesConfig {
   val default: ExplicitResultTypesConfig = ExplicitResultTypesConfig()
-  implicit val reader: ConfDecoder[ExplicitResultTypesConfig] = default.reader
+  implicit val reader: ConfDecoder[ExplicitResultTypesConfig] =
+    generic.deriveDecoder[ExplicitResultTypesConfig](default)
+  implicit val surface: Surface[ExplicitResultTypesConfig] =
+    generic.deriveSurface[ExplicitResultTypesConfig]
 }
 
 sealed trait MemberVisibility

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/LintConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/LintConfig.scala
@@ -2,6 +2,8 @@ package scalafix.internal.config
 
 import scalafix.lint.LintSeverity
 import metaconfig.ConfDecoder
+import metaconfig.generic
+import metaconfig.generic.Surface
 
 case class LintConfig(
     reporter: ScalafixReporter = ScalafixReporter.default,
@@ -11,18 +13,6 @@ case class LintConfig(
     warning: FilterMatcher = FilterMatcher.matchNothing,
     error: FilterMatcher = FilterMatcher.matchNothing
 ) {
-  val reader: ConfDecoder[LintConfig] =
-    ConfDecoder.instanceF[LintConfig] { c =>
-      (
-        c.getOrElse("reporter")(reporter) |@|
-          c.getOrElse("explain")(explain) |@|
-          c.getOrElse("ignore")(ignore) |@|
-          c.getOrElse("info")(info) |@|
-          c.getOrElse("warning")(warning) |@|
-          c.getOrElse("error")(error)
-      ).map { case (((((a, b), c), d), e), f) => LintConfig(a, b, c, d, e, f) }
-    }
-
   def getConfiguredSeverity(key: String): Option[LintSeverity] =
     Option(key).collect {
       case error() => LintSeverity.Error
@@ -32,5 +22,8 @@ case class LintConfig(
 }
 
 object LintConfig {
+  implicit val surface: Surface[LintConfig] = generic.deriveSurface[LintConfig]
   lazy val default: LintConfig = LintConfig()
+  implicit val decoder: ConfDecoder[LintConfig] =
+    generic.deriveDecoder[LintConfig](default)
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/MetaconfigPendingUpstream.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/MetaconfigPendingUpstream.scala
@@ -5,9 +5,7 @@ import metaconfig.Conf
 import metaconfig.ConfDecoder
 import metaconfig.ConfError
 import metaconfig.Configured
-import metaconfig.Configured.NotOk
-import metaconfig.Configured.Ok
-import metaconfig.Metaconfig
+import metaconfig.internal.ConfGet
 
 // TODO(olafur) contribute upstream to metaconfig.
 object MetaconfigPendingUpstream {
@@ -19,39 +17,14 @@ object MetaconfigPendingUpstream {
   }
   def getKey[T](conf: Conf.Obj, path: String, extraNames: String*)(
       implicit ev: ConfDecoder[T]): Configured[T] = {
-    Metaconfig.getKey(conf, path +: extraNames) match {
+    ConfGet.getKey(conf, path +: extraNames) match {
       case Some(value) => ev.read(value)
       case None => ConfError.missingField(conf, path).notOk
     }
   }
-  def get_![T](configured: Configured[T]): T = configured match {
-    case Ok(a) => a
-    case NotOk(e) => sys.error(e.toString())
-  }
 
-  def orElse[T](a: ConfDecoder[T], b: ConfDecoder[T]): ConfDecoder[T] =
-    a.orElse(b)
   implicit class XtensionConfScalafix(conf: Conf) {
     def getField[T: ConfDecoder](e: sourcecode.Text[T]): Configured[T] =
       conf.getOrElse(e.source)(e.value)
-  }
-  implicit class XtensionConfDecoderSeqConfigured[T](lst: Seq[Configured[T]]) {
-    def flipSeq: Configured[Seq[T]] =
-      MetaconfigPendingUpstream.this.flipSeq(lst)
-  }
-  implicit class XtensionConfDecoderScalafix[T](decoder: ConfDecoder[T]) {
-    def orElse(other: ConfDecoder[T]): ConfDecoder[T] =
-      new ConfDecoder[T] {
-        override def read(conf: Conf): Configured[T] =
-          decoder.read(conf) match {
-            case ok @ Configured.Ok(_) => ok
-            case Configured.NotOk(notOk) =>
-              other.read(conf) match {
-                case ok2 @ Configured.Ok(_) => ok2
-                case Configured.NotOk(notOk2) =>
-                  notOk.combine(notOk2).notOk
-              }
-          }
-      }
   }
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/NoInferConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/NoInferConfig.scala
@@ -3,11 +3,13 @@ package scalafix.internal.config
 import metaconfig.ConfDecoder
 import org.langmeta.Symbol
 import metaconfig.generic
+import metaconfig.generic.Surface
 
 case class NoInferConfig(symbols: List[Symbol.Global] = Nil) {}
 
 object NoInferConfig {
-  implicit val surface = generic.deriveSurface[NoInferConfig]
+  implicit val surface: Surface[NoInferConfig] =
+    generic.deriveSurface[NoInferConfig]
   val default: NoInferConfig = NoInferConfig()
   implicit val decoder: ConfDecoder[NoInferConfig] =
     generic.deriveDecoder[NoInferConfig](default)

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/NoInferConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/NoInferConfig.scala
@@ -5,7 +5,7 @@ import org.langmeta.Symbol
 import metaconfig.generic
 import metaconfig.generic.Surface
 
-case class NoInferConfig(symbols: List[Symbol.Global] = Nil) {}
+case class NoInferConfig(symbols: List[Symbol.Global] = Nil)
 
 object NoInferConfig {
   implicit val surface: Surface[NoInferConfig] =

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/NoInferConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/NoInferConfig.scala
@@ -1,11 +1,24 @@
 package scalafix.internal.config
 
 import metaconfig.ConfDecoder
+import metaconfig.annotation._
 import org.langmeta.Symbol
 import metaconfig.generic
 import metaconfig.generic.Surface
 
-case class NoInferConfig(symbols: List[Symbol.Global] = Nil)
+case class NoInferConfig(
+    @Description("The list of symbols to must not get inferred.")
+    @ExampleValue("""[
+                    |  # With custom message (recommended)
+                    |  {
+                    |    symbol = "scala.Any.AsInstanceOf"
+                    |    message = "Use pattern matching instead"
+                    |  }
+                    |  # Without custom message (discouraged)
+                    |  "com.Bar.disabledFunction"
+                    |]""".stripMargin)
+    symbols: List[Symbol.Global] = Nil
+)
 
 object NoInferConfig {
   implicit val surface: Surface[NoInferConfig] =

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/NoInferConfig.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/NoInferConfig.scala
@@ -2,17 +2,13 @@ package scalafix.internal.config
 
 import metaconfig.ConfDecoder
 import org.langmeta.Symbol
+import metaconfig.generic
 
-import MetaconfigPendingUpstream.XtensionConfScalafix
-
-case class NoInferConfig(symbols: List[Symbol.Global] = Nil) {
-  implicit val reader: ConfDecoder[NoInferConfig] =
-    ConfDecoder.instanceF[NoInferConfig](
-      _.getField(symbols).map(NoInferConfig(_))
-    )
-}
+case class NoInferConfig(symbols: List[Symbol.Global] = Nil) {}
 
 object NoInferConfig {
+  implicit val surface = generic.deriveSurface[NoInferConfig]
   val default: NoInferConfig = NoInferConfig()
-  implicit val reader: ConfDecoder[NoInferConfig] = default.reader
+  implicit val decoder: ConfDecoder[NoInferConfig] =
+    generic.deriveDecoder[NoInferConfig](default)
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/ReaderUtil.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/ReaderUtil.scala
@@ -27,7 +27,7 @@ object ReaderUtil {
             val extraMsg = additionalMessage.applyOrElse(x, (_: String) => "")
             val msg =
               s"Unknown input '$x'. Expected one of: $available. $extraMsg"
-            Configured.NotOk(ConfError.msg(msg))
+            Configured.NotOk(ConfError.message(msg))
         }
     }
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/ScalafixMetaconfigReaders.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/ScalafixMetaconfigReaders.scala
@@ -219,14 +219,13 @@ trait ScalafixMetaconfigReaders {
     case Conf.Str(str) => Configured.Ok(FilterMatcher.mkRegexp(List(str)))
     case ConfStrLst(values) => Configured.Ok(FilterMatcher.mkRegexp(values))
   }
-  private val fallbackFilterMatcher = FilterMatcher(Nil, Nil)
   implicit val FilterMatcherReader: ConfDecoder[FilterMatcher] =
     ConfDecoder.instance[FilterMatcher] {
       case Conf.Str(str) => Configured.Ok(FilterMatcher(str))
       case ConfStrLst(values) =>
         Configured.Ok(FilterMatcher(values, Nil))
       case els =>
-        fallbackFilterMatcher.reader.read(els)
+        FilterMatcher.matchNothing.reader.read(els)
     }
 
   def parseReader[T](implicit parse: Parse[T]): ConfDecoder[T] =
@@ -296,4 +295,5 @@ trait ScalafixMetaconfigReaders {
     })
     ReaderUtil.oneOf[PrintStream](empty)
   }
+
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/config/ScalafixMetaconfigReaders.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/config/ScalafixMetaconfigReaders.scala
@@ -162,10 +162,7 @@ trait ScalafixMetaconfigReaders {
   def baseSyntacticRuleDecoder: ConfDecoder[Rule] =
     baseRuleDecoders(LazySemanticdbIndex.empty)
   def baseRuleDecoders(index: LazySemanticdbIndex): ConfDecoder[Rule] = {
-    MetaconfigPendingUpstream.orElse(
-      defaultRuleDecoder(index),
-      classloadRuleDecoder(index)
-    )
+    defaultRuleDecoder(index).orElse(classloadRuleDecoder(index))
   }
   def configFromInput(
       input: Input,
@@ -246,7 +243,7 @@ trait ScalafixMetaconfigReaders {
     case x if ev.runtimeClass.isInstance(x) =>
       Configured.Ok(x.asInstanceOf[To])
     case x =>
-      ConfError.msg(s"Expected Ref, got ${x.getClass}").notOk
+      ConfError.message(s"Expected Ref, got ${x.getClass}").notOk
   }
   implicit lazy val importerReader: ConfDecoder[Importer] =
     parseReader[Importer]

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/ConfigRule.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/ConfigRule.scala
@@ -16,7 +16,7 @@ object ConfigRule {
       getSemanticdbIndex(RuleKind.Semantic) match {
         case None =>
           ConfError
-            .msg(".scalafix.conf patches require the Semantic API.")
+            .message(".scalafix.conf patches require the Semantic API.")
             .notOk
         case Some(index) =>
           val rule = Rule.constant(

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/ClassloadRule.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/ClassloadRule.scala
@@ -124,7 +124,7 @@ object ClassloadRule {
       new ClassloadRule[Rule](classloader).classloadRule(fqn, args)
     result match {
       case Success(e) => Configured.Ok(e)
-      case util.Failure(e) => Configured.NotOk(ConfError.msg(e.toString))
+      case util.Failure(e) => Configured.NotOk(ConfError.message(e.toString))
     }
   }
 }

--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/RuleInstrumentation.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/RuleInstrumentation.scala
@@ -53,7 +53,7 @@ object RuleInstrumentation {
         }
         loop(Vector.empty, ast)
         val x = result.result()
-        if (x.isEmpty) ConfError.msg(s"Found no rules in input $code").notOk
+        if (x.isEmpty) ConfError.message(s"Found no rules in input $code").notOk
         else Configured.Ok(x)
     }
   }

--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ScalafixCompilerDecoder.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ScalafixCompilerDecoder.scala
@@ -76,9 +76,9 @@ object ScalafixCompilerDecoder {
       case GitHubFallback(invalid) =>
         Some(
           ConfError
-            .msg(s"""Invalid url 'github:$invalid'. Valid formats are:
-                    |- github:org/repo/version
-                    |- github:org/repo/version?sha=branch""".stripMargin)
+            .message(s"""Invalid url 'github:$invalid'. Valid formats are:
+                        |- github:org/repo/version
+                        |- github:org/repo/version?sha=branch""".stripMargin)
             .notOk)
       case _ => None
     }

--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ScalafixToolbox.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ScalafixToolbox.scala
@@ -121,7 +121,7 @@ class RuleCompiler(
     val errors = reporter.infos.collect {
       case reporter.Info(pos, msg, reporter.ERROR) =>
         ConfError
-          .msg(msg)
+          .message(msg)
           .atPos(
             if (pos.isDefined) m.Position.Range(input, pos.start, pos.end)
             else m.Position.None

--- a/scalafix-reflect/src/main/scala/scalafix/reflect/ScalafixReflect.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/reflect/ScalafixReflect.scala
@@ -15,9 +15,8 @@ object ScalafixReflect {
 
   def fromLazySemanticdbIndex(index: LazySemanticdbIndex): ConfDecoder[Rule] =
     ruleConfDecoder(
-      MetaconfigPendingUpstream.orElse(
-        ScalafixCompilerDecoder.baseCompilerDecoder(index),
-        baseRuleDecoders(index)
-      )
+      ScalafixCompilerDecoder
+        .baseCompilerDecoder(index)
+        .orElse(baseRuleDecoders(index))
     )
 }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/config/DisableSyntaxConfigSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/config/DisableSyntaxConfigSuite.scala
@@ -76,7 +76,7 @@ class DisableSyntaxConfigSuite extends FunSuite {
 
   def assertError(rawConfig: String, errorMessage: String): Unit = {
     val obtained = read(rawConfig)
-    val expected = NotOk(ConfError.msg(errorMessage))
+    val expected = NotOk(ConfError.message(errorMessage))
     assert(obtained == expected)
   }
 }

--- a/website/src/main/scala/scalafix/website/package.scala
+++ b/website/src/main/scala/scalafix/website/package.scala
@@ -1,0 +1,84 @@
+package scalafix
+
+import scalatags.Text
+import metaconfig.generic.Setting
+import metaconfig.generic.Settings
+import scalatags.Text.all._
+
+package object website {
+  private def flat[T](default: T)(
+      implicit settings: Settings[T],
+      ev: T <:< Product): List[(Setting, Any)] = {
+    settings.settings
+      .zip(default.productIterator.toIterable)
+      .flatMap {
+        case (deepSetting, defaultSetting: Product)
+            if deepSetting.underlying.nonEmpty =>
+          pprint.log(deepSetting)
+          deepSetting.flat.zip(defaultSetting.productIterator.toIterable)
+        case (s, lst: List[_]) =>
+          (s, lst.mkString("[", ", ", "]")) :: Nil
+        case (s, defaultValue) =>
+          (s, defaultValue) :: Nil
+      }
+
+  }
+
+  def rule[T](ruleName: String, default: T)(
+      implicit settings: Settings[T],
+      ev: T <:< Product): String = {
+    val sb = new StringBuilder
+    val all = flat(default)
+    def htmlSetting(
+        setting: Setting,
+        defaultValue: Any): Text.TypedTag[String] = {
+      tr(
+        td(code(setting.name)),
+        // TODO(olafur) hack!
+        td(setting.field.tpe.replace("scalafix.internal.config.", "")),
+        td(setting.description)
+      )
+    }
+
+    def html: String = {
+      val fields = all.map {
+        case (setting, defaultValue) =>
+          htmlSetting(setting, defaultValue)
+      }
+      table(
+        thead(
+          tr(
+            th("Name"),
+            th("Type"),
+            th("Description")
+          )
+        ),
+        tbody(fields)
+      ).toString()
+    }
+    sb.append(html)
+    sb.append("#### Defaults\n\n```")
+    all.foreach {
+      case (setting, value) =>
+        sb.append("\n")
+          .append(ruleName)
+          .append(".")
+          .append(setting.name)
+          .append(" = ")
+          .append(value)
+
+        setting.exampleValues match {
+          case Nil =>
+          case example :: _ =>
+            if (setting.exampleValues.nonEmpty) {
+              sb.append(" // ")
+                .append("Example: ")
+                .append(example)
+            }
+        }
+    }
+    sb.append("\n```\n\n")
+    sb.toString()
+  }
+
+}

--- a/website/src/main/scala/scalafix/website/package.scala
+++ b/website/src/main/scala/scalafix/website/package.scala
@@ -14,7 +14,6 @@ package object website {
       .flatMap {
         case (deepSetting, defaultSetting: Product)
             if deepSetting.underlying.nonEmpty =>
-          pprint.log(deepSetting)
           deepSetting.flat.zip(defaultSetting.productIterator.toIterable)
         case (s, lst: List[_]) =>
           (s, lst.mkString("[", ", ", "]")) :: Nil
@@ -23,61 +22,84 @@ package object website {
       }
 
   }
+  def htmlSetting(setting: Setting): Text.TypedTag[String] = {
+    tr(
+      td(code(setting.name)),
+      // TODO(olafur) hack!
+      td(setting.field.tpe.replace("scalafix.internal.config.", "")),
+      td(setting.description)
+    )
+  }
+
+  def html(all: List[Setting]): String = {
+    val fields = all.map { setting =>
+      htmlSetting(setting)
+    }
+    table(
+      thead(
+        tr(
+          th("Name"),
+          th("Type"),
+          th("Description")
+        )
+      ),
+      tbody(fields)
+    ).toString()
+  }
+
+  def config[T](name: String)(implicit settings: Settings[T]): String =
+    s"#### $name\n\n" +
+      html(settings.settings)
+
+  def defaults[T](ruleName: String, default: T)(
+      implicit settings: Settings[T],
+      ev: T <:< Product): String =
+    defaults[T](ruleName, flat(default))
+
+  def defaults[T](ruleName: String, all: List[(Setting, Any)]): String = {
+    val sb = new StringBuilder
+    sb.append("#### Defaults\n\n```")
+    all.foreach {
+      case (setting, default) =>
+        sb.append("\n")
+          .append(ruleName)
+          .append(".")
+          .append(setting.name)
+          .append(" = ")
+          .append(default)
+    }
+    sb.append("\n```\n\n")
+    sb.toString()
+  }
+
+  def examples[T](ruleName: String)(implicit settings: Settings[T]): String = {
+    val sb = new StringBuilder
+    sb.append("#### Examples\n\n```")
+    settings.settings.foreach {
+      case (setting) =>
+        setting.exampleValues match {
+          case Nil =>
+          case example :: _ =>
+            sb.append("\n")
+              .append(ruleName)
+              .append(".")
+              .append(setting.name)
+              .append(" = ")
+              .append(example)
+        }
+    }
+    sb.append("\n```\n\n")
+    sb.toString()
+  }
 
   def rule[T](ruleName: String, default: T)(
       implicit settings: Settings[T],
       ev: T <:< Product): String = {
     val sb = new StringBuilder
     val all = flat(default)
-    def htmlSetting(
-        setting: Setting,
-        defaultValue: Any): Text.TypedTag[String] = {
-      tr(
-        td(code(setting.name)),
-        // TODO(olafur) hack!
-        td(setting.field.tpe.replace("scalafix.internal.config.", "")),
-        td(setting.description)
-      )
-    }
-
-    def html: String = {
-      val fields = all.map {
-        case (setting, defaultValue) =>
-          htmlSetting(setting, defaultValue)
-      }
-      table(
-        thead(
-          tr(
-            th("Name"),
-            th("Type"),
-            th("Description")
-          )
-        ),
-        tbody(fields)
-      ).toString()
-    }
-    sb.append(html)
-    sb.append("#### Defaults\n\n```")
-    all.foreach {
-      case (setting, value) =>
-        sb.append("\n")
-          .append(ruleName)
-          .append(".")
-          .append(setting.name)
-          .append(" = ")
-          .append(value)
-
-        setting.exampleValues match {
-          case Nil =>
-          case example :: _ =>
-            if (setting.exampleValues.nonEmpty) {
-              sb.append(" // ")
-                .append("Example: ")
-                .append(example)
-            }
-        }
-    }
-    sb.append("\n```\n\n")
+    sb.append(html(all.map(_._1)))
+    sb.append(defaults(ruleName, all))
+    sb.append(examples[T](ruleName))
     sb.toString()
   }
 

--- a/website/src/main/tut/docs/rules/Disable.md
+++ b/website/src/main/tut/docs/rules/Disable.md
@@ -19,44 +19,14 @@ MyCode.scala:7: error: [DisallowSymbol.asInstanceOf] asInstanceOf is disabled.
 
 ## Configuration
 
-By default, this rule does allows all symbols. To disallow a symbol:
+This rule has several different options.
 
-```scala
-Disable.symbols = [
-  "scala.Option.get"
-  "scala.Any.asInstanceOf"
-]
+```tut:invisible
+import scalafix.internal.config._
+```
+```tut:passthrough
+println(
+scalafix.website.rule("Disable", DisableConfig.default)
+)
 ```
 
-## Custom error messages
-
-_Since 0.5.4_
-
-It's possible to provide a custom error message.
-
-```
-scala/test/Disable.scala:47: error: [Disable.get]
-Option.get is the root of all evils
-
-If you really want to do this do:
-... // scalafix:ok Option.get
-  Option(1).get
-            ^
-```
-
-```
-rules = Disable
-Disable.symbols = [
-  "scala.Any.asInstanceOf"
-  "test.Disable.D.disabledFunction"
-  {
-    symbol = "scala.Option.get"
-    message = 
-"""|Option.get is the root of all evils
-   |
-   |If you really want to do this do:
-   |... // scalafix:ok Option.get"""
-
-  }
-]
-````

--- a/website/src/main/tut/docs/rules/DisableUnless.md
+++ b/website/src/main/tut/docs/rules/DisableUnless.md
@@ -7,65 +7,56 @@ title: DisableUnless
 
 _Since 0.5.8_
 
-This rule bans usages of "disabled" symbols unless in a "safe" block. 
+This rule bans usages of "disabled" symbols unless they appear in a "safe" block.
 
-Any inner blocks (e.g. anonymous functions or classes) 
-within the given "safe" blocks are banned again, to avoid leakage. 
+Any inner blocks (e.g. anonymous functions or classes)
+within the given "safe" blocks are banned again, to avoid leakage.
 
 ## Configuration
 
-By default, this rule does allows all symbols. To disallow symbols in a block:
-```
-DisableUnless.symbols = [
-  {
-      unless = "scala.Option"
-      symbols = [
-        {
-          symbol = "test.DisableUnless.dangerousFunction"
-          message = "the function may return null"
-        }
-        "test.DisableUnless.anotherFunction"
-      ]
-  }
-]
-```
-You can use objects or regular strings to specify blocked symbols, 
-`message` is optional parameter and could be used to provide custom errors. 
+By default, this rule does allows all symbols.
 
-## Example
-With the given config:
+```tut:invisible
+import scalafix.internal.config._
 ```
-DisableUnless.symbols = [
-  {
-      unless = "test.DisableUnless.IO"
-      symbols = [
-        {
-          symbol = "scala.Predef.println"
-          message = "println has side-effects"
-        }
-      ]
-  }
-]
+```tut:passthrough
+println(
+scalafix.website.config[UnlessConfig]("UnlessConfig")
+)
+println(
+scalafix.website.config[DisableUnlessConfig]("DisableUnlessConfig")
+)
+println(
+scalafix.website.defaults("DisableUnless", DisableUnlessConfig.default)
+)
+println(
+scalafix.website.examples[DisableUnlessConfig]("DisableUnless")
+)
 ```
 
-We got several linter errors in the following code:
-```
-package test
+The the example configuration above, Scalafix will report the following warnings:
+```scala
+package com
+
+import scala.util.Try
+
+object IO {
+  def apply[T](run: => T) = ???
+}
 
 object Test {
-  object IO {
-    def apply[T](run: => T) = ???
-  }
-
-  
   println("hi") // not ok
-  
   IO {
     println("hi") // ok
   }
-  
   IO {
     def sideEffect(i: Int) = println("not good!") // not ok
     (i: Int) => println("also not good!") // not ok
   }
+
+  Option.empty[Int].get // not ok
+  Try {
+    Option.empty[Int].get // ok
+  }
+}
 ```

--- a/website/src/main/tut/docs/rules/ExplicitResultTypes.md
+++ b/website/src/main/tut/docs/rules/ExplicitResultTypes.md
@@ -19,7 +19,7 @@ implicit val tt = liftedType
 implicit val tt: TypedType[R] = liftedType
 ```
 
-But for local implicit `val` and `def` it's not needed and will not be added by default. 
+But for local implicit `val` and `def` it's not needed and will not be added by default.
 
 ```scala
 def foo = {
@@ -30,16 +30,15 @@ def foo = {
 
 ### Configuration
 
-```scala
-ExplicitResultTypes.memberKind = [Val, Def, Var] // empty by default
-ExplicitResultTypes.memberVisibility = [Public, Protected] // empty by default
-ExplicitResultTypes.skipSimpleDefinitions = false // true by default
-ExplicitResultTypes.skipLocalImplicits = false // true by default
-    
-// Experimental, shorten fully qualified names and insert missing imports
-// By default, names are fully qualified and prefixed with _root_.
-unsafeShortenNames = true // false by default.
-ExplicitResultTypes.unsafeShortenNames = true // false by default.
+This rule has several different options.
+
+```tut:invisible
+import scalafix.internal.config._
+```
+```tut:passthrough
+println(
+scalafix.website.rule("ExplicitResultTypes", ExplicitResultTypesConfig.default)
+)
 ```
 
 ### Known limitations

--- a/website/src/main/tut/docs/rules/NoInfer.md
+++ b/website/src/main/tut/docs/rules/NoInfer.md
@@ -9,42 +9,27 @@ _Since 0.5.0_
 
 This rule reports errors when the compiler infers certain types.
 
-Example:
+By default, no symbols are disabled.
+If the rule is configured to disable `scala.Any` and `Predef.any2stringadd`:
 
 ```scala
 MyCode.scala:7: error: [NoInfer.any] Inferred Any
   List(1, "")
             ^
-```
-
-## Configuration
-
-By default the rule reports on the following types:
-
-- `Serializable`
-- `Any`
-- `AnyVal`
-- `Product`
-
-It's possible to configure which types should not be inferred. In .scalafix.conf:
-
-```scala
-NoInfer.symbols = [
-  "scala.Predef.any2stringadd"
-]
-```
-
-and it would report 
-
-```scala
 MyCode.scala:7: error: [NoInfer.any2stringadd] Inferred any2stringadd
   def sum[A](a: A, b: String): String = { a + b }
                                           ^
 ```
 
-**Note:** when a configuration for NoInfer is given it completely overwrites the defaults so they have to be explicitely added to the list of symbols if needed.
+## Configuration
 
+It's possible to configure which symbols should not get inferred.
 
-## Known limitations
-
-- Scalafix does not yet expose a way to disable rules across regions of code, track [issue #241 for updates](https://github.com/scalacenter/scalafix/issues/241).
+```tut:invisible
+import scalafix.internal.config._
+```
+```tut:passthrough
+println(
+scalafix.website.rule("NoInfer", NoInferConfig.default)
+)
+```


### PR DESCRIPTION
Biggest improvements are automatic derivation of ConfDecoder instances.
See https://olafurpg.github.io/metaconfig/ to learn more.

Keeping the documentation on configuration settings and their default
values is a growing problem. Metaconfig v0.6 adds support for both
deriving automatic decoders as well as automatic documentation
generation from configuration settings.

This commit adds a proof-of-concept implementation that it's possible
to automatically generate docs from a rule configuration class. The
implementation is hacky, but it's still a big improvement over the old
way where default values and descriptions easily got off-sync with the
actual code.


![screen shot 2018-01-24 at 14 57 20](https://user-images.githubusercontent.com/1408093/35336066-82825076-0117-11e8-8ae4-16bd0457fbf9.png)
