### PR TITLE
Remove console noise from non-verbose mode.

### DIFF
--- a/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
+++ b/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
@@ -62,10 +62,12 @@ sealed abstract case class CliRunner(
   implicit val workingDirectory: AbsolutePath = common.workingPath
 
   def run(): ExitStatus = {
-    val display = new TermDisplay(
-      new OutputStreamWriter(
-        if (cli.stdout) cli.common.err else cli.common.out),
-      fallbackMode = true)
+    val outStream =
+      if (!cli.verbose) ClasspathOps.devNull
+      else if (cli.stdout) cli.common.err
+      else cli.common.out
+    val display =
+      new TermDisplay(new OutputStreamWriter(outStream), fallbackMode = true)
     if (inputs.length > 10) display.init()
     val msg = cli.projectIdPrefix + s"Running ${rule.name}"
     display.startTask(msg, common.workingDirectoryFile)

--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -249,7 +249,11 @@ object ScalafixPlugin extends AutoPlugin {
         }
         val finalArgs = args ++ files.map(_.getAbsolutePath)
         val nonBaseArgs = args.filterNot(baseArgs).mkString(" ")
-        log.info(s"Running scalafix $nonBaseArgs")
+        if (scalafixVerbose.value) {
+          log.info(s"Running scalafix $nonBaseArgs")
+        } else if (files.lengthCompare(1) > 0) {
+          log.info(s"Running scalafix on ${files.size} Scala sources")
+        }
         main.main(finalArgs.toArray)
       }
     }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliGitDiffTests.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliGitDiffTests.scala
@@ -47,8 +47,7 @@ class CliGitDiffTests() extends FunSuite with DiffAssertions {
     val obtained = runDiff(cli)
 
     val expected =
-      s"""|Running DisableSyntax
-          |$newCodeAbsPath:3:3: error: [DisableSyntax.keywords.var] var is disabled
+      s"""|$newCodeAbsPath:3:3: error: [DisableSyntax.keywords.var] var is disabled
           |  var newVar = 1
           |  ^
           |""".stripMargin
@@ -88,8 +87,7 @@ class CliGitDiffTests() extends FunSuite with DiffAssertions {
     val obtained = runDiff(cli)
 
     val expected =
-      s"""|Running DisableSyntax
-          |$oldCodeAbsPath:7:3: error: [DisableSyntax.keywords.var] var is disabled
+      s"""|$oldCodeAbsPath:7:3: error: [DisableSyntax.keywords.var] var is disabled
           |  var newVar = 2
           |  ^
           |""".stripMargin
@@ -130,8 +128,7 @@ class CliGitDiffTests() extends FunSuite with DiffAssertions {
     val obtained = runDiff(cli)
 
     val expected =
-      s"""|Running DisableSyntax
-          |$newCodeAbsPath:5:3: error: [DisableSyntax.keywords.var] var is disabled
+      s"""|$newCodeAbsPath:5:3: error: [DisableSyntax.keywords.var] var is disabled
           |  var newVar = 2
           |  ^
           |""".stripMargin
@@ -188,8 +185,7 @@ class CliGitDiffTests() extends FunSuite with DiffAssertions {
     val obtained = runDiff(cli, s"--diff-base=$baseBranch")
 
     val expected =
-      s"""|Running DisableSyntax
-          |$newCodeAbsPath:5:3: error: [DisableSyntax.keywords.var] var is disabled
+      s"""|$newCodeAbsPath:5:3: error: [DisableSyntax.keywords.var] var is disabled
           |  var newVar = 2
           |  ^
           |""".stripMargin

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSyntacticTests.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSyntacticTests.scala
@@ -261,7 +261,7 @@ class CliSyntacticTests extends BaseCliTest {
                         |$original""".stripMargin,
     expectedExit = ExitStatus.LinterError,
     outputAssert = { out =>
-      assert(out.contains(s"\n[${Severity.Error}] "))
+      assert(out.contains(s"[${Severity.Error}] "))
     }
   )
 }


### PR DESCRIPTION
The default console output so far has been geared for debugging implementation
details. This commit moves a lot of noise under --verbose

* Fixes #629
* Fixes #686 
* Fixes #681