### PR TITLE
Support loading custom rules by their name instead of FQN

### DIFF
--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/RuleDecoderOps.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/RuleDecoderOps.scala
@@ -25,6 +25,7 @@ object RuleDecoderOps {
   val legacyRuleClass: Class[v0.Rule] =
     classOf[scalafix.rule.Rule]
   def toRule(cls: Class[_]): v1.Rule = {
+    assertNotOutdatedScalafixRule(cls)
     if (legacySemanticRuleClass.isAssignableFrom(cls)) {
       val fn: v0.SemanticdbIndex => v0.Rule = { index =>
         val ctor = cls.getDeclaredConstructor(classOf[v0.SemanticdbIndex])
@@ -40,6 +41,18 @@ object RuleDecoderOps {
       val ctor = cls.getDeclaredConstructor()
       ctor.setAccessible(true)
       cls.newInstance().asInstanceOf[v1.Rule]
+    }
+  }
+
+  def assertNotOutdatedScalafixRule(cls: Class[_]): Unit = {
+    cls.getSuperclass.getName match {
+      case "scalafix.rule.Rule" | "scalafix.rule.SemanticRule" =>
+        // Custom rule is using 0.5 API that is not supported here.
+        throw new IllegalArgumentException(
+          "Outdated Scalafix rule, please upgrade to the latest Scalafix version"
+        )
+      case _ =>
+        ()
     }
   }
 

--- a/scalafix-tests/input/src/main/scala/test/ServiceLoaders.scala
+++ b/scalafix-tests/input/src/main/scala/test/ServiceLoaders.scala
@@ -1,0 +1,9 @@
+/*
+rules = [
+  SemanticRuleV1
+  SyntacticRuleV1
+]
+ */
+package test
+
+object ServiceLoaders

--- a/scalafix-tests/output/src/main/scala/test/ServiceLoaders.scala
+++ b/scalafix-tests/output/src/main/scala/test/ServiceLoaders.scala
@@ -1,0 +1,6 @@
+package test
+
+object ServiceLoaders
+
+object SemanticRuleV1
+object SyntacticRuleV1

--- a/scalafix-tests/unit/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/scalafix-tests/unit/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,0 +1,2 @@
+banana.rule.SemanticRuleV1
+banana.rule.SyntacticRuleV1


### PR DESCRIPTION
Previously, custom rules had to be configured through the 'class:FQN'
option but this was error prone since it's easy to mess up the rule
FQN and it's long to type. This commit adds support for loading custom
rules from the classpath using JDK ServiceLoaders:
https://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html

```
// Before
rules = [ "class:com.bar.FooRule" ]
// After
rules = [ FooRule ]
```