### PR TITLE
Add ScalafixTestkitPlugin to simplify g8 template.

### DIFF
--- a/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixTestkitPlugin.scala
+++ b/scalafix-sbt/src/main/scala/scalafix/sbt/ScalafixTestkitPlugin.scala
@@ -1,0 +1,47 @@
+package scalafix.sbt
+
+import sbt.Def
+import sbt._
+import sbt.Keys._
+import java.io.File.pathSeparator
+import sbt.plugins.JvmPlugin
+
+object ScalafixTestkitPlugin extends AutoPlugin {
+  override def trigger: PluginTrigger = noTrigger
+  override def requires: Plugins = JvmPlugin
+  object autoImport {
+    val scalafixTestkitInputClasspath =
+      taskKey[Classpath]("Classpath of input project")
+    val scalafixTestkitInputSourceDirectories =
+      taskKey[Seq[File]]("Source directory of output projects")
+    val scalafixTestkitOutputSourceDirectories =
+      taskKey[Seq[File]]("Source directories of output projects")
+  }
+  import autoImport._
+
+  override def projectSettings: Seq[Def.Setting[_]] = List(
+    resourceGenerators.in(Test) += Def.task {
+      val props = new java.util.Properties()
+      val values = Map[String, Seq[File]](
+        "inputClasspath" ->
+          scalafixTestkitInputClasspath.value.map(_.data),
+        "inputSourceDirectories" ->
+          scalafixTestkitInputSourceDirectories.value,
+        "outputSourceDirectories" ->
+          scalafixTestkitOutputSourceDirectories.value
+      )
+      values.foreach {
+        case (key, files) =>
+          props.put(
+            key,
+            files.iterator.filter(_.exists()).mkString(pathSeparator)
+          )
+      }
+      val out =
+        managedResourceDirectories.in(Test).value.head /
+          "scalafix-testkit.properties"
+      IO.write(props, "Input data for scalafix testkit", out)
+      List(out)
+    }
+  )
+}

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/RuleTest.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/RuleTest.scala
@@ -5,7 +5,6 @@ import metaconfig.Conf
 import metaconfig.Configured
 import metaconfig.internal.ConfGet
 import scala.meta.internal.io.FileIO
