### PR TITLE
WIP for solving #670.

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/MatchingUnsealedTrait.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/MatchingUnsealedTrait.scala
@@ -1,0 +1,119 @@
+package scalafix.internal.rule
+
+import scalafix.SemanticdbIndex
+import scalafix.internal.util.EagerInMemorySemanticdbIndex
+import scalafix.lint.{LintCategory, LintMessage}
+import scalafix.rule.{RuleCtx, SemanticRule}
+
+import scala.meta.Term.Match
+import scala.meta._
+import scala.meta.internal.semanticdb3.ClassInfoType
+import scala.meta.internal.semanticdb3.Type.{Tag => t}
+import scala.meta.internal.{semanticdb3 => s}
+
+case class MatchingUnsealedTrait(index: SemanticdbIndex)
+    extends SemanticRule(index, "MatchingUnsealedTrait") {
+
+  override def description: String =
+    "Ensure catch-all when matching on unsealed traits"
+
+  private type Sym = String
+
+  private val errorCategory: LintCategory =
+    LintCategory.error("Some constructs are unsafe to use and should be avoided")
+
+  private def error(sym: Sym, tree: Tree): LintMessage =
+    errorCategory.copy(id = "mustProvideCatchAll").at("", tree.pos)
+
+  private object NotSealedTrait {
+    val internalIdx: EagerInMemorySemanticdbIndex =
+      index.asInstanceOf[EagerInMemorySemanticdbIndex]
+
+    def followTypeRef(symbol: Sym): Option[s.Type] =
+      internalIdx.info(symbol).flatMap(_.tpe)
+
+    /**
+      * @param lastSym `s.ClassInfoType` doesn't bundle it's name, so pass around what we looked up
+      * @param tpe current type we follow
+      * @return
+      */
+    def lookupClassType(
+        lastSym: Sym,
+        tpe: s.Type): Option[(Sym, s.ClassInfoType)] = {
+      tpe.tag match {
+        case t.TYPE_REF =>
+          for {
+            tr <- tpe.typeRef
+            referenced <- followTypeRef(tr.symbol)
+            ret <- lookupClassType(tr.symbol, referenced)
+          } yield ret
+
+        case t.METHOD_TYPE =>
+          for {
+            mt <- tpe.methodType
+            rt <- mt.returnType
+            ct <- lookupClassType(lastSym, rt)
+          } yield ct
+
+        case t.CLASS_INFO_TYPE =>
+          Some((lastSym, tpe.classInfoType.get))
+
+        case t.BY_NAME_TYPE =>
+          for {
+            byName <- tpe.byNameType
+            byNameTpe <- byName.tpe
+            c <- lookupClassType(lastSym, byNameTpe)
+          } yield c
+
+        case t.TYPE_TYPE =>
+          for {
+            typeType <- tpe.typeType
+            lower <- typeType.lowerBound
+            c <- lookupClassType(lastSym, lower)
+          } yield c
+
+        case other =>
+          None
+      }
+    }
+
+    def name(term: Term): Option[Term.Name] =
+      term match {
+        case x: Term.Name => Some(x)
+        case Term.Apply(x: Term.Name, _) => Some(x)
+        case _ => None
+      }
+
+    def unapply(term: Term): Option[(Sym, s.ClassInfoType)] = {
+      import scalafix.internal.util.Implicits.XtensionSymbolInformationProperties
+
+      for {
+        termName <- name(term)
+        sym <- internalIdx.symbol(termName)
+        tr <- followTypeRef(sym.syntax)
+        (sym, c: ClassInfoType) <- lookupClassType(sym.syntax, tr)
+        cc <- internalIdx.info(sym)
+        if cc.kind == s.SymbolInformation.Kind.TRAIT
+        if !cc.is(s.SymbolInformation.Property.SEALED)
+      } yield (sym, c)
+    }
+  }
+
+  private object HasNoCatchAll {
+    def has(cases: List[scala.meta.Case]): Boolean = {
+      cases.last match {
+        case Case(Pat.SeqWildcard(), None, _) => true
+        case Case(Pat.Wildcard(), None, _) => true
+        case Case(Pat.Var(_), None, _) => true
+        case _ => false
+      }
+    }
+
+    def unapply(cases: List[scala.meta.Case]): Boolean = !has(cases)
+  }
+
+  override def check(ctx: RuleCtx): Seq[LintMessage] =
+    ctx.tree.collect {
+      case m@Match(NotSealedTrait((sym, cls)), HasNoCatchAll()) => error(sym, m)
+    }
+}

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/Implicits.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/Implicits.scala
@@ -1,0 +1,18 @@
+package scalafix.internal.util
+
+import scala.meta.internal.semanticdb3.SymbolInformation.{Property => p}
+import scala.meta.internal.{semanticdb3 => s}
+
+private[scalafix] object Implicits {
+  implicit class XtensionSymbolInformationProperties(
+      info: s.SymbolInformation) {
+    def typ: s.Type =
+      info.tpe.getOrElse(throw new IllegalArgumentException(info.toProtoString))
+    def is(property: s.SymbolInformation.Property): Boolean =
+      (info.properties & property.value) != 0
+    def isVal: Boolean = is(p.VAL)
+    def isVar: Boolean = is(p.VAR)
+    def isVarSetter: Boolean =
+      isVar && info.name.endsWith("_=")
+  }
+}

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/util/PrettyType.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/util/PrettyType.scala
@@ -40,7 +40,7 @@ object PrettyType {
 }
 
 class PrettyType private (table: SymbolTable, shorten: QualifyStrategy) {
-
+  import Implicits.XtensionSymbolInformationProperties
   // TODO: workaround for https://github.com/scalameta/scalameta/issues/1492
   private val caseClassMethods = Set(
     "copy",
@@ -61,17 +61,6 @@ class PrettyType private (table: SymbolTable, shorten: QualifyStrategy) {
     result
   }
 
-  private implicit class XtensionSymbolInformationProperties(
-      info: s.SymbolInformation) {
-    def typ: s.Type =
-      info.tpe.getOrElse(throw new IllegalArgumentException(info.toProtoString))
-    def is(property: s.SymbolInformation.Property): Boolean =
-      (info.properties & property.value) != 0
-    def isVal: Boolean = is(p.VAL)
-    def isVar: Boolean = is(p.VAR)
-    def isVarSetter: Boolean =
-      isVar && info.name.endsWith("_=")
-  }
   private implicit class XtensionSymbolInfo(sym: String) {
     def toTermName: Term.Name = Term.Name(info(sym).name)
     def toTypeName: Type.Name = Type.Name(info(sym).name)

--- a/scalafix-core/shared/src/main/scala/scalafix/rule/ScalafixRules.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/rule/ScalafixRules.scala
@@ -20,6 +20,7 @@ object ScalafixRules {
     NoInfer(index, NoInferConfig.default),
     ExplicitResultTypes(index),
     RemoveUnusedImports(index),
+    MatchingUnsealedTrait(index),
     RemoveUnusedTerms(index),
     NoAutoTupling(index),
     Disable(index, DisableConfig.default),

--- a/scalafix-tests/input/src/main/scala/test/MatchingUnsealedTrait.scala
+++ b/scalafix-tests/input/src/main/scala/test/MatchingUnsealedTrait.scala
@@ -1,0 +1,39 @@
+/* 
+rules = MatchingUnsealedTrait
+*/
+
+trait Parent
+trait A
+
+sealed trait S extends Parent
+
+object O {
+  val a: A = null
+  a match { // assert: MatchingUnsealedTrait.mustProvideCatchAll
+    case dsa if false => dsa
+  }
+
+  a match {
+    case dsa => dsa //fine
+  }
+
+  val s: S = null
+  s match {
+    case asd if false => asd //compiler already complains
+  }
+
+  def foo: A = null
+  foo match { // assert: MatchingUnsealedTrait.mustProvideCatchAll
+    case asd if false => asd
+  }
+
+  def foos(i: Int): Seq[S] = null
+  foos(23) match {
+    case s :: Nil => s
+    case _ => ???
+  }
+
+  foos(23).head match {
+    case _ => ???
+  }
+}


### PR DESCRIPTION
When pattern matching on not-sealed traits, enforce that we provide a catch-all case.

That's all for today. Will continue this later if/when we decide this is a good enough approach given it's limitations.