### PR TITLE
Use unmanagedSources.in(scalafix) in sbt-scalafix

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/SuppressOps.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/SuppressOps.scala
@@ -9,8 +9,9 @@ import scalafix.rule.RuleCtx
 import scalafix.util.SemanticdbIndex
 
 object SuppressOps {
-  @tailrec
+
   /** Binary searches for the last leading token before `pos` */
+  @tailrec
   private def findClosestLeadingToken(
       tokens: Tokens,
       pos: Position): Option[Token] = {

--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -210,7 +210,7 @@ object ScalafixPlugin extends AutoPlugin {
       val classDir = classDirectory.value
       val classpath = if (classDir.exists()) classDir.toString else ""
       val sourcesToFix = for {
-        source <- unmanagedSources.value
+        source <- unmanagedSources.in(scalafix).value
         if source.exists()
         if canFix(source)
       } yield source

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/scala212/src/main/scala/IgnoreMe.scala
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/scala212/src/main/scala/IgnoreMe.scala
@@ -1,0 +1,3 @@
+object IgnoreMe {
+  def main(args: Array[String]) { println(args) }
+}

--- a/website/src/main/tut/docs/users/installation.md
+++ b/website/src/main/tut/docs/users/installation.md
@@ -88,6 +88,16 @@ git diff // should produce a diff
 | `scalafixEnabled`           | `Boolean`     | Deprecated. Use the scalafixEnable command or manually configure scalacOptions/libraryDependecies/scalaVersion                            |
 | `scalametaSourceroot`       | `File`        | Deprecated. Renamed to `scalafixSourceroot`                                                                                               |
 
+
+### FAQ
+{: #sbt-faq}
+
+* How to exclude/add files that are processed by the `scalafix` task?
+
+```
+unmanagedSources.in(Compile, scalafix) := unmanagedSources.in(Compile).value.filter(file => ...)
+```
+
 ## scalafix-cli
 
 The recommended way to install the scalafix command-line interface is with


### PR DESCRIPTION
This allows users to exclude/include files that are handled by sbt-scalafix. Fixes #496