### PR TITLE
Fix invalid rewrite for ProcedureSyntax

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/ProcedureSyntax.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/ProcedureSyntax.scala
@@ -24,7 +24,7 @@ case object ProcedureSyntax extends Rule("ProcedureSyntax") {
         } yield lastParam.tokens.last).getOrElse(t.name.tokens.last)
         val closingParen =
           ctx.tokenList
-            .slice(defEnd, bodyStart)
+            .slice(ctx.tokenList.next(defEnd), bodyStart)
             .find(_.is[RightParen])
             .getOrElse(defEnd)
         ctx.addRight(closingParen, s": Unit =").atomic

--- a/scalafix-tests/input/src/main/scala/test/ProcedureSyntax.scala
+++ b/scalafix-tests/input/src/main/scala/test/ProcedureSyntax.scala
@@ -17,4 +17,7 @@ object ProcedureSyntax {
     println(1)
   }
   def main() /* unit */ {}
+  def bar(args: (Int, Int)) {
+    println(1)
+  }
 }

--- a/scalafix-tests/output-dotty/src/main/scala/test/ProcedureSyntax.scala
+++ b/scalafix-tests/output-dotty/src/main/scala/test/ProcedureSyntax.scala
@@ -14,4 +14,7 @@ object ProcedureSyntax {
     println(1)
   }
   def main(): Unit = /* unit */ {}
+  def bar(args: (Int, Int)): Unit = {
+    println(1)
+  }
 }


### PR DESCRIPTION
Fixes #557 

The invalid rewrites seem to happen on definition which has a `RightParen` as `defEnd` token, like `def bar(args (Int, Int)) {}`. 

If a `defEnd` is `RightParen`, this rule mistake `closingParen` because [Tokenlist.slice's from param is inclusive](https://github.com/scalacenter/scalafix/pull/534) and `ctx.tokenList.slice(defEnd, bodyStart)` contains two `RightParen`s (`defEnd` and real closing paren).

https://github.com/scalacenter/scalafix/blob/6b7b3656c21e0ee2cae7f22272e63431f77f84bd/scalafix-core/shared/src/main/scala/scalafix/internal/rule/ProcedureSyntax.scala#L27-L28