### PR TITLE
MissingFinal bugfixes

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/internal/patch/EscapeHatch.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/patch/EscapeHatch.scala
@@ -210,13 +210,11 @@ object EscapeHatch {
       }
 
     private def extractRules(mods: List[Mod]): List[(String, Position)] = {
-      def process(rules: List[Term]) = rules.flatMap {
+      def process(rules: List[Term]) = rules.collect {
         case lit @ Lit.String(rule) =>
           val lo = lit.pos.start + 1 // drop leading quote
           val hi = lit.pos.end - 1 // drop trailing quote
-          Some(rule -> Position.Range(lit.pos.input, lo, hi))
-
-        case _ => None
+          rule -> Position.Range(lit.pos.input, lo, hi)
       }
 
       mods.flatMap {

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/MissingFinal.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/MissingFinal.scala
@@ -64,23 +64,23 @@ final case class MissingFinal(index: SemanticdbIndex)
       case (_: Defn.Class | _: Defn.Trait, _) => (None, PropagatesOuterRef)
       case (_: Defn.Object | _: Template, outerRef) => (None, outerRef)
       case _ => (None, NoOuterRef)
-    }.asPatch
+    }
   }
 
   private val PropagatesOuterRef = true
   private val NoOuterRef = false
 
   private def collect(tree: Tree)(
-      fn: (Tree, Boolean) => (Option[Patch], Boolean)): List[Patch] = {
-    val buf = scala.collection.mutable.ListBuffer[Patch]()
+      fn: (Tree, Boolean) => (Option[Patch], Boolean)): Patch = {
+    var patch = Patch.empty
     var outerRef = NoOuterRef
 
     object traverser extends Traverser {
       override def apply(tree: Tree): Unit = {
         val prev = outerRef
         fn(tree, prev) match {
-          case (Some(patch), outer) =>
-            buf += patch
+          case (Some(p), outer) =>
+            patch += p
             outerRef = outer
           case (None, outer) =>
             outerRef = outer
@@ -90,6 +90,6 @@ final case class MissingFinal(index: SemanticdbIndex)
       }
     }
     traverser(tree)
-    buf.toList
+    patch
   }
 }

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/MissingFinal.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/MissingFinal.scala
@@ -38,10 +38,13 @@ final case class MissingFinal(index: SemanticdbIndex)
           }
       }).atomic
 
