### PR TITLE
Fail fast in case of sonatype release conflicts [ci skip]

### DIFF
--- a/bin/ci-publish.sh
+++ b/bin/ci-publish.sh
@@ -29,7 +29,7 @@ if [[ "$TRAVIS_SECURE_ENV_VARS" == true && "$CI_PUBLISH" == true ]]; then
   echo "$PGP_SECRET" | base64 --decode | gpg --import
   if [ -n "$TRAVIS_TAG" ]; then
     echo "Tag push, publishing stable release to Sonatype."
-    sbt ci-release sonatypeReleaseAll
+    sbt ci-release sonatypeRelease
   else
     echo "Merge, publishing snapshot to Sonatype."
     sbt -Dscalafix.snapshot=true ci-release


### PR DESCRIPTION
By using sonatypeReleaseAll we risk releasing artifacts for bloop
in case a parallel release happens. This commit changes the release
script to use sonatypeRelease that fails fast in case there are more
than one staging repository, meaning we'll have to manually release in
case of conflict.

cc/ @jvican 