### PR TITLE
Expose simple constructor for SemanticRuleSuite

### DIFF
--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/BaseCliSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/BaseCliSuite.scala
@@ -18,10 +18,12 @@ import ammonite.ops
 import scala.meta.io.AbsolutePath
 import scala.meta.io.RelativePath
 import org.scalatest.FunSuite
+import scala.meta.io.Classpath
 import scalafix.v1.Main
 
 // extend this class to run custom cli tests.
 trait BaseCliSuite extends FunSuite with DiffAssertions {
+
   val original: String =
     """|object Main {
        |  def foo() {
@@ -46,6 +48,9 @@ trait BaseCliSuite extends FunSuite with DiffAssertions {
       .resolve("ExplicitResultTypesBase.scala")
   val semanticClasspath: String =
     BuildInfo.semanticClasspath.getAbsolutePath
+  def defaultClasspath: Classpath =
+    SemanticRuleSuite.defaultClasspath(
+      AbsolutePath(BuildInfo.semanticClasspath))
 
   def check(
       name: String,

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSemanticSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSemanticSuite.scala
@@ -6,7 +6,6 @@ import scala.meta.internal.io.PathIO
 import scala.meta.internal.io.FileIO
 import scalafix.cli._
 import scalafix.internal.rule.ExplicitResultTypes
-import scalafix.tests.rule.RuleSuite
 
 class CliSemanticSuite extends BaseCliSuite {
 
@@ -58,7 +57,7 @@ class CliSemanticSuite extends BaseCliSuite {
     name = "StaleSemanticDB",
     args = Array(
       "--classpath",
-      RuleSuite.defaultClasspath.syntax
+      defaultClasspath.syntax
     ),
     preprocess = { root =>
       val path = root.resolve(explicitResultTypesPath)
@@ -81,7 +80,7 @@ class CliSemanticSuite extends BaseCliSuite {
     name = "StaleSemanticDB fix matches input",
     args = Array(
       "--classpath",
-      RuleSuite.defaultClasspath.syntax
+      defaultClasspath.syntax
     ),
     preprocess = { root =>
       val expectedOutput = slurpOutput(explicitResultTypesPath)
@@ -101,7 +100,7 @@ class CliSemanticSuite extends BaseCliSuite {
     name = "explicit result types OK",
     args = Array(
       "--classpath",
-      RuleSuite.defaultClasspath.syntax
+      defaultClasspath.syntax
     ),
     expectedExit = ExitStatus.Ok,
     rule = ExplicitResultTypes.toString(),

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/rule/RuleSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/rule/RuleSuite.scala
@@ -1,33 +1,16 @@
 package scalafix.tests.rule
 
-import scala.meta._
 import scalafix.testkit._
 import scalafix.tests.BuildInfo
-import scalafix.tests.rule.RuleSuite._
-import scalafix.internal.reflect.RuleCompiler
 
 class RuleSuite
     extends SemanticRuleSuite(
-      AbsolutePath(BuildInfo.inputSourceroot),
-      defaultClasspath,
+      BuildInfo.semanticClasspath,
+      BuildInfo.inputSourceroot,
       Seq(
-        AbsolutePath(BuildInfo.outputSourceroot),
-        AbsolutePath(BuildInfo.outputDottySourceroot)
+        BuildInfo.outputSourceroot,
+        BuildInfo.outputDottySourceroot
       )
     ) {
   runAllTests()
-}
-
-object RuleSuite {
-  def defaultClasspath = Classpath(
-    classpath.entries ++
-      RuleCompiler.defaultClasspathPaths.filter(path =>
-        path.toNIO.getFileName.toString.contains("scala-library"))
-  )
-  def classpath: Classpath = Classpath(
-    List(
-      AbsolutePath(BuildInfo.semanticClasspath)
-    )
-  )
-
 }


### PR DESCRIPTION
This constructor uses the BuildInfo types directly simplifying the code
that scalafix.g8 needs to generate.