### PR TITLE
typo in docs

### DIFF
--- a/website/src/main/tut/docs/rules/Disable.md
+++ b/website/src/main/tut/docs/rules/Disable.md
@@ -78,13 +78,13 @@ println(
 scalafix.website.config[UnlessInsideBlock]("UnlessInsideBlock")
 )
 println(
-scalafix.website.config[DisableConfig]("DisableConfig")
+scalafix.website.config[DisableConfig]("Disable")
 )
 println(
-scalafix.website.defaults("DisableConfig", DisableConfig.default)
+scalafix.website.defaults("Disable", DisableConfig.default)
 )
 println(
-scalafix.website.examples[DisableConfig]("DisableConfig")
+scalafix.website.examples[DisableConfig]("Disable")
 )
 ```
 


### PR DESCRIPTION
I think this is the reason for the mistake in the docs at

https://scalacenter.github.io/scalafix/docs/rules/Disable#examples-1