### PR TITLE
Bug fix: 'scalafix:ok' must not re-enable rules already suppressed

### DIFF
--- a/scalafix-tests/input/src/main/scala/test/escapeHatch/AnchorOverlapping.scala
+++ b/scalafix-tests/input/src/main/scala/test/escapeHatch/AnchorOverlapping.scala
@@ -1,0 +1,185 @@
+/*
+rules = [
+  "class:scalafix.test.NoDummy"
+  "class:scalafix.test.NoNull"
+]
+*/
+package test.escapeHatch
+
+object AnchorOverlapping {
+
+  // ensure rules are ON
+  val dummy0 = 0 // assert: NoDummy
+  null // assert: NoNull
+
+
+  // -----------------------------------------------------------------------------
+  // Test case: when there is a complete overlapping between 'off|on' and 'ok',
+  // the outermost one should prevail and the other should be reported as unused
+  // -----------------------------------------------------------------------------
+
+  {
+    /* scalafix:off */ // assert: UnusedScalafixSuppression
+    val dummy = 0
+    null
+    // scalafix:on
+  } // scalafix:ok
+
+
+  // ensure rules are ON
+  val dummy1 = 0 // assert: NoDummy
+  null // assert: NoNull
+
+
+  // scalafix:off
+  {
+    val dummy = 0
+    null
+  } /* scalafix:ok */ // assert: UnusedScalafixSuppression
+  // scalafix:on
+
+
+  // ensure rules are ON
+  val dummy2 = 0 // assert: NoDummy
+  null // assert: NoNull
+
+
+
+  // -----------------------------------------------------------------------------
+  // Test case: when there is a partial overlapping between 'off|on' and 'ok', the
+  // one that starts first should prevail and the other should be reported as unused
+  // -----------------------------------------------------------------------------
+
+  // scalafix:off
+  {
+    val dummy = 0
+    null
+    // scalafix:on
+  } /* scalafix:ok */ // assert: UnusedScalafixSuppression
+
+
+  // ensure rules are ON
+  val dummy3 = 0 // assert: NoDummy
+  null // assert: NoNull
+
+
+  {
+    /* scalafix:off */ // assert: UnusedScalafixSuppression
+    val dummy = 0
+    null
+  } // scalafix:ok
+  // scalafix:on
+
+
+  // ensure rules are ON
+  val dummy4 = 0 // assert: NoDummy
+  null // assert: NoNull
+
+
+  // -----------------------------------------------------------------------------
+  // Test case: partial overlapping between 'off|on' and 'ok' should not report
+  // unused if both escapes are triggered
+  // -----------------------------------------------------------------------------
+
+  // scalafix:off
+  {
+    val dummy = 0
+    // scalafix:on
+    null
+  } // scalafix:ok
+
+
+  // ensure rules are ON
+  val dummy5 = 0 // assert: NoDummy
+  null // assert: NoNull
+
+
+  {
+    // scalafix:off
+    val dummy = 0
+    null
+  } // scalafix:ok
+  null
+  // scalafix:on
+
+
+  // ensure rules are ON
+  val dummy6 = 0 // assert: NoDummy
+  null // assert: NoNull
+
+
+
+  // -----------------------------------------------------------------------------
+  // Test case: a 'on' should not re-enable a rule within the range of a 'ok' and
+  // it should be reported as unused.
+  // -----------------------------------------------------------------------------
+
+  {
+    /* scalafix:on */ // FIXME bug - this should be reported as unused
+    val dummy = 0
+    null
+  } // scalafix:ok
+
+
+  // ensure rules are ON
+  val dummy7 = 0 // assert: NoDummy
+  null // assert: NoNull
+
+
+
+  // -----------------------------------------------------------------------------
+  // Test case: overlapping 'off|on' and 'ok' should not conflict if they target
+  // different rules
+  // -----------------------------------------------------------------------------
+
+  // scalafix:off NoNull
+  {
+    val dummy = 0
+    null
+  } // scalafix:ok NoDummy
+  // scalafix:on NoNull
+
+
+  // ensure rules are ON
+  val dummy8 = 0 // assert: NoDummy
+  null // assert: NoNull
+
+
+  {
+    val dummy = 0
+    // scalafix:off NoNull
+    null
+    // scalafix:on NoNull
+  } // scalafix:ok NoDummy
+
+
+  // ensure rules are ON
+  val dummy9 = 0 // assert: NoDummy
+  null // assert: NoNull
+
+
+  // scalafix:off NoNull
+  {
+    val dummy = 0
+    null
+    // scalafix:on NoNull
+  } // scalafix:ok NoDummy
+
+
+  // ensure rules are ON
+  val dummy10 = 0 // assert: NoDummy
+  null // assert: NoNull
+
+
+  {
+    val dummy = 0
+    // scalafix:off NoNull
+    null
+  } // scalafix:ok NoDummy
+  // scalafix:on NoNull
+
+
+  // ensure rules are ON
+  val dummy11 = 0 // assert: NoDummy
+  null // assert: NoNull
+}

