### PR TITLE
Avoid crash in sbt-scalafix's scalafix task when arguments are empty

### DIFF
--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -314,7 +314,7 @@ object ScalafixPlugin extends AutoPlugin {
               .getOrElse(Nil)
 
           val inputArgs0 =
-            if (compat) "--rules" +: inputArgs
+            if (compat && inputArgs.nonEmpty) "--rules" +: inputArgs
             else inputArgs
 
           val sourceroot = scalafixSourceroot.value.getAbsolutePath


### PR DESCRIPTION
@fommil just for you ;-). scalafixCli is more powerful, it's better if you don't revert your fix. However, I'm fixing this task since we don't want to break it!