### PR TITLE
Support sourceroot in testkit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -317,13 +317,14 @@ def unit(
         // copy-pasted code from ScalafixTestkitPlugin to avoid cyclic dependencies between build and sbt-scalafix.
         val props = new java.util.Properties()
 
-        def put(key: String, files: Seq[File]): Unit =
-          props.put(
-            key,
-            files.iterator
-              .filter(_.exists())
-              .mkString(java.io.File.pathSeparator)
-          )
+        def put(key: String, files: Seq[File]): Unit = {
+          val value = files.iterator
+            .filter(_.exists())
+            .mkString(java.io.File.pathSeparator)
+          val scalaName = s"scala-${scalaBinaryVersion.value}"
+          val adjustedValue = value.replace("scala-2.12", scalaName)
+          props.put(key, adjustedValue)
+        }
 
         put(
           "inputClasspath",

--- a/build.sbt
+++ b/build.sbt
@@ -197,7 +197,6 @@ val testkit = MultiScalaProject(
     scalafixSettings,
     libraryDependencies ++= Seq(
       semanticdb,
-      ammonite,
       googleDiff,
       scalacheck,
       scalatest

--- a/build.sbt
+++ b/build.sbt
@@ -227,10 +227,6 @@ val testsInput = TestProject(
     project.settings(
       noPublish,
       semanticdbSettings,
-      scalacOptions += {
-        val sourceroot = baseDirectory.in(ThisBuild).value / srcMain / "scala"
-        s"-P:semanticdb:sourceroot:$sourceroot"
-      },
       scalacOptions ~= (_.filterNot(_ == "-Yno-adapted-args")),
       scalacOptions += "-Ywarn-adapted-args", // For NoAutoTupling
       scalacOptions += "-Ywarn-unused-import", // For RemoveUnusedImports

--- a/build.sbt
+++ b/build.sbt
@@ -320,8 +320,12 @@ def unit(
           val value = files.iterator
             .filter(_.exists())
             .mkString(java.io.File.pathSeparator)
-          val scalaName = s"scala-${scalaBinaryVersion.value}"
-          val adjustedValue = value.replace("scala-2.12", scalaName)
+          val inputScalaVersion = scalaBinaryVersion.in(testsInput).value
+          val outputScalaVersion = scalaBinaryVersion.value
+          val adjustedValue = value.replace(
+            s"scala-$inputScalaVersion",
+            s"scala-$outputScalaVersion"
+          )
           props.put(key, adjustedValue)
         }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,6 @@ object Dependencies {
   var testClasspath: String = "empty"
   def semanticdb: ModuleID = "org.scalameta" % "semanticdb-scalac" % scalametaV cross CrossVersion.full
   def metaconfig: ModuleID = "com.geirsson" %% "metaconfig-typesafe-config" % metaconfigV
-  def ammonite = "com.lihaoyi" %% "ammonite-ops" % "0.9.0"
   def googleDiff = "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0"
 
   def metacp = "org.scalameta" %% "metacp" % scalametaV

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -250,8 +250,8 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
       Developer(
         "ShaneDelmore",
         "Shane Delmore",
-        "eugene.burmako@gmail.com",
-        url("http://delmore.io")
+        "shane@delmore.io",
+        url("https://github.com/shanedelmore")
       )
     )
   )

--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
@@ -264,6 +264,9 @@ case class Args(
     } else classpath
   }
 
+  def classLoader: ClassLoader =
+    ClasspathOps.toClassLoader(validatedClasspath)
+
   def validate: Configured[ValidatedArgs] = {
     baseConfig.andThen {
       case (base, scalafixConfig) =>
@@ -282,7 +285,7 @@ case class Args(
               scalafixConfig.withFormat(
                 format
               ),
-              validatedClasspath,
+              classLoader,
               root,
               pathReplace,
               diffDisable

--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/MainOps.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/MainOps.scala
@@ -165,7 +165,7 @@ object MainOps {
             val sdoc = SemanticDoc.fromPath(
               doc,
               relpath,
-              args.classpath,
+              args.classLoader,
               args.symtab
             )
             val (fix, messages) =

--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/ValidatedArgs.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/ValidatedArgs.scala
@@ -16,7 +16,7 @@ case class ValidatedArgs(
     symtab: SymbolTable,
     rules: Rules,
     config: ScalafixConfig,
-    classpath: Classpath,
+    classLoader: ClassLoader,
     sourceroot: AbsolutePath,
     pathReplace: AbsolutePath => AbsolutePath,
     diffDisable: DiffDisable

--- a/scalafix-core/shared/src/main/scala/scalafix/internal/v1/package.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/internal/v1/package.scala
@@ -5,7 +5,6 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
 import scala.meta.io.AbsolutePath
-import scala.meta.io.Classpath
 import scala.meta.io.RelativePath
 import scala.collection.JavaConverters._
 import scala.meta.inputs.Input
@@ -20,19 +19,6 @@ package object v1 {
         new URI(null, null, path.getFileName.toString, null).toString
       }
       URI.create(reluri.mkString("/"))
-    }
-  }
-
-  implicit class XtensionClasspathScalafix(cp: Classpath) {
-    def resolveSemanticdb(path: RelativePath): Option[AbsolutePath] = {
-      cp.entries.iterator
-        .filter(_.isDirectory)
-        .map(
-          _.resolve("META-INF")
-            .resolve("semanticdb")
-            .resolve(path.toString() + ".semanticdb")
-        )
-        .collectFirst { case p if p.isFile => p }
     }
   }
 

--- a/scalafix-core/shared/src/main/scala/scalafix/v1/SemanticDoc.scala
+++ b/scalafix-core/shared/src/main/scala/scalafix/v1/SemanticDoc.scala
@@ -109,34 +109,31 @@ final class SemanticDoc private[scalafix] (
 object SemanticDoc {
   sealed abstract class Error(msg: String) extends Exception(msg)
   object Error {
-    final case class MissingSemanticdb(
-        relpath: RelativePath,
-        classpath: Classpath)
-        extends Error(s"No SemanticDB associated with $relpath in: ${classpath.entries.mkString("\n")}")
-    final case class MissingTextDocument(
-        reluri: String)
-        extends Error(
-          s"No TextDocument associated with uri $reluri in semanticdb"
-        )
+    final case class MissingSemanticdb(relpath: RelativePath)
+        extends Error(s"SemanticDB not found: $relpath")
+    final case class MissingTextDocument(reluri: String)
+        extends Error(s"TextDocument.uri not found: $reluri")
   }
 
   def fromPath(
       doc: Doc,
       path: RelativePath,
-      classpath: Classpath,
+      classLoader: ClassLoader,
       symtab: SymbolTable
   ): SemanticDoc = {
     val reluri = path.toRelativeURI.toString
-    val urls = classpath.entries.map(_.toNIO.toUri.toURL).toArray
-    val semanticdbLoader = new java.net.URLClassLoader(urls)
-    val semanticDbRelativeLocation = s"META-INF/semanticdb/$path.semanticdb"
-    Option(semanticdbLoader.getResourceAsStream(semanticDbRelativeLocation))
-      .map{inputStream =>
-        val sdocs = s.TextDocuments.parseFrom(inputStream).documents
+    val semanticdbReluri = s"META-INF/semanticdb/$path.semanticdb"
+    Option(classLoader.getResourceAsStream(semanticdbReluri)) match {
+      case Some(inputStream) =>
+        val sdocs =
+          try s.TextDocuments.parseFrom(inputStream).documents
+          finally inputStream.close()
         val sdoc = sdocs.find(_.uri == reluri).getOrElse {
           throw Error.MissingTextDocument(reluri)
         }
         new SemanticDoc(doc, sdoc, symtab)
-      }.getOrElse(throw Error.MissingSemanticdb(path, classpath))
+      case None =>
+        throw Error.MissingSemanticdb(path)
+    }
   }
 }

--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ClasspathOps.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ClasspathOps.scala
@@ -3,6 +3,7 @@ package scalafix.internal.reflect
 import java.io.File
 import java.io.OutputStream
 import java.io.PrintStream
+import java.net.URLClassLoader
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.Path
@@ -97,5 +98,10 @@ object ClasspathOps {
     }
     roots.foreach(x => Files.walkFileTree(x.toNIO, visitor))
     Classpath(buffer.result())
+  }
+
+  def toClassLoader(classpath: Classpath): ClassLoader = {
+    val urls = classpath.entries.map(_.toNIO.toUri.toURL).toArray
+    new URLClassLoader(urls, null)
   }
 }

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/RuleTest.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/RuleTest.scala
@@ -1,11 +1,7 @@
 package scalafix.testkit
 
-import java.nio.charset.StandardCharsets
-import java.nio.file.FileSystems
 import metaconfig.Conf
-import metaconfig.Configured
 import metaconfig.internal.ConfGet
-import scala.meta.internal.io.FileIO
 import scalafix.v1
 import scala.meta._
 import scalafix.internal.util.SymbolTable
@@ -15,50 +11,36 @@ import scalafix.internal.config.ScalafixConfig
 import scalafix.v1.RuleDecoder
 
 final class RuleTest(
-    val filename: RelativePath,
-    val run: () => Configured[(Rules, v1.SemanticDoc)]
+    val path: TestkitPath,
+    val run: () => (Rules, v1.SemanticDoc)
 )
 
 object RuleTest {
-  private val isScalaFile =
-    FileSystems.getDefault.getPathMatcher("glob:**.scala")
-
-  def fromDirectory(
-      offset: RelativePath,
-      dir: AbsolutePath,
+  def fromPath(
+      test: TestkitPath,
       classLoader: ClassLoader,
-      symtab: SymbolTable): Seq[RuleTest] = {
-    val scalaFiles =
-      FileIO.listAllFilesRecursively(dir).files.filter(isScalaFile.matches(_))
-    scalaFiles.map { rel =>
-      new RuleTest(
-        rel, { () =>
-          val input = Input.VirtualFile(
-            rel.toString(),
-            FileIO.slurp(dir.resolve(rel), StandardCharsets.UTF_8))
-          val tree = input.parse[Source].get
-          val doc = v1.Doc.fromTree(tree)
-          val sdoc = v1.SemanticDoc
-            .fromPath(doc, offset.resolve(rel), classLoader, symtab)
-          val comment = SemanticRuleSuite.findTestkitComment(tree.tokens)
-          val syntax = comment.syntax.stripPrefix("/*").stripSuffix("*/")
-          val conf = Conf.parseString(rel.toString(), syntax).get
-          val config = conf.as[ScalafixConfig]
-          config.andThen(scalafixConfig => {
-            val decoderSettings =
-              RuleDecoder.Settings().withConfig(scalafixConfig)
-            val decoder = RuleDecoder.decoder(decoderSettings)
-            val rulesConf =
-              ConfGet
-                .getKey(conf, "rules" :: "rule" :: Nil)
-                .getOrElse(Conf.Lst(Nil))
-            decoder
-              .read(rulesConf)
-              .andThen(_.withConfig(conf))
-              .map(_ -> sdoc)
-          })
-        }
-      )
+      symtab: SymbolTable): RuleTest = {
+    val run: () => (Rules, v1.SemanticDoc) = { () =>
+      val input = test.toInput
+      val tree = input.parse[Source].get
+      val doc = v1.Doc.fromTree(tree)
+      val sdoc =
+        v1.SemanticDoc.fromPath(doc, test.semanticdbPath, classLoader, symtab)
+      val comment = SemanticRuleSuite.findTestkitComment(tree.tokens)
+      val syntax = comment.syntax.stripPrefix("/*").stripSuffix("*/")
+      val conf = Conf.parseString(test.testName, syntax).get
+      val scalafixConfig = conf.as[ScalafixConfig].get
+      val decoderSettings =
+        RuleDecoder.Settings().withConfig(scalafixConfig)
+      val decoder = RuleDecoder.decoder(decoderSettings)
+      val rulesConf =
+        ConfGet
+          .getKey(conf, "rules" :: "rule" :: Nil)
+          .getOrElse(Conf.Lst(Nil))
+      val rules = decoder.read(rulesConf).get.withConfig(conf).get
+      (rules, sdoc)
     }
+
+    new RuleTest(test, run)
   }
 }

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
@@ -92,7 +92,7 @@ abstract class SemanticRuleSuite
       .newSymbolTable(props.inputClasspath)
       .getOrElse { sys.error("Failed to load symbol table") }
     props.inputSourceDirectories.flatMap { dir =>
-      RuleTest.fromDirectory(dir, props.inputClasspath, symtab)
+      RuleTest.fromDirectory(props.inputOffset, dir, props.inputClasspath, symtab)
     }
   }
   def runAllTests(): Unit = {

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
@@ -1,6 +1,5 @@
 package scalafix.testkit
 
-import java.net.URLClassLoader
 import java.nio.charset.StandardCharsets
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FunSuite
@@ -16,10 +15,12 @@ import scalafix.internal.testkit.MultiLineAssertExtractor
 import scalafix.v0.SemanticdbIndex
 
 /** Construct a test suite for running semantic Scalafix rules. */
-abstract class SemanticRuleSuite
+abstract class SemanticRuleSuite(val props: TestkitProperties)
     extends FunSuite
     with DiffAssertions
     with BeforeAndAfterAll { self =>
+
+  def this() = this(TestkitProperties.loadFromResources())
 
   @deprecated(
     "Use empty constructor instead. Arguments are passed as resource 'scalafix-testkit.properties'",
@@ -30,7 +31,6 @@ abstract class SemanticRuleSuite
       expectedOutputSourceroot: Seq[AbsolutePath]
   ) = this()
 
-  val props: TestkitProperties = TestkitProperties.loadFromResources()
   private def scalaVersion: String = scala.util.Properties.versionNumberString
   private def scalaVersionDirectory: Option[String] =
     if (scalaVersion.startsWith("2.11")) Some("scala-2.11")
@@ -38,35 +38,23 @@ abstract class SemanticRuleSuite
     else None
 
   def runOn(diffTest: RuleTest): Unit = {
-    test(diffTest.filename.toString()) {
-      val (rule, sdoc) = diffTest.run.apply().get
+    test(diffTest.path.testName) {
+      val (rule, sdoc) = diffTest.run.apply()
       val (fixed, messages) = rule.semanticPatch(sdoc, suppress = false)
 
       val tokens = fixed.tokenize.get
       val obtained = SemanticRuleSuite.stripTestkitComments(tokens)
-      val candidateOutputFiles = props.outputSourceDirectories.flatMap { root =>
-        val scalaSpecificFilename = scalaVersionDirectory.toList.map { path =>
-          root.resolve(
-            RelativePath(
-              diffTest.filename.toString().replaceFirst("scala", path)))
-        }
-        root.resolve(diffTest.filename) :: scalaSpecificFilename
-      }
-      val expected = candidateOutputFiles
-        .collectFirst {
-          case f if f.isFile =>
-            FileIO.slurp(f, StandardCharsets.UTF_8)
-        }
-        .getOrElse {
+      val expected = diffTest.path.resolveOutput(props) match {
+        case Right(file) =>
+          FileIO.slurp(file, StandardCharsets.UTF_8)
+        case Left(err) =>
           if (fixed == sdoc.input.text) {
-            obtained // linter
+            // rule is a linter, no need for an output file.
+            obtained
           } else {
-            val tried = candidateOutputFiles.mkString("\n")
-            sys.error(
-              s"""Missing expected output file for test ${diffTest.filename}. Tried:
-                 |$tried""".stripMargin)
+            fail(err)
           }
-        }
+      }
 
       val expectedLintMessages = CommentAssertion.extract(sdoc.tokens)
       val diff = AssertDiff(messages, expectedLintMessages)
@@ -93,8 +81,9 @@ abstract class SemanticRuleSuite
       .newSymbolTable(props.inputClasspath)
       .getOrElse { sys.error("Failed to load symbol table") }
     val classLoader = ClasspathOps.toClassLoader(props.inputClasspath)
-    props.inputSourceDirectories.flatMap { dir =>
-      RuleTest.fromDirectory(props.inputOffset, dir, classLoader, symtab)
+    val tests = TestkitPath.fromProperties(props)
+    tests.map { test =>
+      RuleTest.fromPath(test, classLoader, symtab)
     }
   }
   def runAllTests(): Unit = {

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
@@ -1,5 +1,6 @@
 package scalafix.testkit
 
+import java.net.URLClassLoader
 import java.nio.charset.StandardCharsets
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FunSuite
@@ -91,8 +92,9 @@ abstract class SemanticRuleSuite
     val symtab = ClasspathOps
       .newSymbolTable(props.inputClasspath)
       .getOrElse { sys.error("Failed to load symbol table") }
+    val classLoader = ClasspathOps.toClassLoader(props.inputClasspath)
     props.inputSourceDirectories.flatMap { dir =>
-      RuleTest.fromDirectory(props.inputOffset, dir, props.inputClasspath, symtab)
+      RuleTest.fromDirectory(props.inputOffset, dir, classLoader, symtab)
     }
   }
   def runAllTests(): Unit = {

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/TestkitPath.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/TestkitPath.scala
@@ -1,0 +1,65 @@
+package scalafix.testkit
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.FileSystems
+import scala.meta.inputs.Input
+import scala.meta.internal.io.FileIO
+import scala.meta.io.AbsolutePath
+import scala.meta.io.RelativePath
+import scalafix.internal.v1._
+
+/**
+  * An input file for a testkit test.
+  *
+  * @param input the absolute path to the input file.
+  * @param testPath the input file relativized by the input source directory.
+  *                 Used to compute the test name and the expected output file.
+  * @param semanticdbPath the input file relativized by the SemanticDB sourceroot.
+  *                       Used to compute the path to the SemanticDB payload.
+  */
+final class TestkitPath(
+    val input: AbsolutePath,
+    val testPath: RelativePath,
+    val semanticdbPath: RelativePath
+) {
+  override def toString: String = {
+    val map = Map(
+      "input" -> input,
+      "testPath" -> testPath,
+      "semanticdbPath" -> semanticdbPath
+    )
+    pprint.PPrinter.BlackWhite.tokenize(map).mkString
+  }
+  def testName: String = testPath.toRelativeURI.toString
+  def toInput: Input =
+    Input.VirtualFile(testName, FileIO.slurp(input, StandardCharsets.UTF_8))
+  def resolveOutput(props: TestkitProperties): Either[String, AbsolutePath] = {
+    val candidates =
+      props.outputSourceDirectories.map(dir => dir.resolve(testPath))
+    def tried: String = candidates.mkString("\n  ", "\n  ", "")
+    candidates.filter(_.isFile) match {
+      case head :: Nil =>
+        Right(head)
+      case Nil =>
+        Left(s"Missing output file for $testPath: $tried")
+      case _ =>
+        Left(s"Ambiguous output file for $testPath: $tried")
+    }
+  }
+}
+
+object TestkitPath {
+  private val isScalaFile =
+    FileSystems.getDefault.getPathMatcher("glob:**.scala")
+  def fromProperties(props: TestkitProperties): List[TestkitPath] = {
+    props.inputSourceDirectories.flatMap { sourceDirectory =>
+      val ls = FileIO.listAllFilesRecursively(sourceDirectory)
+      val scalaFiles = ls.files.filter(path => isScalaFile.matches(path.toNIO))
+      scalaFiles.map { testPath =>
+        val input = sourceDirectory.resolve(testPath)
+        val semanticdbPath = input.toRelative(props.sourceroot)
+        new TestkitPath(input, testPath, semanticdbPath)
+      }
+    }
+  }
+}

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/TestkitProperties.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/TestkitProperties.scala
@@ -2,6 +2,7 @@ package scalafix.testkit
 
 import scala.meta.AbsolutePath
 import scala.meta.Classpath
+import scala.meta.RelativePath
 
 /**
   * Input arguments to run scalafix testkit rules.
@@ -21,17 +22,21 @@ import scala.meta.Classpath
 final class TestkitProperties(
     val inputClasspath: Classpath,
     val inputSourceDirectories: List[AbsolutePath],
-    val outputSourceDirectories: List[AbsolutePath]
+    val outputSourceDirectories: List[AbsolutePath],
+    val sourceRoot: AbsolutePath
 ) {
   def inputSourceDirectory: AbsolutePath =
     inputSourceDirectories.head
   def outputSourceDirectory: AbsolutePath =
     outputSourceDirectories.head
+  def inputOffset: RelativePath = inputSourceDirectory.toRelative(sourceRoot)
+  def outputOffset: RelativePath = outputSourceDirectory.toRelative(sourceRoot)
   override def toString: String = {
     val map = Map(
       "inputSourceDirectories" -> inputSourceDirectories,
       "outputSourceDirectories" -> outputSourceDirectories,
-      "inputClasspath" -> inputClasspath.syntax
+      "inputClasspath" -> inputClasspath.syntax,
+      "sourceRoot" -> sourceRoot
     )
     pprint.PPrinter.BlackWhite.tokenize(map).mkString
   }
@@ -54,7 +59,8 @@ object TestkitProperties {
       new TestkitProperties(
         Classpath(sprops("inputClasspath")),
         Classpath(sprops("inputSourceDirectories")).entries,
-        Classpath(sprops("outputSourceDirectories")).entries
+        Classpath(sprops("outputSourceDirectories")).entries,
+        Classpath(sprops.getOrElse("sourceRoot", default = "")).entries.head
       )
     }
   }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/BaseCliSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/BaseCliSuite.scala
@@ -174,16 +174,22 @@ trait BaseCliSuite extends FunSuite with DiffAssertions {
   ): Unit = {
     test(name, SkipWindows) {
       val fileIsFixed = expectedExit.isOk
-      val tmp = AbsolutePath(Files.createTempDirectory("scalafix"))
+      val cwd = Files.createTempDirectory("scalafix")
+      val inputSourceDirectory =
+        cwd.resolve("scalafix-tests/input/src/main/scala/")
+      Files.createDirectories(inputSourceDirectory)
+      val root = AbsolutePath(inputSourceDirectory)
       val out = new ByteArrayOutputStream()
-      tmp.toFile.deleteOnExit()
-      val root = tmp
-      copyRecursively(props.inputSourceDirectory, tmp)
+      root.toFile.deleteOnExit()
+      copyRecursively(source = props.inputSourceDirectory, target = root)
       val rootNIO = root
       writeTestkitConfiguration(rootNIO, rootNIO.resolve(path))
       preprocess(root)
+      val sourceroot =
+        if (args.contains("--sourceroot")) Array[String]()
+        else Array("--sourceroot", cwd.toString)
       val exit = Main.run(
-        args ++ Seq(
+        args ++ sourceroot ++ Seq(
           "-r",
           rule,
           files

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSemanticSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSemanticSuite.scala
@@ -49,7 +49,7 @@ class CliSemanticSuite extends BaseCliSuite {
     args = Array(), // no --classpath
     expectedExit = ExitStatus.MissingSemanticdbError,
     outputAssert = { out =>
-      assert(out.contains("No SemanticDB associated with"))
+      assert(out.contains("SemanticDB not found: "))
       assert(out.contains(removeImportsPath.toNIO.getFileName.toString))
     }
   )


### PR DESCRIPTION
This is not ready for merge, it is meant only to demonstrate a small set of changes that would fix scalafix-testkit support for build tools using a sourceroot format like Pants/Bazel/Buck.  This PR currently breaks SBT usage.