### PR TITLE
Upgrade to Scalameta 3.3.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 /* scalafmt: { maxColumn = 120 }*/
 
 object Dependencies {
-  val scalametaV = "3.3.0"
+  val scalametaV = "3.3.1"
   val metaconfigV = "0.6.0-RC1"
   def semanticdbSbt = "0.6.0"
   def dotty = "0.1.1-bin-20170530-f8f52cc-NIGHTLY"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,9 +3,9 @@ import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 /* scalafmt: { maxColumn = 120 }*/
 
 object Dependencies {
-  val scalametaV = "3.2.0"
+  val scalametaV = "3.3.0"
   val metaconfigV = "0.6.0-RC1"
-  def semanticdbSbt = "0.5.0"
+  def semanticdbSbt = "0.6.0"
   def dotty = "0.1.1-bin-20170530-f8f52cc-NIGHTLY"
   def scala210 = "2.10.6"
   // NOTE(olafur) downgraded from 2.11.12 and 2.12.4 because of non-reproducible error

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/DenotationOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/DenotationOps.scala
@@ -22,8 +22,9 @@ object DenotationOps {
         x
     }
     val signature =
-      if (denot.isVal || denot.isDef | denot.isVar) denot.signature
-      else {
+      if (denot.isVal || denot.isDef || denot.isGetter || denot.isSetter || denot.isVar) {
+        denot.signature
+      } else {
         throw new UnsupportedOperationException(
           s"Can't parse type for denotation $denot, denot.info=${denot.signature}")
       }

--- a/scalafix-tests/input/src/main/scala/test/ReplaceSymbol.scala
+++ b/scalafix-tests/input/src/main/scala/test/ReplaceSymbol.scala
@@ -18,9 +18,9 @@ patches.replaceSymbols = [
   { from = "_root_.scala.collection.TraversableOnce.mkString."
     to = "unsafeMkString" }
   // non-normalized symbol renames single method overload
-  { from = "_root_.java.lang.String#substring(I)Ljava/lang/String;."
+  { from = "_root_.java.lang.String#substring(Int)."
     to = "substringFrom" }
-  { from = "_root_.java.lang.String#substring(II)Ljava/lang/String;."
+  { from = "_root_.java.lang.String#substring(Int,Int)."
     to = "substringBetween" }
 ]
  */

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/SymbolMatcherTest.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/SymbolMatcherTest.scala
@@ -23,9 +23,9 @@ class SymbolMatcherTest extends BaseSemanticTest("SymbolMatcherTest") {
   test("normalized") {
     val term = SymbolMatcher.normalized(Symbol("_root_.Foo.a."))
     assert(term.matches(Symbol("_root_.Foo.a#"))) // type
-    assert(term.matches(Symbol("_root_.Foo#a(I)I."))) // method
+    assert(term.matches(Symbol("_root_.Foo#a(Int)."))) // method
     assert(term.matches(Symbol("_root_.Buz.;_root_.Foo.a#"))) // multi
-    assert(!term.matches(Symbol("_root_.Foo.a.apply()LFoo/a;."))) // apply
+    assert(!term.matches(Symbol("_root_.Foo.a.apply()."))) // apply
   }
 
 }


### PR DESCRIPTION
The only failing test is due to semanticdb-sbt. To fix it, please merge and release https://github.com/scalameta/semanticdb-sbt/pull/25.