### PR TITLE
Inline scalameta-structure into repo

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/internal/util/Inspect.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/util/Inspect.scala
@@ -5,15 +5,16 @@ import scala.meta._
 import org.typelevel.paiges._
 
 object Inspect {
-  def pretty(tree: Tree, showFieldNames: Boolean): String = {
-    prettyTree(tree, showFieldNames).render(1)
-  }
 
-  private def prettyList(tree: List[Tree], showFieldNames: Boolean): Doc = {
+  def prettyList(tree: List[Tree], showFieldNames: Boolean): Doc = {
     wrapList(tree.map(t => prettyTree(t, showFieldNames)))
   }
 
-  private def prettyTree(tree: Tree, showFieldNames: Boolean): Doc = {
+  def prettyOption(tree: Option[Tree], showFieldNames: Boolean): Doc = {
+    wrapOption(tree.map(t => prettyTree(t, showFieldNames)))
+  }
+
+  def prettyTree(tree: Tree, showFieldNames: Boolean): Doc = {
     tree match {
       case _ if tree.tokens.isEmpty =>
         Doc.empty

--- a/scalafix-core/src/main/scala/scalafix/util/Api.scala
+++ b/scalafix-core/src/main/scala/scalafix/util/Api.scala
@@ -19,15 +19,31 @@ trait Api {
     def asPatch: Patch = patch.getOrElse(Patch.empty)
   }
 
-  implicit class XtensionScalafixTreeInspect(tree: Tree) {
-    def inspect: String = Inspect.pretty(tree, showFieldNames = false)
-    def inspectLabeled: String = Inspect.pretty(tree, showFieldNames = true)
-  }
-
   type Diagnostic = scalafix.lint.Diagnostic
   val Diagnostic = scalafix.lint.Diagnostic
 
   type CustomMessage[T] = scalafix.config.CustomMessage[T]
   val CustomMessage = scalafix.config.CustomMessage
+
+  implicit class XtensionScalafixTreeInspect(tree: Tree) {
+    def inspect: String =
+      Inspect.prettyTree(tree, showFieldNames = false).render(1)
+    def inspectLabeled: String =
+      Inspect.prettyTree(tree, showFieldNames = true).render(1)
+  }
+
+  implicit class XtensionScalafixOptionTreeInspect(tree: Option[Tree]) {
+    def inspect: String =
+      Inspect.prettyOption(tree, showFieldNames = false).render(1)
+    def inspectLabeled: String =
+      Inspect.prettyOption(tree, showFieldNames = true).render(1)
+  }
+
+  implicit class XtensionScalafixListTreeInspect(tree: List[Tree]) {
+    def inspect: String =
+      Inspect.prettyList(tree, showFieldNames = false).render(1)
+    def inspectLabeled: String =
+      Inspect.prettyList(tree, showFieldNames = true).render(1)
+  }
 
 }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/util/InspectSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/util/InspectSuite.scala
@@ -37,4 +37,23 @@ class InspectSuite extends FunSuite with DiffAssertions {
          |)""".stripMargin
     assert(obtained == expected)
   }
+
+  test("option") {
+    assertNoDiff(
+      q"def foo: A = ???".decltpe.inspect,
+      """|
+         |Some(Type.Name("A"))
+         |""".stripMargin
+    )
+  }
+
+  test("list") {
+    assertNoDiff(
+      q"foo(a)".args.inspect,
+      """|List(
+         |  Term.Name("a")
+         |)
+         |""".stripMargin
+    )
+  }
 }


### PR DESCRIPTION
Based on feedback from @MasseGuillaume and @ShaneDelmore, there's been missing a utility to inspect the structure of trees. `Tree.structure` is too dense to be helpful. This commit inlines the sources from the repo https://github.com/masseguillaume/scalameta-structure. Thank you @MasseGuillaume for implementing scalameta-structure! I did my best to preserve the git history, but I suspect I messed it up somehow 😅 