### PR TITLE
Add completion for rules description in zsh.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -154,7 +154,8 @@ val cli = MultiScalaProject(
       "org.typelevel" %% "paiges-core" % "0.2.0",
       "com.martiansoftware" % "nailgun-server" % "0.9.1",
       jgit,
-      "ch.qos.logback" % "logback-classic" % "1.2.3"
+      "ch.qos.logback" % "logback-classic" % "1.2.3",
+      "org.apache.commons" % "commons-text" % "1.2"
     )
   )
 )

--- a/scalafix-cli/src/main/scala/scalafix/cli/Cli.scala
+++ b/scalafix-cli/src/main/scala/scalafix/cli/Cli.scala
@@ -80,9 +80,8 @@ object Cli {
       }
       val description = arg.helpMessage
         .map { x =>
-          val escaped = x.message
-            .replaceAll("\n *", " ")
-            .replaceAllLiterally(":", "\\:")
+          val escaped =
+            StringEscapeUtils.escapeXSI(x.message.replaceAll("\\s+", " "))
           s"$assign[$escaped]"
         }
         .getOrElse("")

--- a/scalafix-cli/src/main/scala/scalafix/cli/Cli.scala
+++ b/scalafix-cli/src/main/scala/scalafix/cli/Cli.scala
@@ -18,6 +18,7 @@ import com.martiansoftware.nailgun.NGContext
 import metaconfig.Configured.NotOk
 import metaconfig.Configured.Ok
 import org.typelevel.paiges.Doc
+import org.apache.commons.text.StringEscapeUtils
 
 object Cli {
   private def wrap(msg: String) = Doc.paragraph(msg).render(70)
@@ -105,7 +106,12 @@ object Cli {
   }
 
   def zshNames: String =
-    ScalafixRules.allNames.map(x => s""""$x"""").mkString(" \\\n  ")
+    ScalafixRules.allNamesDescriptions
+      .map {
+        case (name, description) =>
+          s""""$name[${StringEscapeUtils.escapeXSI(description)}]""""
+      }
+      .mkString(" \\\n  ")
 
   def sbtNames: String =
     ScalafixRules.allNames.map(x => s""""$x"""").mkString(",\n    ")
@@ -141,7 +147,7 @@ typeset -A opt_args
 local context state line
 
 _rule_names () {
-   compadd $zshNames
+   _values "rules" $zshNames
 }
 
 local -a scalafix_opts


### PR DESCRIPTION
issue: https://github.com/scalacenter/scalafix/issues/260

This PR enable zsh to show rules description on tab completion like this gif.

![scalafix-zsh-completion](https://user-images.githubusercontent.com/9353584/36742616-7f932136-1c2b-11e8-85b8-8881a3173e2e.gif)

I couldn't find the way to show description on tab completion (without autocompleting whole element including description) in bash and sbt. 😢