### PR TITLE
Improve DisableSyntax's error message

### DIFF
--- a/scalafix-core/shared/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
@@ -46,11 +46,15 @@ final case class DisableSyntax(
           .copy(id = s"keywords.$keyword")
           .at(s"$keyword is disabled", token.pos)
       case token @ Token.Semicolon() if config.noSemicolons =>
-        error("noSemicolons", token)
+        errorCategory
+          .copy(id = "noSemicolons")
+          .at("semicolons are disabled", token.pos)
       case token @ Token.Tab() if config.noTabs =>
-        error("noTabs", token)
+        errorCategory.copy(id = "noTabs").at("tabs are disabled", token.pos)
       case token @ Token.Xml.Start() if config.noXml =>
-        error("noXml", token)
+        errorCategory
+          .copy(id = "noXml")
+          .at("xml literals are disabled", token.pos)
     }
   }
 
@@ -197,9 +201,6 @@ final case class DisableSyntax(
       id = "noValPatterns",
       explain = "Pattern matching in val assignment can result in match error, " +
         "use \"_ match { ... }\" with a fallback case instead.")
-
-  private def error(keyword: String, token: Token): LintMessage =
-    errorCategory.copy(id = keyword).at(s"$keyword is disabled", token.pos)
 }
 
 object DisableSyntax {

--- a/scalafix-tests/input/src/main/scala/test/disableSyntax/DisableSyntaxBase.scala
+++ b/scalafix-tests/input/src/main/scala/test/disableSyntax/DisableSyntaxBase.scala
@@ -37,9 +37,17 @@ case object DisableSyntaxBase {
   def foo: Unit = return    // assert: DisableSyntax.keywords.return
   throw new Exception("ok") // assert: DisableSyntax.keywords.throw
 
-  "semicolon";              // assert: DisableSyntax.noSemicolons
-  <a>xml</a>                // assert: DisableSyntax.noXml
-	                          // assert: DisableSyntax.noTabs
+  "semicolon"; /* assert: DisableSyntax.noSemicolons
+             ^
+  semicolons are disabled */
+
+  <a>xml</a>   /* assert: DisableSyntax.noXml
+  ^
+  xml literals are disabled */
+
+	             /* assert: DisableSyntax.noTabs
+^
+  tabs are disabled */
 
   implicit class StringPimp(value: String) { // assert: DisableSyntax.offensive
     def -(other: String): String = s"$value - $other"


### PR DESCRIPTION
Addresses https://github.com/scalacenter/scalafix/issues/660

This PR improves the report messages of `DisableSyntax.{noSemicolons, noTabs, noXml}` from  messages like `noSemicolons is disabled` to those like `semicolons are disabled`.