+    def isNonFinalConcreteCaseClass(mods: List[Mod]) =
+      mods.exists(_.is[Mod.Case]) &&
+        !mods.exists(m => m.is[Mod.Final] || m.is[Mod.Abstract])
+
     ctx.tree.collect {
       case t @ Defn.Class(mods, _, _, _, _)
-          if mods.exists(_.is[Mod.Case]) &&
-            !mods.exists(_.is[Mod.Final]) =>
+          if isNonFinalConcreteCaseClass(mods) =>
         addFinal(mods, t)
       case t @ Defn.Class(mods, _, _, _, templ)
           if leaksSealedParent(mods, templ) =>

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/MissingFinal.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/MissingFinal.scala
@@ -29,14 +29,14 @@ final case class MissingFinal(index: SemanticdbIndex)
         mods.forall(m => !m.is[Mod.Final] && !m.is[Mod.Sealed])
 
     def addFinal(mods: Seq[Mod], d: Defn): Patch =
-      mods.find(!_.is[Mod.Annot]) match {
+      (mods.find(!_.is[Mod.Annot]) match {
         case Some(mod) => ctx.addLeft(mod, "final ")
         case None =>
           mods.lastOption match {
             case Some(lastMod) => ctx.addRight(lastMod, " final")
             case None => ctx.addLeft(d, "final ")
           }
-      }
+      }).atomic
 
     ctx.tree.collect {
       case t @ Defn.Class(mods, _, _, _, _)

--- a/scalafix-tests/input/src/main/scala/test/MissingFinal.scala
+++ b/scalafix-tests/input/src/main/scala/test/MissingFinal.scala
@@ -5,17 +5,20 @@ package test
 
 object MissingFinal {
   sealed trait Sealed
-  trait NotSealed
-
   class A extends Sealed // assert: MissingFinal.class
-  class B extends Sealed // assert: MissingFinal.class
-  trait C extends Sealed // assert: MissingFinal.trait
-  final class D extends Sealed // ok - class is already final
-  sealed class E extends Sealed // ok - class is also sealed
-  sealed trait F extends Sealed // ok - trait is also sealed
+  abstract class B extends Sealed // assert: MissingFinal.class
+  abstract case class C() extends Sealed // assert: MissingFinal.class
+  trait D extends Sealed // assert: MissingFinal.trait
+  final class E extends Sealed // ok - class is already final
+  sealed class F extends Sealed // ok - class is also sealed
+  sealed abstract class G extends Sealed // ok - abstract class is also sealed
+  sealed abstract case class H() extends Sealed // ok - abstract case class is also sealed
+  sealed trait I extends Sealed // ok - trait is also sealed
+  object J extends Sealed // ok - it's an object
   @SuppressWarnings(Array("scalafix:MissingFinal"))
-  class G extends Sealed // ok - rule is suppressed
+  class L extends Sealed // ok - rule is suppressed
 
-  class H extends NotSealed // ok - not leaking sealed
-  trait I extends NotSealed // ok - not leaking sealed
+  trait NotSealed
+  class M extends NotSealed // ok - parent is not sealed
+  trait N extends NotSealed // ok - parent is not sealed
 }

--- a/scalafix-tests/input/src/main/scala/test/MissingFinal.scala
+++ b/scalafix-tests/input/src/main/scala/test/MissingFinal.scala
@@ -4,15 +4,18 @@ rules = MissingFinal
 package test
 
 object MissingFinal {
-  sealed trait S
-  class A extends S // assert: MissingFinal.class
-  class B extends S // assert: MissingFinal.class
-  trait C extends S // assert: MissingFinal.trait
-  final class D extends S // ok
-  sealed class E extends S // ok
-  sealed trait F extends S // ok
+  sealed trait Sealed
+  trait NotSealed
 
-  trait NotS // ok
-  class G extends NotS // ok
-  trait H extends NotS // ok
+  class A extends Sealed // assert: MissingFinal.class
+  class B extends Sealed // assert: MissingFinal.class
+  trait C extends Sealed // assert: MissingFinal.trait
+  final class D extends Sealed // ok - class is already final
+  sealed class E extends Sealed // ok - class is also sealed
+  sealed trait F extends Sealed // ok - trait is also sealed
+  @SuppressWarnings(Array("scalafix:MissingFinal"))
+  class G extends Sealed // ok - rule is suppressed
+
+  class H extends NotSealed // ok - not leaking sealed
+  trait I extends NotSealed // ok - not leaking sealed
 }

--- a/scalafix-tests/input/src/main/scala/test/MissingFinalRewrite.scala
+++ b/scalafix-tests/input/src/main/scala/test/MissingFinalRewrite.scala
@@ -61,4 +61,12 @@ object MissingFinalRewrite {
       }
     }
   }
+
+  object Outer9 {
+    class Outer91 {
+      object Outer911 {
+        case class Inner9()
+      }
+    }
+  }
 }

--- a/scalafix-tests/input/src/main/scala/test/MissingFinalRewrite.scala
+++ b/scalafix-tests/input/src/main/scala/test/MissingFinalRewrite.scala
@@ -12,4 +12,53 @@ object MissingFinalRewrite {
   }
   abstract case class Baz(baz: String)
   case class LeaveMeAlone(x: Int) // scalafix:ok MissingFinal
+
+  // scenarios where case class may/may not hold reference to an outer class
+
+  class Outer1 {
+    case class Inner1()
+  }
+
+  class Outer2 {
+    { case class Inner2() }
+  }
+
+  trait Outer3 {
+    case class Inner3()
+  }
+
+  trait Outer4 {
+    def foo() = {
+      case class Inner4()
+      "foo"
+    }
+  }
+
+  object Outer5 {
+    case class Inner5()
+  }
+
+  class Outer6 {
+    object Outer61 {
+      object Outer611 {
+        case class Inner6()
+      }
+    }
+  }
+
+  trait Outer7 {
+    object Outer71 {
+      object Outer711 {
+        case class Inner7()
+      }
+    }
+  }
+
+  object Outer8 {
+    object Outer81 {
+      object Outer811 {
+        case class Inner8()
+      }
+    }
+  }
 }

--- a/scalafix-tests/input/src/main/scala/test/MissingFinalRewrite.scala
+++ b/scalafix-tests/input/src/main/scala/test/MissingFinalRewrite.scala
@@ -10,5 +10,6 @@ object MissingFinalRewrite {
   object FooBar {
     case class Foo(s: String)
   }
+  abstract case class Baz(baz: String)
   case class LeaveMeAlone(x: Int) // scalafix:ok MissingFinal
 }

--- a/scalafix-tests/input/src/main/scala/test/MissingFinalRewrite.scala
+++ b/scalafix-tests/input/src/main/scala/test/MissingFinalRewrite.scala
@@ -10,4 +10,5 @@ object MissingFinalRewrite {
   object FooBar {
     case class Foo(s: String)
   }
+  case class LeaveMeAlone(x: Int) // scalafix:ok MissingFinal
 }

