### PR TITLE
Disable parallel processing in sbt by default.

### DIFF
--- a/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
+++ b/scalafix-cli/src/main/scala/scalafix/cli/CliRunner.scala
@@ -75,8 +75,8 @@ sealed abstract case class CliRunner(
     val exitCode = new AtomicReference(ExitStatus.Ok)
     val counter = new AtomicInteger()
     val inputsToFix =
-      if (cli.singleThread) inputs
-      else inputs.toVector.par
+      if (cli.parallel && inputs.lengthCompare(15) > 0) inputs.par
+      else inputs
     inputsToFix.foreach { input =>
       val code = safeHandleInput(input)
       val progress = counter.incrementAndGet()
@@ -369,7 +369,7 @@ object CliRunner {
             val symbolTable = ClasspathOps.newSymbolTable(
               classpath = Classpath(classpath.shallow ++ deps),
               cacheDirectory = metacpCacheDir.map(AbsolutePath(_)),
-              parallel = !metacpNoPar,
+              parallel = metacpParallel && parallel,
               out = common.out)
             symbolTable match {
               case None =>

--- a/scalafix-cli/src/main/scala/scalafix/internal/cli/ScalafixOptions.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/cli/ScalafixOptions.scala
@@ -76,9 +76,11 @@ case class ScalafixOptions(
         "On macOS the default cache directory is ~/Library/Caches/semanticdb. ")
     metacpCacheDir: Option[String] = None,
     @HelpMessage(
-      "Set this flag to disable parallel processing with metacp. " +
-        "Metacp uses the standard library parallel collections, which may enter deadlocks.")
-    metacpNoPar: Boolean = false,
+      "If true, runs metacp in single-threaded mode. If false (default), use all available cores in metacp. " +
+        "See --metacp-cache-dir to learn more about metacp. " +
+        "Metacp uses the standard library parallel collections, which may enter deadlocks."
+    )
+    noMetacpParallel: Boolean = false,
     @HelpMessage(
       "Automatically infer --classpath starting from these directories. " +
         "Ignored if --classpath is provided.")
@@ -130,8 +132,13 @@ case class ScalafixOptions(
     @ValueDescription("core Foobar.scala")
     exclude: List[String] = Nil,
     @HelpMessage(
-      "If true, run on single thread. If false (default), use all available cores")
-    singleThread: Boolean = false,
+      "If true, run on single thread. If false (default), use all available cores. " +
+        "If true, enables --no-metacp-parallel as well. " +
+        "Difference between this flag and --no-metacp-parallel is that this flag additionally makes the main " +
+        "scalafix loop for fixing source files single-threaded."
+    )
+    @ExtraName("singleThread")
+    noParallel: Boolean = false,
     // NOTE: This option could be avoided by adding another entrypoint like 'Cli.safeMain'
     // or SafeCli.main. However, I opted for a cli flag since that plays nicely
     // with default 'run.in(Compile).toTask("--no-sys-exit").value' in sbt.
@@ -175,6 +182,8 @@ case class ScalafixOptions(
     diffBase: Option[String] = None,
     format: Option[OutputFormat] = None
 ) {
+  def metacpParallel: Boolean = !noMetacpParallel
+  def parallel: Boolean = !noParallel
   def classpathRoots: List[AbsolutePath] =
     classpathAutoRoots.fold(List(common.workingPath))(cp =>
       Classpath(cp).shallow)

--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixPlugin.scala
@@ -47,6 +47,11 @@ object ScalafixPlugin extends AutoPlugin {
         "The default location depends on the OS and is computed with https://github.com/soc/directories-jvm " +
         "using the project name 'semanticdb'. " +
         "On macOS the default cache directory is ~/Library/Caches/semanticdb. ")
+    val scalafixParallel: SettingKey[Boolean] = settingKey(
+      "If false (default), run scalafix in single-threaded mode. " +
+        "If true, allow scalafix to utilize available CPUs. " +
+        "Default is false because sbt automatically parallelizes across projects and configurations."
+    )
     val scalafixSemanticdb =
       "org.scalameta" % "semanticdb-scalac" % Versions.scalameta cross CrossVersion.full
     val scalafixVerbose: SettingKey[Boolean] =
@@ -123,6 +128,7 @@ object ScalafixPlugin extends AutoPlugin {
     scalafixSemanticdbVersion := Versions.scalameta,
     scalafixScalaVersion := Versions.scala212,
     scalafixMetacpCacheDirectory := None,
+    scalafixParallel := false,
     cliWrapperClasspath := {
       val jars = cachedCoursierJars.computeIfAbsent(
         scalafixScalaVersion.value -> scalafixVersion.value,
@@ -284,6 +290,10 @@ object ScalafixPlugin extends AutoPlugin {
           "--no-sys-exit",
           "--non-interactive"
         )
+
+        if (!scalafixParallel.value) {
+          args += "--no-parallel"
+        }
 
         args ++= files.iterator.map(_.getAbsolutePath)
 

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliArgsTest.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliArgsTest.scala
@@ -44,7 +44,7 @@ class CliArgsTest extends BaseCliTest {
     assert(!runner.writeMode.isWriteFile)
     assert(runner.config.fatalWarnings)
     assert(obtained.verbose)
-    assert(obtained.singleThread)
+    assert(obtained.noParallel)
     assert(
       obtained.files == List(
         "build.sbt",


### PR DESCRIPTION
Sbt automatically parallelizes across projects and configurations so
there is less need to parallelize between individual files. This should help reduce memory pressure, although we will need to do a bigger refactoring to properly fix memory problems.