--- a/scalafix-tests/input/src/main/scala/test/escapeHatch/AnchorWildcard.scala
+++ b/scalafix-tests/input/src/main/scala/test/escapeHatch/AnchorWildcard.scala
@@ -6,11 +6,10 @@ rules = [
 */
 package test.escapeHatch
 
-// when `scalafix:on|off|ok` does not have a rule list
-// it affects every rules
-
+// when `scalafix:on|off|ok` does not have a rule list it affects every rule
 object AnchorWildcard {
-  // null // assert: NoNull
+
+  null // assert: NoNull
   val aDummy = 0 // assert: NoDummy
 
   // scalafix:off
@@ -18,6 +17,26 @@ object AnchorWildcard {
   val bDummy = 0
   // scalafix:on
 
-  // null // assert: NoNull
+  null // assert: NoNull
   val cDummy = 0 // assert: NoDummy
+
+  {
+    null
+    val dummy = 0
+  } // scalafix:ok
+
+  null // assert: NoNull
+  val eDummy = 0 // assert: NoDummy
+
+
+  // after a `scalafix:ok`, only rules that were previously enabled should be re-enabled
+
+  // scalafix:off NoNull
+  {
+    null
+    val dummy = 0
+  } // scalafix:ok
+
+  null
+  val fDummy = 0 // assert: NoDummy
 }

--- a/scalafix-tests/input/src/main/scala/test/escapeHatch/Issue694.scala
+++ b/scalafix-tests/input/src/main/scala/test/escapeHatch/Issue694.scala
@@ -1,0 +1,16 @@
+/*
+rules = Disable
+Disable.symbols = [
+  scala.collection.mutable
+]
+*/
+package test.escapeHatch
+
+import scala.collection.mutable
+
+class Issue694 {
+
+  // overlapping switches must not interfere with each other. The one with wider range wins
+  val map: mutable.Map[String, String] /* scalafix:ok */ = // assert: UnusedScalafixSuppression
+    mutable.Map.empty // scalafix:ok
+}


### PR DESCRIPTION
Fixes:
- #693: `scalafix:ok` (wildcard) incorrectly re-enables all rules after the end of its corresponding expression. This includes rules that were already suppressed before the expression (example [here](https://github.com/scalacenter/scalafix/issues/693#issuecomment-381344041)). With this fix, `scalafix:ok` now only re-enables rules suppressed by itself

- #694: a `scalafix:ok` comment is currently interpreted as two independent `off` and `on` instructions whose end offset is EOF. This causes unpredictable results when +2  expressions marked with `scalafix:ok` overlap (see example [here](https://github.com/scalacenter/scalafix/issues/694#issuecomment-384107792)). With this fix, `scalafix:ok` comments are now treated as a single `off` instruction whose end offset is the last position of the corresponding expression (this is similar to how `@SuppressWarnings` is handled).
