### PR TITLE
Upgrade to scalameta v4.0-M8

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 /* scalafmt: { maxColumn = 120 }*/
 
 object Dependencies {
-  val scalametaV = "4.0.0-M6"
+  val scalametaV = "4.0.0-M8"
   val metaconfigV = "0.8.3"
   def dotty = "0.9.0-RC1"
   def scala210 = "2.10.6"

--- a/scalafix-core/src/main/scala/scalafix/internal/util/PrettyType.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/util/PrettyType.scala
@@ -6,7 +6,6 @@ import scala.meta.internal.symtab.SymbolTable
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.semanticdb.SymbolInformation.{Kind => k}
 import scala.meta.internal.semanticdb.SymbolInformation.{Property => p}
-import scala.meta.internal.semanticdb.Accessibility.{Tag => a}
 import scala.meta.internal.{semanticdb => s}
 import scala.util.control.NoStackTrace
 import scala.util.control.NonFatal
@@ -413,9 +412,9 @@ class PrettyType private (
   case class TypeToTreeError(msg: String, cause: Option[Throwable] = None)
       extends Exception(msg, cause.orNull)
   def fail(sig: s.Signature): Nothing =
-    fail(sig.toSignatureMessage)
+    fail(sig.asMessage)
   def fail(tpe: s.Type): Nothing =
-    fail(tpe.toTypeMessage)
+    fail(tpe.asMessage)
   def fail(tree: Tree): Nothing =
     throw TypeToTreeError(tree.syntax + s"\n\n${tree.structure}")
   def fail(any: GeneratedMessage): Nothing =
@@ -687,22 +686,20 @@ class PrettyType private (
 
   def toMods(info: s.SymbolInformation): List[Mod] = {
     val buf = List.newBuilder[Mod]
-    info.accessibility.foreach { accessibility =>
-      accessibility.tag match {
-        case a.PRIVATE =>
-          buf += Mod.Private(Name.Anonymous())
-        case a.PRIVATE_WITHIN =>
-          buf += Mod.Private(accessibility.symbol.toIndeterminateName)
-        case a.PRIVATE_THIS =>
-          buf += Mod.Private(Term.This(Name.Anonymous()))
-        case a.PROTECTED =>
-          buf += Mod.Protected(Name.Anonymous())
-        case a.PROTECTED_WITHIN =>
-          buf += Mod.Protected(accessibility.symbol.toIndeterminateName)
-        case a.PROTECTED_THIS =>
-          buf += Mod.Protected(Term.This(Name.Anonymous()))
-        case _ =>
-      }
+    info.access match {
+      case s.PrivateAccess() =>
+        buf += Mod.Private(Name.Anonymous())
+      case s.PrivateWithinAccess(symbol) =>
+        buf += Mod.Private(symbol.toIndeterminateName)
+      case s.PrivateThisAccess() =>
+        buf += Mod.Private(Term.This(Name.Anonymous()))
+      case s.ProtectedAccess() =>
+        buf += Mod.Protected(Name.Anonymous())
+      case s.ProtectedWithinAccess(symbol) =>
+        buf += Mod.Protected(symbol.toIndeterminateName)
+      case s.ProtectedThisAccess() =>
+        buf += Mod.Protected(Term.This(Name.Anonymous()))
+      case _ =>
     }
     if (info.is(p.SEALED)) buf += Mod.Sealed()
     if (info.kind.isClass && info.is(p.ABSTRACT)) buf += Mod.Abstract()

--- a/scalafix-core/src/main/scala/scalafix/internal/v0/LegacyCodePrinter.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/v0/LegacyCodePrinter.scala
@@ -1,0 +1,176 @@
+package scalafix.internal.v0
+
+import java.nio.charset.StandardCharsets
+import scala.meta.inputs.Input
+import scala.meta.inputs.Position
+import scala.meta.internal.semanticdb.Scala._
+import scala.meta.internal.{semanticdb => s}
+import scalafix.internal.patch.DocSemanticdbIndex.InputSynthetic
+import scalafix.v0
+import scalafix.v0.ResolvedName
+import scalafix.v1.SemanticDoc
+
+class LegacyCodePrinter() {
+  case class PositionedSymbol(symbol: v0.Symbol, start: Int, end: Int)
+  private val buf = List.newBuilder[PositionedSymbol]
+  private val text = new StringBuilder
+  private def emit(symbol: String): Unit = {
+    emitCode(symbol.desc.name, symbol)
+  }
+  private def emitCode(code: String, sym: String): Unit = {
+    val start = text.length
+    text.append(code)
+    val end = text.length
+    buf += PositionedSymbol(v0.Symbol(sym), start, end)
+  }
+  private def mkString[T](start: String, trees: Seq[T], end: String)(
+      fn: T => Unit): Unit = {
+    if (trees.isEmpty) ()
+    else {
+      text.append(start)
+      var first = true
+      trees.foreach { tree =>
+        fn(tree)
+        if (first) {
+          first = false
+        } else {
+          text.append(", ")
+        }
+      }
+      text.append(end)
+    }
+  }
+
+  private def pprint(sig: s.Signature): Unit = sig match {
+    case s.ValueSignature(tpe) =>
+      pprint(tpe)
+    case _ =>
+  }
+  private def pprint(tpe: s.Type): Unit = tpe match {
+    case s.TypeRef(prefix, symbol, typeArguments) =>
+      prefix match {
+        case s.NoType =>
+        case _ =>
+          pprint(prefix)
+          text.append(".")
+      }
+      emit(symbol)
+      mkString("[", typeArguments, "]")(pprint)
+    // TODO(olafur): Print out more advanced types https://github.com/scalacenter/scalafix/issues/785
+    case s.SingleType(prefix, symbol) =>
+      pprint(prefix)
+      emit(symbol)
+    case s.ThisType(symbol) =>
+      emit(symbol)
+    case s.SuperType(prefix, symbol) =>
+      pprint(prefix)
+      emit(symbol)
+    case s.ConstantType(constant) =>
+      pprint(constant)
+    case s.IntersectionType(types) =>
+      types.foreach(pprint)
+    case s.UnionType(types) =>
+      types.foreach(pprint)
+    case s.WithType(types) =>
+      types.foreach(pprint)
+    case s.StructuralType(tpe, declarations) =>
+      pprint(tpe)
+      declarations.foreach { s =>
+        s.symbols.foreach(emit)
+        s.hardlinks.foreach(info => pprint(info.signature))
+      }
+    case s.AnnotatedType(_, tpe) =>
+      pprint(tpe)
+    case s.ExistentialType(tpe, declarations) =>
+      pprint(tpe)
+      declarations.foreach { s =>
+        s.symbols.foreach(emit)
+        s.hardlinks.foreach(info => pprint(info.signature))
+      }
+    case s.UniversalType(typeParameters, tpe) =>
+      typeParameters.foreach { s =>
+        s.symbols.foreach(emit)
+        s.hardlinks.foreach(info => pprint(info.signature))
+      }
+      pprint(tpe)
+    case s.ByNameType(tpe) =>
+      pprint(tpe)
+    case s.RepeatedType(tpe) =>
+      pprint(tpe)
+    case s.NoType =>
+  }
+  private def pprint(const: s.Constant): Unit = {
+    const match {
+      case s.NoConstant =>
+        text.append("<?>")
+      case s.UnitConstant() =>
+        text.append("()")
+      case s.BooleanConstant(true) =>
+        text.append(true)
+      case s.BooleanConstant(false) =>
+        text.append(false)
+      case s.ByteConstant(value) =>
+        text.append(value.toByte)
+      case s.ShortConstant(value) =>
+        text.append(value.toShort)
+      case s.CharConstant(value) =>
+        text.append("'" + value.toChar + "'")
+      case s.IntConstant(value) =>
+        text.append(value)
+      case s.LongConstant(value) =>
+        text.append(value + "L")
+      case s.FloatConstant(value) =>
+        text.append(value + "f")
+      case s.DoubleConstant(value) =>
+        text.append(value)
+      case s.StringConstant(value) =>
+        // TODO: Escape
+        text.append("\"" + value + "\"")
+      case s.NullConstant() =>
+        text.append("null")
+    }
+  }
+  private def loop(tree: s.Tree): Unit = tree match {
+    case s.NoTree =>
+    case s.ApplyTree(fn, args) =>
+      loop(fn)
+      mkString("(", args, ")")(loop)
+    case s.FunctionTree(params, term) =>
+      text.append("{")
+      mkString("(", params, ") => ")(loop)
+      loop(term)
+      text.append("}")
+    case s.IdTree(sym) =>
+      emit(sym)
+    case s.LiteralTree(const) =>
+      pprint(const)
+    case s.MacroExpansionTree(_, tpe) =>
+      text.append("(`macro-expandee` : ")
+      pprint(tpe)
+      text.append(")")
+    case s.OriginalTree(_) =>
+      emitCode("*", "_star_.")
+    case s.SelectTree(qual, id) =>
+      loop(qual)
+      text.append(".")
+      id.foreach(loop) // id should be no_box
+    case s.TypeApplyTree(fn, targs) =>
+      loop(fn)
+      mkString("[", targs, "]")(pprint)
+  }
+
+  def toLegacy(
+      synthetic: s.Synthetic,
+      doc: SemanticDoc,
+      pos: Position): v0.Synthetic = {
+    loop(synthetic.tree)
+    val input = Input.Stream(
+      InputSynthetic(text.result(), doc.input, pos.start, pos.end),
+      StandardCharsets.UTF_8)
+    val names = buf.result().map { sym =>
+      val symPos = Position.Range(input, sym.start, sym.end)
+      ResolvedName(symPos, sym.symbol, isDefinition = false)
+    }
+    v0.Synthetic(pos, input.text, names)
+  }
+}

--- a/scalafix-core/src/main/scala/scalafix/v1/Sym.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/Sym.scala
@@ -63,8 +63,7 @@ object Sym {
     def name: String = info.name
     def kind: Kind = new Kind(info)
     def props: Properties = new Properties(info.properties)
-    def access: Accessibility =
-      new Accessibility(info.accessibility.getOrElse(s.Accessibility()))
+    def access: Access = new Access(info.access)
 
     override def toString: String = s"Sym.Info(${info.symbol})"
   }
@@ -117,13 +116,21 @@ object Sym {
       (props & property.value) != 0
   }
 
-  final class Accessibility private[Sym] (a: s.Accessibility) {
-    def isPrivate: Boolean = a.tag.isPrivate
-    def isPrivateThis: Boolean = a.tag.isPrivateThis
-    def isProtected: Boolean = a.tag.isProtected
-    def isProtectedThis: Boolean = a.tag.isProtectedThis
-    def isPublic: Boolean = a.tag.isPublic
-    def within: Sym = new Sym(a.symbol)
+  final class Access private[Sym] (a: s.Access) {
+    def isPrivate: Boolean = a.isInstanceOf[s.PrivateAccess]
+    def isPrivateThis: Boolean = a.isInstanceOf[s.PrivateThisAccess]
+    def privateWithin: Option[Sym] = a match {
+      case s.PrivateWithinAccess(symbol) => Some(Sym(symbol))
+      case _ => scala.None
+    }
+    def isProtected: Boolean = a.isInstanceOf[s.ProtectedAccess]
+    def isProtectedThis: Boolean = a.isInstanceOf[s.ProtectedThisAccess]
+    def protectedWithin: Option[Sym] = a match {
+      case s.ProtectedWithinAccess(symbol) => Some(Sym(symbol))
+      case _ => scala.None
+    }
+    def isPublic: Boolean = a.isInstanceOf[s.PublicAccess]
+    def isNone: Boolean = a == s.NoAccess
   }
 
   final class Matcher private (doc: SemanticDoc, syms: Seq[Sym]) {

--- a/scalafix-tests/input/src/main/scala/test/DisableSimple.scala
+++ b/scalafix-tests/input/src/main/scala/test/DisableSimple.scala
@@ -64,7 +64,7 @@ If you must Option.get, wrap the code block with
   val l: ListBuffer[Int] = scala.collection.mutable.ListBuffer.empty[Int] // assert: Disable.mutable
   List(1) + "any2stringadd" /* assert: Disable.any2stringadd
   ^
-any2stringadd is disabled and it got inferred as `scala.Predef.any2stringadd[List[Int]](*)`
+any2stringadd is disabled and it got inferred as `any2stringadd[List[Int]](*)`
   */
 
   @SuppressWarnings(Array("Disable.drop", "Disable.length"))


### PR DESCRIPTION
This is most likely the last milestone release.  There were two major
breaking changes that are addressed in this commit.

- new synthetics are now an ADT so we implement a code printer to
  produce the old synthetics
- accessibility is now an ADT