### PR TITLE
Upgrade to scalameta v4.0.0-M6.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 /* scalafmt: { maxColumn = 120 }*/
 
 object Dependencies {
-  val scalametaV = "4.0.0-M4-194-4947ce29-SNAPSHOT"
+  val scalametaV = "4.0.0-M6"
   val metaconfigV = "0.8.3"
   def dotty = "0.9.0-RC1"
   def scala210 = "2.10.6"


### PR DESCRIPTION
Updated PrettyTypeFuzzSuite to ignore expected failures.
The fuzz test needs improvement to reduce false negatives.