-import scala.meta.internal.io.PathIO
 import scalafix.v1
 import scala.meta._
 import scalafix.internal.util.SymbolTable

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/TestkitProperties.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/TestkitProperties.scala
@@ -23,6 +23,10 @@ final class TestkitProperties(
     val inputSourceDirectories: List[AbsolutePath],
     val outputSourceDirectories: List[AbsolutePath],
 ) {
+  def inputSourceDirectory: AbsolutePath =
+    inputSourceDirectories.head
+  def outputSourceDirectory: AbsolutePath =
+    outputSourceDirectories.head
   override def toString: String = {
     val map = Map(
       "inputSourceDirectories" -> inputSourceDirectories,

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/TestkitProperties.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/TestkitProperties.scala
@@ -21,7 +21,7 @@ import scala.meta.Classpath
 final class TestkitProperties(
     val inputClasspath: Classpath,
     val inputSourceDirectories: List[AbsolutePath],
-    val outputSourceDirectories: List[AbsolutePath],
+    val outputSourceDirectories: List[AbsolutePath]
 ) {
   def inputSourceDirectory: AbsolutePath =
     inputSourceDirectories.head

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/TestkitProperties.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/TestkitProperties.scala
@@ -1,0 +1,58 @@
+package scalafix.testkit
+
+import scala.meta.AbsolutePath
+import scala.meta.Classpath
+
+/**
+  * Input arguments to run scalafix testkit rules.
+  *
+  * @param inputClasspath
+  *        The class directory of the input sources. This directory should contain a
+  *        META-INF/semanticd sub-directory with SemanticDB files.
+  * @param inputSourceDirectories
+  *        The source directory of the input sources. This directory should contain Scala code to
+  *        be fixed by Scalafix.
+  * @param outputSourceDirectories
+  *        The source directories of the expected output sources. These directories should contain
+  *        Scala source files with the expected output after running Scalafix. When multiple directories
+  *        are provided, the first directory that contains a source files with a matching relative path
+  *        in inputSourceroot is used.
+  */
+final class TestkitProperties(
+    val inputClasspath: Classpath,
+    val inputSourceDirectories: List[AbsolutePath],
+    val outputSourceDirectories: List[AbsolutePath],
+) {
+  override def toString: String = {
+    val map = Map(
+      "inputSourceDirectories" -> inputSourceDirectories,
+      "outputSourceDirectories" -> outputSourceDirectories,
+      "inputClasspath" -> inputClasspath.syntax
+    )
+    pprint.PPrinter.BlackWhite.tokenize(map).mkString
+  }
+}
+
+object TestkitProperties {
+
+  /** Loads TestkitProperties from resource "scalafix-testkit.properties" of this classloader. */
+  def loadFromResources(): TestkitProperties = {
+    import scala.collection.JavaConverters._
+    val props = new java.util.Properties()
+    val path = "scalafix-testkit.properties"
+    val in = this.getClass.getClassLoader.getResourceAsStream(path)
+    if (in == null) {
+      sys.error(s"Failed to load resource $path")
+    } else {
+      val sprops = props.asScala
+      try props.load(in)
+      finally in.close()
+      new TestkitProperties(
+        Classpath(sprops("inputClasspath")),
+        Classpath(sprops("inputSourceDirectories")).entries,
+        Classpath(sprops("outputSourceDirectories")).entries
+      )
+    }
+  }
+
+}

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/BaseCliSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/BaseCliSuite.scala
@@ -70,7 +70,7 @@ trait BaseCliSuite extends FunSuite with DiffAssertions {
         new PrintStream(out)
       )
       val obtained = StringFS.dir2string(root)
-      val output = fansi.Str(out.toString).plainText
+      val output = fansi.Str(out.toString).plainText.replaceAll("\r\n", "\n")
       assert(exit == expectedExit, output)
       assertNoDiff(obtained, expectedLayout)
       outputAssert(output)

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/BaseCliSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/BaseCliSuite.scala
@@ -13,8 +13,6 @@ import scalafix.internal.tests.utils.SkipWindows
 import scalafix.test.StringFS
 import scalafix.testkit.DiffAssertions
 import scalafix.testkit.SemanticRuleSuite
-import scalafix.tests.BuildInfo
-import ammonite.ops
 import java.nio.file.FileVisitResult
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.StandardCopyOption
@@ -22,7 +20,6 @@ import java.nio.file.attribute.BasicFileAttributes
 import scala.meta.io.AbsolutePath
 import scala.meta.io.RelativePath
 import org.scalatest.FunSuite
-import scala.meta.io.Classpath
 import scalafix.testkit.TestkitProperties
 import scalafix.v1.Main
 

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSemanticSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSemanticSuite.scala
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.io.FileIO
+import scala.meta.io.Classpath
 import scalafix.cli._
 import scalafix.internal.rule.ExplicitResultTypes
 
@@ -13,7 +14,7 @@ class CliSemanticSuite extends BaseCliSuite {
     name = "--classpath ok",
     args = Array(
       "--classpath",
-      semanticClasspath
+      defaultClasspath
     ),
     expectedExit = ExitStatus.Ok
   )
@@ -34,7 +35,7 @@ class CliSemanticSuite extends BaseCliSuite {
       "--sourceroot",
       "bogus",
       "--classpath",
-      semanticClasspath
+      defaultClasspath
     ),
     expectedExit = ExitStatus.CommandLineError,
     outputAssert = { out =>
@@ -57,7 +58,7 @@ class CliSemanticSuite extends BaseCliSuite {
     name = "StaleSemanticDB",
     args = Array(
       "--classpath",
-      defaultClasspath.syntax
+      defaultClasspath
     ),
     preprocess = { root =>
       val path = root.resolve(explicitResultTypesPath)
@@ -80,7 +81,7 @@ class CliSemanticSuite extends BaseCliSuite {
     name = "StaleSemanticDB fix matches input",
     args = Array(
       "--classpath",
-      defaultClasspath.syntax
+      defaultClasspath
     ),
     preprocess = { root =>
       val expectedOutput = slurpOutput(explicitResultTypesPath)
@@ -100,7 +101,7 @@ class CliSemanticSuite extends BaseCliSuite {
     name = "explicit result types OK",
     args = Array(
       "--classpath",
-      defaultClasspath.syntax
+      defaultClasspath
     ),
     expectedExit = ExitStatus.Ok,
     rule = ExplicitResultTypes.toString(),
@@ -112,7 +113,9 @@ class CliSemanticSuite extends BaseCliSuite {
     name = "incomplete classpath does not result in error exit code",
     args = Array(
       "--classpath",
-      semanticClasspath // missing scala-library
+      Classpath(
+        props.inputClasspath.entries
+          .filterNot(_.toString().contains("scala-library"))).syntax
     ),
     // Errors in ExplicitResultTypes are suppressed.
     expectedExit = ExitStatus.Ok,

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/rule/RuleSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/rule/RuleSuite.scala
@@ -1,7 +1,6 @@
 package scalafix.tests.rule
 
 import scalafix.testkit._
-import scalafix.tests.BuildInfo
 
 class RuleSuite extends SemanticRuleSuite {
   runAllTests()

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/rule/RuleSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/rule/RuleSuite.scala
@@ -3,14 +3,6 @@ package scalafix.tests.rule
 import scalafix.testkit._
 import scalafix.tests.BuildInfo
 
-class RuleSuite
-    extends SemanticRuleSuite(
-      BuildInfo.semanticClasspath,
-      BuildInfo.inputSourceroot,
-      Seq(
-        BuildInfo.outputSourceroot,
-        BuildInfo.outputDottySourceroot
-      )
-    ) {
+class RuleSuite extends SemanticRuleSuite {
   runAllTests()
 }


### PR DESCRIPTION
With v0.6 testkit will need the full classpath of the input project.
Previously, testkit only needed the input classDirectory.
This commit introduces a new ScalafixTestkitPlugin to help abstract
over how arguments are passed from the build to testkit.
This simplifies the g8 template and also makes it easier to later
customize what data is passed from the build without modifying g8
templates.

Manually tested on typelevel/cats migration rewrites and seems to work well.