### PR TITLE
Remove automatic installation of semanticdb-scalac

### DIFF
--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixEnable.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixEnable.scala
@@ -49,8 +49,7 @@ object ScalafixEnable {
         scalaVersion.in(p) := fullVersion,
         scalacOptions.in(p) ++= List(
           "-Yrangepos",
-          s"-Xplugin-require:semanticdb",
-          s"-P:semanticdb:sourceroot:${scalafixSourceroot.value.getAbsolutePath}"
+          s"-Xplugin-require:semanticdb"
         ),
         libraryDependencies.in(p) += compilerPlugin(
           "org.scalameta" % "semanticdb-scalac" %

--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -19,7 +19,8 @@ object ScalafixPlugin extends AutoPlugin {
     val scalafixCli: InputKey[Unit] =
       inputKey[Unit]("Run scalafix rule.")
     val scalafixTest: InputKey[Unit] =
-      inputKey[Unit]("Run scalafix as a test(without modifying sources).")
+      inputKey[Unit](
+        "Runs scalafix failing the build if sources would change. Does not modify files.")
     val scalafixAutoSuppressLinterErrors: InputKey[Unit] =
       inputKey[Unit](
         "Run scalafix and automatically suppress linter errors " +
@@ -30,12 +31,10 @@ object ScalafixPlugin extends AutoPlugin {
         "Run syntactic scalafix rule on build sources. Note, semantic rewrites are not supported.")
     val sbtfixTest: InputKey[Unit] =
       inputKey[Unit](
-        "Run syntactic scalafix rule on build sources as a test(without modifying sources).")
+        "Run scalafix on build sources failing the build if source would change. Does not modify files.")
     val scalafixConfig: SettingKey[Option[File]] =
       settingKey[Option[File]](
         ".scalafix.conf file to specify which scalafix rules should run.")
-    val scalafixSourceroot: SettingKey[File] = settingKey[File](
-      s"Which sourceroot should be used for .semanticdb files.")
     val scalafixVersion: SettingKey[String] = settingKey[String](
       s"Which scalafix version to run. Default is ${Versions.version}.")
     val scalafixScalaVersion: SettingKey[String] = settingKey[String](
@@ -46,30 +45,6 @@ object ScalafixPlugin extends AutoPlugin {
       "org.scalameta" % "semanticdb-scalac" % Versions.scalameta cross CrossVersion.full
     val scalafixVerbose: SettingKey[Boolean] =
       settingKey[Boolean]("pass --verbose to scalafix")
-
-    /** Add -Yrangepos and semanticdb sourceroot to scalacOptions. */
-    @deprecated("Use scalacOptions += -Yrangepos instead", "0.6.0")
-    def scalafixScalacOptions: Def.Initialize[Seq[String]] =
-      ScalafixPlugin.scalafixScalacOptions
-
-    /** Add semanticdb-scalac compiler plugin to libraryDependencies. */
-    @deprecated("Use addCompilerPlugin(semanticdb-scalac) instead", "0.6.0")
-    def scalafixLibraryDependencies: Def.Initialize[List[ModuleID]] =
-      ScalafixPlugin.scalafixLibraryDependencies
-
-    @deprecated("This setting is no longer used", "0.6.0")
-    def sbtfixSettings: Seq[Def.Setting[_]] = Nil
-
-    /** Settings to enable semanticdb-scalac compiler plugin and Yrangepos.
-      * Must appear after scalacOptions and libraryDependencies
-      **/
-    @deprecated(
-      "Use addCompilerPlugin(semanticdb-scalac) and scalacOptions += -Yrangepos instead",
-      "0.6.0")
-    def scalafixSettings: Seq[Def.Setting[_]] = List(
-      scalacOptions ++= scalafixScalacOptions.value,
-      libraryDependencies ++= scalafixLibraryDependencies.value
-    )
 
     lazy val scalafixConfigSettings: Seq[Def.Setting[_]] = Seq(
       scalafix := scalafixTaskImpl(
@@ -89,6 +64,24 @@ object ScalafixPlugin extends AutoPlugin {
         compat = true,
         Seq("--auto-suppress-linter-errors", "--format", "sbt")).evaluated
     )
+
+    @deprecated("This setting is no longer used", "0.6.0")
+    val scalafixSourceroot: SettingKey[File] = settingKey[File]("Unused")
+    @deprecated("Use scalacOptions += -Yrangepos instead", "0.6.0")
+    def scalafixScalacOptions: Def.Initialize[Seq[String]] =
+      ScalafixPlugin.scalafixScalacOptions
+    @deprecated("Use addCompilerPlugin(semanticdb-scalac) instead", "0.6.0")
+    def scalafixLibraryDependencies: Def.Initialize[List[ModuleID]] =
+      ScalafixPlugin.scalafixLibraryDependencies
+    @deprecated("This setting is no longer used", "0.6.0")
+    def sbtfixSettings: Seq[Def.Setting[_]] = Nil
+    @deprecated(
+      "Use addCompilerPlugin(semanticdb-scalac) and scalacOptions += -Yrangepos instead",
+      "0.6.0")
+    def scalafixSettings: Seq[Def.Setting[_]] = List(
+      scalacOptions ++= scalafixScalacOptions.value,
+      libraryDependencies ++= scalafixLibraryDependencies.value
+    )
   }
   import scalafix.internal.sbt.CliWrapperPlugin.autoImport._
   import autoImport._
@@ -105,7 +98,6 @@ object ScalafixPlugin extends AutoPlugin {
     sbtfixTest := sbtfixImpl(compat = true, extraOptions = Seq("--test")).evaluated,
     aggregate.in(sbtfix) := false,
     aggregate.in(sbtfixTest) := false,
-    scalafixSourceroot := baseDirectory.in(ThisBuild).value,
     scalafixVersion := Versions.version,
     scalafixSemanticdbVersion := Versions.scalameta,
     scalafixScalaVersion := Versions.scala212,
@@ -172,8 +164,7 @@ object ScalafixPlugin extends AutoPlugin {
     if (isSupportedScalaVersion.value) {
       Seq(
         "-Yrangepos",
-        s"-Xplugin-require:semanticdb",
-        s"-P:semanticdb:sourceroot:${scalafixSourceroot.value.getAbsolutePath}"
+        s"-Xplugin-require:semanticdb"
       )
     } else Nil
   }
@@ -241,17 +232,12 @@ object ScalafixPlugin extends AutoPlugin {
             if (compat && inputArgs.nonEmpty) "--rules" +: inputArgs
             else inputArgs
 
-          val sourceroot = scalafixSourceroot.value.getAbsolutePath
           // only fix unmanaged sources, skip code generated files.
           verbose ++
             config ++
             inputArgs0 ++
             baseArgs ++
-            options ++
-            List(
-              "--sourceroot",
-              sourceroot
-            )
+            options
         }
         val finalArgs = args ++ files.map(_.getAbsolutePath)
         val nonBaseArgs = args.filterNot(baseArgs).mkString(" ")

--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -42,63 +42,63 @@ object ScalafixPlugin extends AutoPlugin {
       s"Which scala version to run scalafix from. Default is ${Versions.scala212}.")
     val scalafixSemanticdbVersion: SettingKey[String] = settingKey[String](
       s"Which version of semanticdb to use. Default is ${Versions.scalameta}.")
+    val scalafixSemanticdb =
+      "org.scalameta" % "semanticdb-scalac" % Versions.scalameta cross CrossVersion.full
     val scalafixVerbose: SettingKey[Boolean] =
       settingKey[Boolean]("pass --verbose to scalafix")
 
     /** Add -Yrangepos and semanticdb sourceroot to scalacOptions. */
+    @deprecated("Use scalacOptions += -Yrangepos instead", "0.6.0")
     def scalafixScalacOptions: Def.Initialize[Seq[String]] =
       ScalafixPlugin.scalafixScalacOptions
 
     /** Add semanticdb-scalac compiler plugin to libraryDependencies. */
+    @deprecated("Use addCompilerPlugin(semanticdb-scalac) instead", "0.6.0")
     def scalafixLibraryDependencies: Def.Initialize[List[ModuleID]] =
       ScalafixPlugin.scalafixLibraryDependencies
 
     @deprecated("This setting is no longer used", "0.6.0")
     def sbtfixSettings: Seq[Def.Setting[_]] = Nil
 
-    /** Settings that must appear after scalacOptions and libraryDependencies */
+    /** Settings to enable semanticdb-scalac compiler plugin and Yrangepos.
+      * Must appear after scalacOptions and libraryDependencies
+      **/
+    @deprecated(
+      "Use addCompilerPlugin(semanticdb-scalac) and scalacOptions += -Yrangepos instead",
+      "0.6.0")
     def scalafixSettings: Seq[Def.Setting[_]] = List(
       scalacOptions ++= scalafixScalacOptions.value,
       libraryDependencies ++= scalafixLibraryDependencies.value
     )
 
-    // TODO(olafur) remove this in 0.6.0, replaced
-    val scalafixEnabled: SettingKey[Boolean] =
-      settingKey[Boolean](
-        "No longer used. Use the scalafixEnable command or manually configure " +
-          "scalacOptions/libraryDependecies/scalaVersion")
-
-    lazy val scalafixConfigSettings: Seq[Def.Setting[_]] = scalafixSettings ++
-      Seq(
-        scalafix := scalafixTaskImpl(
-          scalafixParserCompat,
-          compat = true,
-          Seq("--format", "sbt")).evaluated,
-        scalafixTest := scalafixTaskImpl(
-          scalafixParserCompat,
-          compat = true,
-          Seq("--test", "--format", "sbt")).evaluated,
-        scalafixCli := scalafixTaskImpl(
-          scalafixParser,
-          compat = false,
-          Seq("--format", "sbt")).evaluated,
-        scalafixAutoSuppressLinterErrors := scalafixTaskImpl(
-          scalafixParser,
-          compat = true,
-          Seq("--auto-suppress-linter-errors", "--format", "sbt")).evaluated
-      )
+    lazy val scalafixConfigSettings: Seq[Def.Setting[_]] = Seq(
+      scalafix := scalafixTaskImpl(
+        scalafixParserCompat,
+        compat = true,
+        Seq("--format", "sbt")).evaluated,
+      scalafixTest := scalafixTaskImpl(
+        scalafixParserCompat,
+        compat = true,
+        Seq("--test", "--format", "sbt")).evaluated,
+      scalafixCli := scalafixTaskImpl(
+        scalafixParser,
+        compat = false,
+        Seq("--format", "sbt")).evaluated,
+      scalafixAutoSuppressLinterErrors := scalafixTaskImpl(
+        scalafixParser,
+        compat = true,
+        Seq("--auto-suppress-linter-errors", "--format", "sbt")).evaluated
+    )
   }
   import scalafix.internal.sbt.CliWrapperPlugin.autoImport._
   import autoImport._
 
   override def projectSettings: Seq[Def.Setting[_]] =
-    scalafixSettings ++
-      Seq(Compile, Test).flatMap(inConfig(_)(scalafixConfigSettings))
+    Seq(Compile, Test).flatMap(inConfig(_)(scalafixConfigSettings))
 
   override def globalSettings: Seq[Def.Setting[_]] = Seq(
     scalafixConfig := Option(file(".scalafix.conf")).filter(_.isFile),
     cliWrapperMainClass := "scalafix.cli.Cli$",
-    scalafixEnabled := true,
     scalafixVerbose := false,
     commands += ScalafixEnable.command,
     sbtfix := sbtfixImpl(compat = true).evaluated,
@@ -162,14 +162,14 @@ object ScalafixPlugin extends AutoPlugin {
 
   lazy val scalafixLibraryDependencies: Def.Initialize[List[ModuleID]] =
     Def.setting {
-      if (scalafixEnabled.value && isSupportedScalaVersion.value) {
+      if (isSupportedScalaVersion.value) {
         compilerPlugin(
           "org.scalameta" % "semanticdb-scalac" % scalafixSemanticdbVersion.value cross CrossVersion.full
         ) :: Nil
       } else Nil
     }
   lazy val scalafixScalacOptions: Def.Initialize[Seq[String]] = Def.setting {
-    if (scalafixEnabled.value && isSupportedScalaVersion.value) {
+    if (isSupportedScalaVersion.value) {
       Seq(
         "-Yrangepos",
         s"-Xplugin-require:semanticdb",

--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -76,7 +76,7 @@ object ScalafixPlugin extends AutoPlugin {
     @deprecated("This setting is no longer used", "0.6.0")
     def sbtfixSettings: Seq[Def.Setting[_]] = Nil
     @deprecated(
-      "Use addCompilerPlugin(semanticdb-scalac) and scalacOptions += -Yrangepos instead",
+      "Use addCompilerPlugin(scalafixSemanticdb) and scalacOptions += \"-Yrangepos\" instead",
       "0.6.0")
     def scalafixSettings: Seq[Def.Setting[_]] = List(
       scalacOptions ++= scalafixScalacOptions.value,

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/build.sbt
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/build.sbt
@@ -10,7 +10,6 @@ lazy val root = project
   .in(file("."))
   .aggregate(
     javaProject,
-    customSourceroot,
     scala211,
     scala210,
     scala212
@@ -29,11 +28,6 @@ lazy val scala212 = project
     inConfig(IntegrationTest)(scalafixConfigSettings),
     scalaVersion := Versions.scala212
   )
-lazy val customSourceroot = project.settings(
-  scalaVersion := Versions.scala212,
-  scalacOptions += "-P:semanticdb:sourceroot:" + sourceDirectory.value.getAbsolutePath,
-  scalafixSourceroot := sourceDirectory.value
-)
 lazy val javaProject = project.settings(
   scalaVersion := Versions.scala212
 )
@@ -63,7 +57,7 @@ TaskKey[Unit]("check") := {
       "scala212/src/it/scala/Main.scala",
       expected
     ) +:
-      Seq(scala210, scala211, scala212, customSourceroot).flatMap { project =>
+      Seq(scala210, scala211, scala212).flatMap { project =>
       val prefix = project.id
       Seq(
         assertContentMatches(

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/build.sbt
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/build.sbt
@@ -6,6 +6,12 @@ inThisBuild(
     resolvers += Resolver.sonatypeRepo("releases")
   )
 )
+
+lazy val scalafixSettings = List(
+  addCompilerPlugin(scalafixSemanticdb),
+  scalacOptions += "-Yrangepos"
+)
+
 lazy val root = project
   .in(file("."))
   .aggregate(
@@ -19,17 +25,20 @@ lazy val scala210 = project.settings(
   scalaVersion := "2.10.5"
 )
 lazy val scala211 = project.settings(
-  scalaVersion := Versions.scala211
+  scalaVersion := Versions.scala211,
+  scalafixSettings
 )
 lazy val scala212 = project
   .configs(IntegrationTest)
   .settings(
     Defaults.itSettings,
     inConfig(IntegrationTest)(scalafixConfigSettings),
-    scalaVersion := Versions.scala212
+    scalaVersion := Versions.scala212,
+    scalafixSettings
   )
 lazy val javaProject = project.settings(
-  scalaVersion := Versions.scala212
+  scalaVersion := Versions.scala212,
+  scalafixSettings
 )
 
 TaskKey[Unit]("check") := {

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/build.sbt
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/build.sbt
@@ -31,6 +31,7 @@ lazy val scala212 = project
   )
 lazy val customSourceroot = project.settings(
   scalaVersion := Versions.scala212,
+  scalacOptions += "-P:semanticdb:sourceroot:" + sourceDirectory.value.getAbsolutePath,
   scalafixSourceroot := sourceDirectory.value
 )
 lazy val javaProject = project.settings(

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/customSourceroot/src/main/scala/Main.scala
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/customSourceroot/src/main/scala/Main.scala
@@ -1,7 +1,0 @@
-object Main {
-  def foo(a: (Int, String)) = a
-  foo(1, "str")
-  def main(args: Array[String]) {
-    println(1)
-  }
-}

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/customSourceroot/src/test/scala/MainTest.scala
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/customSourceroot/src/test/scala/MainTest.scala
@@ -1,7 +1,0 @@
-object MainTest {
-  def foo(a: (Int, String)) = a
-  foo(1, "str")
-  def main(args: Array[String]) {
-    println(1)
-  }
-}

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/test
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/test
@@ -1,3 +1,4 @@
+> scalafixEnable
 # compile should not affect scalafix
 > compile
 

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/test
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/cross-build/test
@@ -1,4 +1,3 @@
-> scalafixEnable
 # compile should not affect scalafix
 > compile
 

--- a/scalafix-sbt/src/sbt-test/sbt-scalafix/suppress/test
+++ b/scalafix-sbt/src/sbt-test/sbt-scalafix/suppress/test
@@ -1,3 +1,4 @@
+> scalafixEnable
 -> compile:scalafixTest
 > compile:scalafixAutoSuppressLinterErrors
 > compile:scalafixTest

--- a/website/src/main/tut/docs/users/installation.md
+++ b/website/src/main/tut/docs/users/installation.md
@@ -32,19 +32,19 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "{{ site.stableVersion }}")
 > scalafixCli --test                                  // Make sure no files needs to be fixed
 
 
-// (optional, to avoid need for scalafixEnable) permanently enable scalafix in build.sbt
+// (optional) to avoid running scalafixEnable every time, permanently enable scalafix in build.sbt
 // ===> build.sbt
 scalaVersion := "{{ site.scala212 }}" // {{ site.scala211 }} is also supported.
-
-// If you get "-Yrangepos is required" error or "Missing compiler plugin semanticdb",
-// This setting must appear after scalacOptions and libraryDependencies.
-scalafixSettings
-// or scalafixLibraryDependencies (Add semanticdb-scalac compiler plugin to libraryDependencies.)
-// & scalacOptions bellow
-
-// To configure for custom configurations like IntegrationTest
-scalafixConfigure(Compile, Test, IntegrationTest)
+addCompilerPlugin(scalafixSemanticdb)
+scalacOptions += "-Yrangepos"
 ```
+
+Notes. 
+* The `semanticdb-scalac` compiler plugin is required to run semantic Scalafix rules like {% rule_ref Disable %}.
+* The `semanticdb-scalac` compiler plugin is not required to run syntactic rules like {% rule_ref DisableSyntax %}.
+* The `semanticdb-scalac` compiler plugin produces `*.semanticdb` files in the target `META-INF/semanticdb/` directory.
+* The compilation overhead of `semanticdb-scalac` depends on the compiler settings used, but by default it is around 30% 
+  over regular compilation.
 
 ### Verify installation
 
@@ -54,8 +54,6 @@ contain the values below.
 ```scala
 > show scalacOptions
 [info] * -Yrangepos                   // required
-[info] * -Xplugin-require:semanticdb  // recommended
-[info] * -P:semanticdb:sourceroot:/x  // recommended
 > show libraryDependencies
 [info] * org.scalameta:semanticdb-scalac:{{ site.scalametaVersion }}:plugin->default(compile)
 ```


### PR DESCRIPTION
Previously, addSbtPlugin(sbt-scalafix) would automatically enable the
semanticdb-scalac compiler plugin and -Yrange scalac options.
This commit removes the automatic installation so that users now need to
manually enable the following settings
```
addCompilerPlugin(scalafixSemanticdb)
scalacOptions += "-Yrangepos"
```
This makes the installation consistent for all users regardless of what
order they define libraryDependencies and scalacOptions.
The installation documentation for sbt-scalafix was pretty complex
before because the automatic setup only worked sometimes.

Fixes #589 

PS. Right after merging this PR we should immediately cut a v0.6.0-M2 release in order to make the installation instructions up-to-date.

