### PR TITLE
Fix #653

### DIFF
--- a/scalafix-tests/input/src/main/scala/test/RemoveUnusedImports.scala
+++ b/scalafix-tests/input/src/main/scala/test/RemoveUnusedImports.scala
@@ -23,6 +23,7 @@ import scala.concurrent.{ // formatting caveat
 //  , ExecutionException
 //  , TimeoutException // ERROR
 //}
+import scala.util, util.Sorting._, util.Sorting
 
 object RemoveUnusedImports {
   import Future._
@@ -34,4 +35,5 @@ object RemoveUnusedImports {
   ExecutionContext.defaultReporter
   new RichBoolean(true)
   new TimeoutException
+  Sorting.quickSort(List(2, 1, 3).toArray)
 }

--- a/scalafix-tests/output/src/main/scala/test/RemoveUnusedImports.scala
+++ b/scalafix-tests/output/src/main/scala/test/RemoveUnusedImports.scala
@@ -14,6 +14,7 @@ TimeoutException
 //  , ExecutionException
 //  , TimeoutException // ERROR
 //}
+import scala.util, util.Sorting
 
 object RemoveUnusedImports {
   val NonFatal(a) = new Exception
@@ -24,4 +25,5 @@ object RemoveUnusedImports {
   ExecutionContext.defaultReporter
   new RichBoolean(true)
   new TimeoutException
+  Sorting.quickSort(List(2, 1, 3).toArray)
 }


### PR DESCRIPTION
I think I've identified the problem, but this is still WIP (for now, I've simply added a failing test)

In short: we currently remove the comma leading an importer in any case, but we should probably limit it to when the importer lives in a binpack block.

E.g.

```scala
import a.b.{ c, d } // it's ok to remove the leading comma when removing `c`

import a.b, b.c._, b.d // it's not ok to remove the leading comma when removing `b.c._`
```

This boils down to fixing the logic here:

https://github.com/scalacenter/scalafix/blob/f5e0a1c084256e42cf6725208d5c13113f3f4821/scalafix-core/shared/src/main/scala/scalafix/internal/patch/ImportPatchOps.scala#L206-L207

which I still haven't figured out how.