--- a/scalafix-tests/output/src/main/scala/test/MissingFinalRewrite.scala
+++ b/scalafix-tests/output/src/main/scala/test/MissingFinalRewrite.scala
@@ -7,4 +7,5 @@ object MissingFinalRewrite {
   object FooBar {
     final case class Foo(s: String)
   }
+  case class LeaveMeAlone(x: Int) // scalafix:ok MissingFinal
 }

--- a/scalafix-tests/output/src/main/scala/test/MissingFinalRewrite.scala
+++ b/scalafix-tests/output/src/main/scala/test/MissingFinalRewrite.scala
@@ -58,4 +58,12 @@ object MissingFinalRewrite {
       }
     }
   }
+
+  object Outer9 {
+    class Outer91 {
+      object Outer911 {
+        case class Inner9()
+      }
+    }
+  }
 }

--- a/scalafix-tests/output/src/main/scala/test/MissingFinalRewrite.scala
+++ b/scalafix-tests/output/src/main/scala/test/MissingFinalRewrite.scala
@@ -7,5 +7,6 @@ object MissingFinalRewrite {
   object FooBar {
     final case class Foo(s: String)
   }
+  abstract case class Baz(baz: String)
   case class LeaveMeAlone(x: Int) // scalafix:ok MissingFinal
 }

--- a/scalafix-tests/output/src/main/scala/test/MissingFinalRewrite.scala
+++ b/scalafix-tests/output/src/main/scala/test/MissingFinalRewrite.scala
@@ -9,4 +9,53 @@ object MissingFinalRewrite {
   }
   abstract case class Baz(baz: String)
   case class LeaveMeAlone(x: Int) // scalafix:ok MissingFinal
+
+  // scenarios where case class may/may not hold reference to an outer class
+
+  class Outer1 {
+    case class Inner1()
+  }
+
+  class Outer2 {
+    { final case class Inner2() }
+  }
+
+  trait Outer3 {
+    case class Inner3()
+  }
+
+  trait Outer4 {
+    def foo() = {
+      final case class Inner4()
+      "foo"
+    }
+  }
+
+  object Outer5 {
+    final case class Inner5()
+  }
+
+  class Outer6 {
+    object Outer61 {
+      object Outer611 {
+        case class Inner6()
+      }
+    }
+  }
+
+  trait Outer7 {
+    object Outer71 {
+      object Outer711 {
+        case class Inner7()
+      }
+    }
+  }
+
+  object Outer8 {
+    object Outer81 {
+      object Outer811 {
+        final case class Inner8()
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR fixes 3 issues in the `MissingFinal` rule:

**1. Allow ~~individual `TokenPatch` to be suppressed~~ `MissingFinal` rewrites to be suppressed by making individual patches atomic** (#678)
>Side note: My perception is that the `atomic` feature should work the other way around: 
>- patches are atomic by default;
>- if a group of patches need to be atomic, they should be explicitly grouped together;
>
>At the moment, the suppression mechanism only works for rewrites if rule authors remember to call `.atomic` for their patches, which is something very easy to forget. For instance, some other default rules in scalafix (`DottyVarArgPattern`, `DottyVolatileLazyVal`, `LeakingImplicitClassVal`) can't be suppressed because their patches are not made atomic.
>
>UPDATE: actually there is nothing wrong with `atomic` as it currently is. Probably what needs to change is `EscapeHatch`. It needs to apply the escapes to patches not grouped in a `AtomicPatch` too.

**2. Do not add the `final` modifier to abstract case classes** (#678)

**3. Do not add the `final` modifier to case classes that can hold outer references** (#603)

This avoids the following compilation warning when the `final` modifier is added to inner case classes: `The outer reference in this type test cannot be checked at run time.`
This warning seems to be a bug in scalac (https://github.com/scala/bug/issues/4440) which does not exist in Dotty (https://github.com/lampepfl/dotty/issues/3652).

From my observations, the compiler emits such warning when a final case class...
- is enclosed by a `class` or a `trait` (doesn't matter how many levels above); and
- all the enclosing scopes are definitions of `class`/`trait`/`object` (there must be no blocks or `def`s in between)

Examples:
```scala
  class A { final case class X(s: String) } // warning emitted

  class B { { final case class X(s: String) } } // ok (note the inner class is defined inside a block)

  class C {
    object D {
      object E {
        final case class F(s: String) // warning emitted (note the outmost parent is a class)
      }
    }
  }

  object G {
    object H {
      object I {
        final case class J(s: String) // ok (note all enclosing scopes are objects definitions)
      }
    }
  }
```

