### PR TITLE
Fix ProcedureSyntax rule for type params

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/ProcedureSyntax.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/ProcedureSyntax.scala
@@ -4,6 +4,7 @@ import scala.collection.immutable.Seq
 import scala.meta._
 import scala.meta.tokens.Token.LeftBrace
 import scala.meta.tokens.Token.RightParen
+import scala.meta.tokens.Token.RightBracket
 import scalafix.Patch
 import scalafix.rule.Rule
 import scalafix.rule.RuleCtx
@@ -22,12 +23,17 @@ case object ProcedureSyntax extends Rule("ProcedureSyntax") {
           lastParmList <- t.paramss.lastOption
           lastParam <- lastParmList.lastOption
         } yield lastParam.tokens.last).getOrElse(t.name.tokens.last)
-        val closingParen =
-          ctx.tokenList
-            .slice(ctx.tokenList.next(defEnd), bodyStart)
-            .find(_.is[RightParen])
-            .getOrElse(defEnd)
-        ctx.addRight(closingParen, s": Unit =").atomic
+        val tokens =
+          ctx.tokenList.slice(ctx.tokenList.next(defEnd), bodyStart)
+        val closingBracketOrParen =
+          tokens
+            .find(_.is[RightBracket])
+            .getOrElse(
+              tokens
+                .find(_.is[RightParen])
+                .getOrElse(defEnd)
+            )
+        ctx.addRight(closingBracketOrParen, s": Unit =").atomic
     }
     patches.asPatch
   }

--- a/scalafix-tests/input/src/main/scala/test/ProcedureSyntax.scala
+++ b/scalafix-tests/input/src/main/scala/test/ProcedureSyntax.scala
@@ -20,4 +20,5 @@ object ProcedureSyntax {
   def bar(args: (Int, Int)) {
     println(1)
   }
+  def baz[A] { println("baz[A]") }
 }

--- a/scalafix-tests/output-dotty/src/main/scala/test/ProcedureSyntax.scala
+++ b/scalafix-tests/output-dotty/src/main/scala/test/ProcedureSyntax.scala
@@ -17,4 +17,5 @@ object ProcedureSyntax {
   def bar(args: (Int, Int)): Unit = {
     println(1)
   }
+  def baz[A]: Unit = { println("baz[A]") }
 }


### PR DESCRIPTION
### steps

run ProcedureSyntax on the following:

```scala
  def baz[A] { println("baz[A]") }
```

### problem

ProcedureSyntax generates uncompilable code.

```scala
  def baz: Unit =[A] { println("baz[A]") }
```

### expectation

```scala
  def baz[A]: Unit = { println("baz[A]") }
```

### notes

Previously the rule was looking for the right paren. That's not enough if the procedure has  a type parameter.