### PR TITLE
Cache jars and classloaders in sbt-scalafix.

### DIFF
--- a/scalafix-sbt/src/main/scala/scalafix/internal/sbt/CliWrapperPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/internal/sbt/CliWrapperPlugin.scala
@@ -1,5 +1,8 @@
 package scalafix.internal.sbt
 
+import java.net.URL
+import java.net.URLClassLoader
+import java.util
 import sbt.AutoPlugin
 import sbt.Def
 import sbt.File
@@ -29,15 +32,30 @@ object CliWrapperPlugin extends AutoPlugin {
       taskKey[HasMain]("Classloaded instance of main")
   }
   import autoImport._
+  private val cachedScalafixMain =
+    util.Collections.synchronizedMap(
+      new util.HashMap[(Seq[URL], String), HasMain]())
+  private val computeClassloader =
+    new util.function.Function[(Seq[URL], String), HasMain] {
+      override def apply(t: (Seq[URL], String)): HasMain = {
+        val (classpath, cliWrapperMainClass) = t
+        val classloader = new URLClassLoader(classpath.toArray, null)
+        val clazz = classloader.loadClass(cliWrapperMainClass)
+        val constructor = clazz.getDeclaredConstructor()
+        constructor.setAccessible(true)
+        val main = constructor.newInstance().asInstanceOf[Main]
+        new HasMain(main)
+      }
+    }
+
   override def globalSettings: Seq[Def.Setting[_]] = Seq(
     cliWrapperMain := {
       val cp = cliWrapperClasspath.value.map(_.toURI.toURL)
-      val cl = new java.net.URLClassLoader(cp.toArray, null)
-      val cls = cl.loadClass(cliWrapperMainClass.value)
-      val constuctor = cls.getDeclaredConstructor()
-      constuctor.setAccessible(true)
-      val main = constuctor.newInstance().asInstanceOf[Main]
-      new HasMain(main)
+      val main = cachedScalafixMain.computeIfAbsent(
+        cp -> cliWrapperMainClass.value,
+        computeClassloader
+      )
+      main
     }
   )
 }


### PR DESCRIPTION
There were reported heap-space usage problems that are potentially
caused by leaking classloaders in the sbt plugin. I thought that the sbt
task engine cached task results if the depended on settings/tasks don't
change.  This commit is a quick fix to test the hypothesis whether the
sbt plugin is causing problems