### PR TITLE
Fix and extend maven installation docs

### DIFF
--- a/website/src/main/tut/docs/users/installation.md
+++ b/website/src/main/tut/docs/users/installation.md
@@ -7,6 +7,13 @@ To run scalafix on your project, you must first install the Scalafix sbt plugin
 or command line interface.
 Currently, Scalafix does not provide any IDE integrations with IntelliJ/ENSIME.
 
+Here's a version compatibility table for reference:
+
+| Scalafix Version   | Scalameta(SemanticDB) Version | Scala Version                             |
+| ------------------ | ----------------------------- | ----------------------------------------- |
+| 0.5.10             | 2.1.7                         | 2.11.12 / 2.12.4                          |
+| {{ site.version }} | {{ site.scalametaVersion }}   | {{ site.scala211 }} / {{ site.scala212 }} | 
+
 * TOC
 {:toc}
 
@@ -154,10 +161,10 @@ wget https://github.com/coursier/coursier/raw/master/coursier && chmod +x coursi
 Then, once you have coursier installed, assuming you are on {{ site.scala212 }}, download the plugin:
 
 ```
-coursier fetch --intransitive org.scalameta:semanticdb-scalac_{{ site.scala212 }}:2.1.7
+coursier fetch --intransitive org.scalameta:semanticdb-scalac_{{ site.scala212 }}:{{ site.scalametaVersion }}
 ```
 
-Alternatively, you can also use `wget` or a simalar tool to retrieve the jar from `https://repo1.maven.org/maven2/org/scalameta/semanticdb-scalac_{{ site.scala212 }}/2.1.7/semanticdb-scalac_{{ site.scala212 }}-2.1.7.jar`.
+Alternatively, you can also use `wget` or a similar tool to retrieve the jar from `https://repo1.maven.org/maven2/org/scalameta/semanticdb-scalac_{{ site.scala212 }}/{{ site.scalametaVersion }}/semanticdb-scalac_{{ site.scala212 }}-{{ site.scalametaVersion }}.jar`.
 
 If you prefer using maven profile instead of manual download, add the following snippet to your maven `pom.xml`:
 
@@ -174,7 +181,7 @@ If you prefer using maven profile instead of manual download, add the following 
             <compilerPlugin>
               <groupId>org.scalameta</groupId>
               <artifactId>semanticdb-scalac_{{ site.scala212 }}</artifactId>
-              <version>2.1.7</version>
+              <version>{{ site.scalametaVersion }}</version>
             </compilerPlugin>
           </compilerPlugins>
           <addScalacArgs>-Yrangepos|-Ywarn-unused-import</addScalacArgs>
@@ -189,12 +196,12 @@ If you prefer using maven profile instead of manual download, add the following 
 
 If you installed the semanticdb plugin manually, you have to locate it first.
 
-Let's say the `semanticdb-scalac_{{ site.scala212 }}-2.1.7.jar` is available in `PLUGINS/semanticdb-scalac_{{ site.scala212 }}-2.1.7.jar` path on your file system.
+Let's say the `semanticdb-scalac_{{ site.scala212 }}-{{ site.scalametaVersion }}.jar` is available in `PLUGINS/semanticdb-scalac_{{ site.scala212 }}-{{ site.scalametaVersion }}.jar` path on your file system.
 
 Then, recompile your project using `-DaddScalacArgs` as follows:
 
 ```
-mvn clean test -DskipTests=true -DaddScalacArgs="-Yrangepos|-Xplugin-require:semanticdb|-Xplugin:PLUGIN/semanticdb-scalac_{{ site.scala212 }}-2.1.7.jar|-Ywarn-unused-import"
+mvn clean test -DskipTests=true -DaddScalacArgs="-Yrangepos|-Xplugin-require:semanticdb|-Xplugin:PLUGIN/semanticdb-scalac_{{ site.scala212 }}-{{ site.scalametaVersion }}.jar|-Ywarn-unused-import"
 ```
 
 If you used maven profile instead, you can do the following:
@@ -207,7 +214,7 @@ We compile both main sources and tests to have semantic information generated fo
 The added flags for scala are given with the `addScalaArgs` option (see http://davidb.github.io/scala-maven-plugin/help-mojo.html#addScalacArgs):
 
 * `-Yrangepos` is required for `semanticdb` to function properly,
-* `-Xplugin:PLUGIN/semanticdb-scalac_{{ site.scala212 }}-2.1.7.jar` give the path where the `semanticdb` jar can be found,
+* `-Xplugin:PLUGIN/semanticdb-scalac_{{ site.scala212 }}-{{ site.scalametaVersion }}.jar` give the path where the `semanticdb` jar can be found,
 * (optional) `-Xplugin-require:semanticdb` tells scalac to fails if it can't load the `semanticdb` plugin,
 * (optional) `-Ywarn-unused-import` is required for the `RemoveUnusedImports` rule. If you don't run `RemoveUnusedImports` you can skip this flag. Consult the scalafix documentation for each rule to see which flags it requires.
 * (optional) Customize the --sourceroot with `-P:semanticdb:sourceroot:/path/to/sourceroot` (more details below)

--- a/website/src/main/tut/docs/users/installation.md
+++ b/website/src/main/tut/docs/users/installation.md
@@ -139,34 +139,71 @@ It is possible to use scalafix with scala-maven-plugin but it requires a custom 
 
 ### Install semanticdb compiler plugin
 
-First, download the `semanticdb-scalac` compiler plugin which corresponds to your exact scala version of your project, down to the patch number.
+You can either install the semanticdb compiler plugin manually or let maven resolve the dependency for you.
 
-To begin with, it's recommended to install the coursier command line interface https://github.com/coursier/coursier.
+To install the plugin manually, first, download the `semanticdb-scalac` compiler plugin which corresponds to the exact scala version of your project(down to the patch number).
+
+It's recommended to do it via the [coursier command line interface](https://github.com/coursier/coursier) which simplifies downloading and launching library artifacts.
+
+To install coursier:
 
 ```
 wget https://github.com/coursier/coursier/raw/master/coursier && chmod +x coursier && ./coursier --help
 ```
 
-Coursier is a tool to download and launch library artifacts.
-Once you have coursier installed, assuming you are on {{ site.scala212 }}:
+Then, once you have coursier installed, assuming you are on {{ site.scala212 }}, download the plugin:
 
 ```
 coursier fetch --intransitive org.scalameta:semanticdb-scalac_{{ site.scala212 }}:{{ site.scalametaVersion }}
 ```
 
-You can also use `wget` or a simalar tool to retrieve the jar from `https://repo1.maven.org/maven2/org/scalameta/semanticdb-scalac_{{ site.scala212 }}/{{ site.scalametaVersion }}/semanticdb-scalac_{{ site.scala212 }}-{{ site.scalametaVersion }}-javadoc.jar`.
+Alternatively, you can also use `wget` or a simalar tool to retrieve the jar from `https://repo1.maven.org/maven2/org/scalameta/semanticdb-scalac_{{ site.scala212 }}/{{ site.scalametaVersion }}/semanticdb-scalac_{{ site.scala212 }}-{{ site.scalametaVersion }}.jar`.
+
+If you prefer using maven profile instead of manual download, add the following snippet to your maven `pom.xml`:
+
+```
+<profile>
+  <id>scalafix</id>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <configuration>
+          <compilerPlugins>
+            <compilerPlugin>
+              <groupId>org.scalameta</groupId>
+              <artifactId>semanticdb-scalac_{{ site.scala212 }}</artifactId>
+              <version>{{ site.scalametaVersion }}</version>
+            </compilerPlugin>
+          </compilerPlugins>
+          <addScalacArgs>-Yrangepos|-Ywarn-unused-import</addScalacArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</profile>
+```
 
 ### Compile sources with semanticdb
 
+If you installed the semanticdb plugin manually, you have to locate it first.
+
 Let's say the `semanticdb-scalac_{{ site.scala212 }}-{{ site.scalametaVersion }}.jar` is available in `PLUGINS/semanticdb-scalac_{{ site.scala212 }}-{{ site.scalametaVersion }}.jar` path on your file system.
 
-Recompile your project using `-DaddScalacArgs` as follow:
+Then, recompile your project using `-DaddScalacArgs` as follows:
 
 ```
 mvn clean test -DskipTests=true -DaddScalacArgs="-Yrangepos|-Xplugin-require:semanticdb|-Xplugin:PLUGIN/semanticdb-scalac_{{ site.scala212 }}-{{ site.scalametaVersion }}.jar|-Ywarn-unused-import"
 ```
 
-Here, we compile both main sources and tests to have semantic information generated for all of them, but we skip test execution because it is not the point of that compilation.
+If you used maven profile instead, you can do the following:
+
+```
+mvn clean test -DskipTests=true -P scalafix
+```
+
+We compile both main sources and tests to have semantic information generated for all of them, but we skip test execution because it is not the point of that compilation.
 The added flags for scala are given with the `addScalaArgs` option (see http://davidb.github.io/scala-maven-plugin/help-mojo.html#addScalacArgs):
 
 * `-Yrangepos` is required for `semanticdb` to function properly,

--- a/website/src/main/tut/docs/users/installation.md
+++ b/website/src/main/tut/docs/users/installation.md
@@ -154,10 +154,10 @@ wget https://github.com/coursier/coursier/raw/master/coursier && chmod +x coursi
 Then, once you have coursier installed, assuming you are on {{ site.scala212 }}, download the plugin:
 
 ```
-coursier fetch --intransitive org.scalameta:semanticdb-scalac_{{ site.scala212 }}:{{ site.scalametaVersion }}
+coursier fetch --intransitive org.scalameta:semanticdb-scalac_{{ site.scala212 }}:2.1.7
 ```
 
-Alternatively, you can also use `wget` or a simalar tool to retrieve the jar from `https://repo1.maven.org/maven2/org/scalameta/semanticdb-scalac_{{ site.scala212 }}/{{ site.scalametaVersion }}/semanticdb-scalac_{{ site.scala212 }}-{{ site.scalametaVersion }}.jar`.
+Alternatively, you can also use `wget` or a simalar tool to retrieve the jar from `https://repo1.maven.org/maven2/org/scalameta/semanticdb-scalac_{{ site.scala212 }}/2.1.7/semanticdb-scalac_{{ site.scala212 }}-2.1.7.jar`.
 
 If you prefer using maven profile instead of manual download, add the following snippet to your maven `pom.xml`:
 
@@ -174,7 +174,7 @@ If you prefer using maven profile instead of manual download, add the following 
             <compilerPlugin>
               <groupId>org.scalameta</groupId>
               <artifactId>semanticdb-scalac_{{ site.scala212 }}</artifactId>
-              <version>{{ site.scalametaVersion }}</version>
+              <version>2.1.7</version>
             </compilerPlugin>
           </compilerPlugins>
           <addScalacArgs>-Yrangepos|-Ywarn-unused-import</addScalacArgs>
@@ -189,12 +189,12 @@ If you prefer using maven profile instead of manual download, add the following 
 
 If you installed the semanticdb plugin manually, you have to locate it first.
 
-Let's say the `semanticdb-scalac_{{ site.scala212 }}-{{ site.scalametaVersion }}.jar` is available in `PLUGINS/semanticdb-scalac_{{ site.scala212 }}-{{ site.scalametaVersion }}.jar` path on your file system.
+Let's say the `semanticdb-scalac_{{ site.scala212 }}-2.1.7.jar` is available in `PLUGINS/semanticdb-scalac_{{ site.scala212 }}-2.1.7.jar` path on your file system.
 
 Then, recompile your project using `-DaddScalacArgs` as follows:
 
 ```
-mvn clean test -DskipTests=true -DaddScalacArgs="-Yrangepos|-Xplugin-require:semanticdb|-Xplugin:PLUGIN/semanticdb-scalac_{{ site.scala212 }}-{{ site.scalametaVersion }}.jar|-Ywarn-unused-import"
+mvn clean test -DskipTests=true -DaddScalacArgs="-Yrangepos|-Xplugin-require:semanticdb|-Xplugin:PLUGIN/semanticdb-scalac_{{ site.scala212 }}-2.1.7.jar|-Ywarn-unused-import"
 ```
 
 If you used maven profile instead, you can do the following:
@@ -207,7 +207,7 @@ We compile both main sources and tests to have semantic information generated fo
 The added flags for scala are given with the `addScalaArgs` option (see http://davidb.github.io/scala-maven-plugin/help-mojo.html#addScalacArgs):
 
 * `-Yrangepos` is required for `semanticdb` to function properly,
-* `-Xplugin:PLUGIN/semanticdb-scalac_{{ site.scala212 }}-{{ site.scalametaVersion }}.jar` give the path where the `semanticdb` jar can be found,
+* `-Xplugin:PLUGIN/semanticdb-scalac_{{ site.scala212 }}-2.1.7.jar` give the path where the `semanticdb` jar can be found,
 * (optional) `-Xplugin-require:semanticdb` tells scalac to fails if it can't load the `semanticdb` plugin,
 * (optional) `-Ywarn-unused-import` is required for the `RemoveUnusedImports` rule. If you don't run `RemoveUnusedImports` you can skip this flag. Consult the scalafix documentation for each rule to see which flags it requires.
 * (optional) Customize the --sourceroot with `-P:semanticdb:sourceroot:/path/to/sourceroot` (more details below)


### PR DESCRIPTION
Changes:
- added how-to instruction on using semanticdb plugin via maven profile instead of manual download
- added version compatibility table to installation doc

Testing:
- run `sbt website/makeMicrosite`
- run `jekyll serve` in `website/target/site` and verified the updated text is correct

Questions:
I wasn't sure if should `site.scalametaVersion` property so I hardcoded the correct version of the plugin instead. Feel free to reach out to me if you want it done differently.