### PR TITLE
Fix: EscapeHatch is not reporting unused 'scalafix:on' in some cases

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/internal/patch/EscapeHatch.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/patch/EscapeHatch.scala
@@ -204,8 +204,9 @@ object EscapeHatch {
     private def extractRules(mods: List[Mod]): List[(String, Position)] = {
       def process(rules: List[Term]) = rules.collect {
         case lit @ Lit.String(rule) =>
-          val lo = lit.pos.start + 1 // drop leading quote
-          val hi = lit.pos.end - 1 // drop trailing quote
+          // get the exact position of the rule name
+          val lo = lit.pos.start + lit.pos.text.indexOf(rule)
+          val hi = lo + rule.length
           rule -> Position.Range(lit.pos.input, lo, hi)
       }
 

--- a/scalafix-tests/input/src/main/scala/test/escapeHatch/AnchorOverlapping.scala
+++ b/scalafix-tests/input/src/main/scala/test/escapeHatch/AnchorOverlapping.scala
@@ -115,7 +115,7 @@ object AnchorOverlapping {
   // -----------------------------------------------------------------------------
 
   {
-    /* scalafix:on */ // FIXME bug - this should be reported as unused
+    /* scalafix:on */ // assert: UnusedScalafixSuppression
     val dummy = 0
     null
   } // scalafix:ok

--- a/scalafix-tests/input/src/main/scala/test/escapeHatch/AnchorUnused.scala
+++ b/scalafix-tests/input/src/main/scala/test/escapeHatch/AnchorUnused.scala
@@ -1,16 +1,18 @@
 /*
 rules = [
-  "class:scalafix.test.NoDummy",
+  "class:scalafix.test.NoDummy"
+  "class:scalafix.test.NoNull"
 ]
 */
-
 package test.escapeHatch
 
 // Unused disable, enable or expressions are reported as a warning
 
 object AnchorUnused {
 
-// Positive Tests (should not report unused)
+  // -----------------------------------------------------------------------------
+  // Positive Tests (should not report unused)
+  // -----------------------------------------------------------------------------
 
   // scalafix:off NoDummy
   val aDummy = 1
@@ -27,16 +29,36 @@ object AnchorUnused {
     val a = 1
   }
 
-// Negative Tests (should report unused)
+
+  // -----------------------------------------------------------------------------
+  // Test case: ON/OFF without any code in between
+  // -----------------------------------------------------------------------------
 
   /* scalafix:off NoDummy */ // assert: UnusedScalafixSuppression
   // ...
-  /* scalafix:on NoDummy */
+  // scalafix:on NoDummy
 
+
+  // ensure rule is ON
+  val dDummy = 0 // assert: NoDummy
+
+
+
+  // -----------------------------------------------------------------------------
+  // Test case: ON/OFF without any code in between and typo
+  // -----------------------------------------------------------------------------
 
   /* scalafix:off NoDummy */ // assert: UnusedScalafixSuppression
   // ...
   /* scalafix:on NoDummyTypo */ // assert: UnusedScalafixSuppression
+
+  /* scalafix:on NoDummy */ // turn rule back to ON
+
+
+
+  // -----------------------------------------------------------------------------
+  // Test case: unused OK
+  // -----------------------------------------------------------------------------
 
   val ok = 1 /* scalafix:ok NoDummy */ // assert: UnusedScalafixSuppression
 
@@ -48,4 +70,45 @@ object AnchorUnused {
   object Ok { /* scalafix:ok NoDummy */ // assert: UnusedScalafixSuppression
     val a = 1
   }
+
+
+
+  // -----------------------------------------------------------------------------
+  // Test case: redundant/duplicate ON/OFF
+  // -----------------------------------------------------------------------------
+
+  /* scalafix:off */ // turn all rules off before start
+
+  val fDummy = null // ensure rule is OFF
+
+  // scalafix:on NoDummy
+  // scalafix:on NoNull
+  // scalafix:on
+  /* scalafix:on */ // assert: UnusedScalafixSuppression
+  /* scalafix:on NoDummy */ // assert: UnusedScalafixSuppression
+  /* scalafix:on NoNull */ // assert: UnusedScalafixSuppression
+
+
+  // ensure rules are ON
+  val gDummy = 1 // assert: NoDummy
+  null // assert: NoNull
+
+
+  // scalafix:off NoDummy
+  /* scalafix:off NoDummy */ // assert: UnusedScalafixSuppression
+  // scalafix:off NoNull
+  /* scalafix:off NoNull */ // assert: UnusedScalafixSuppression
+  /* scalafix:off */ // assert: UnusedScalafixSuppression
+  /* scalafix:off */ // assert: UnusedScalafixSuppression
+
+  val hDummy = null // ensure rules are OFF
+
+  // scalafix:on
+  /* scalafix:on */ // assert: UnusedScalafixSuppression
+  /* scalafix:on NoDummy */ // assert: UnusedScalafixSuppression
+  /* scalafix:on NoNull */ // assert: UnusedScalafixSuppression
+
+  // ensure rules are ON
+  val iDummy = 1 // assert: NoDummy
+  null // assert: NoNull
 }

--- a/scalafix-tests/input/src/main/scala/test/escapeHatch/AnnotationUnused.scala
+++ b/scalafix-tests/input/src/main/scala/test/escapeHatch/AnnotationUnused.scala
@@ -21,6 +21,9 @@ object AnnotationUnused {
   @SuppressWarnings(Array("NoDummy", "NoNull")) // OK, not prefixed
   def d = ()
 
+  @SuppressWarnings(Array("""scalafix:NoDummy""")) // assert: UnusedScalafixSuppression
+  def tripleQuotes = ()
+
   @SuppressWarnings(Array("scalafix:NoDummy")) // assert: UnusedScalafixSuppression
   object Foo {
 


### PR DESCRIPTION
- fix missing cases where `scalafix:on` is not reported as unused:
  - sequence of multiple `scalafix:on`
  - after a rule is turned OFF and then ON again
- report unused rule when it is wrapped by triple quotes in `@SuppressWarnings`
- minor refactorings in `EscapeHatch` to save some lines of code

Each change is in a separate commit.