### PR TITLE
Rename Tpe to SType.

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/internal/v1/FromProtobuf.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/v1/FromProtobuf.scala
@@ -17,35 +17,35 @@ class FromProtobuf()(implicit doc: SemanticDoc) {
       else sc.infos.iterator.map(i => new SymbolInfo(i)).toList
   }
 
-  def stype(t: s.Type): Tpe = t match {
+  def stype(t: s.Type): SType = t match {
     case s.IntersectionType(types) =>
-      new IntersectionTpe(types.convert)
+      new IntersectionType(types.convert)
     case s.SuperType(prefix, symbol) =>
-      new SuperTpe(prefix.convert, symbol.convert)
+      new SuperType(prefix.convert, symbol.convert)
     case s.ByNameType(tpe) =>
-      new ByNameTpe(tpe.convert)
+      new ByNameType(tpe.convert)
     case s.AnnotatedType(annotations, tpe) =>
-      new AnnotatedTpe(annotations.convert, tpe.convert)
+      new AnnotatedType(annotations.convert, tpe.convert)
     case s.ConstantType(constant) =>
-      new ConstantTpe(sconstant(constant))
+      new ConstantType(sconstant(constant))
     case s.TypeRef(prefix, symbol, typeArguments) =>
-      new TpeRef(prefix.convert, symbol.convert, typeArguments.convert)
+      new TypeRef(prefix.convert, symbol.convert, typeArguments.convert)
     case s.StructuralType(tpe, declarations) =>
-      new StructuralTpe(tpe.convert, declarations.convert)
+      new StructuralType(tpe.convert, declarations.convert)
     case s.RepeatedType(tpe) =>
-      new RepeatedTpe(tpe.convert)
+      new RepeatedType(tpe.convert)
     case s.ThisType(symbol) =>
-      new ThisTpe(symbol.convert)
+      new ThisType(symbol.convert)
     case s.WithType(types) =>
-      new WithTpe(types.convert)
+      new WithType(types.convert)
     case s.UniversalType(typeParameters, tpe) =>
-      new UniversalTpe(typeParameters.convert, tpe.convert)
+      new UniversalType(typeParameters.convert, tpe.convert)
     case s.SingleType(prefix, symbol) =>
-      new SingleTpe(prefix.convert, symbol.convert)
+      new SingleType(prefix.convert, symbol.convert)
     case s.ExistentialType(tpe, declarations) =>
-      new ExistentialTpe(tpe.convert, declarations.convert)
+      new ExistentialType(tpe.convert, declarations.convert)
     case s.UnionType(types) =>
-      new UnionTpe(types.convert)
+      new UnionType(types.convert)
     case s.NoType =>
       NoTpe
   }
@@ -113,10 +113,10 @@ class FromProtobuf()(implicit doc: SemanticDoc) {
     def convert: Symbol = Symbol(sym)
   }
   implicit class RichType(t: s.Type) {
-    def convert: Tpe = stype(t)
+    def convert: SType = stype(t)
   }
   implicit class RichTypes(types: Seq[s.Type]) {
-    def convert: List[Tpe] = types.iterator.map(stype).toList
+    def convert: List[SType] = types.iterator.map(stype).toList
   }
   implicit class RichScope(scope: Option[s.Scope]) {
     def convert: List[SymbolInfo] = sscope(scope)

--- a/scalafix-core/src/main/scala/scalafix/v1/Annotation.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/Annotation.scala
@@ -2,7 +2,7 @@ package scalafix.v1
 
 import scala.runtime.Statics
 
-final class Annotation(val tpe: Tpe) {
+final class Annotation(val tpe: SType) {
   override def toString: String = s"Annotation($tpe)"
   override def equals(obj: Any): Boolean =
     this.eq(obj.asInstanceOf[AnyRef]) || (obj match {

--- a/scalafix-core/src/main/scala/scalafix/v1/SType.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/SType.scala
@@ -2,20 +2,20 @@ package scalafix.v1
 
 import scala.runtime.Statics
 
-sealed abstract class Tpe
+sealed abstract class SType
 
-case object NoTpe extends Tpe
+case object NoTpe extends SType
 
-final class TpeRef(
-    val prefix: Tpe,
+final class TypeRef(
+    val prefix: SType,
     val symbol: Symbol,
-    val typeArguments: List[Tpe]
-) extends Tpe {
+    val typeArguments: List[SType]
+) extends SType {
   override def toString: String =
     s"TypeRef($prefix,$symbol,$typeArguments)"
   override def equals(obj: Any): Boolean =
     this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
-      case s: TpeRef =>
+      case s: TypeRef =>
         this.prefix == s.prefix &&
           this.symbol == s.symbol &&
           this.typeArguments == s.typeArguments
@@ -30,15 +30,15 @@ final class TpeRef(
   }
 }
 
-final class SingleTpe(
-    val prefix: Tpe,
+final class SingleType(
+    val prefix: SType,
     val symbol: Symbol
-) extends Tpe {
+) extends SType {
   override def toString: String =
     s"SingleType($prefix,$symbol)"
   override def equals(obj: Any): Boolean =
     this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
-      case s: TpeRef =>
+      case s: TypeRef =>
         this.prefix == s.prefix &&
           this.symbol == s.symbol
       case _ => false
@@ -51,14 +51,14 @@ final class SingleTpe(
   }
 }
 
-final class ThisTpe(
+final class ThisType(
     val symbol: Symbol
-) extends Tpe {
+) extends SType {
   override def toString: String =
     s"ThisType($symbol)"
   override def equals(obj: Any): Boolean =
     this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
-      case s: ThisTpe =>
+      case s: ThisType =>
         this.symbol == s.symbol
       case _ => false
     })
@@ -69,15 +69,15 @@ final class ThisTpe(
   }
 }
 
-final class SuperTpe(
-    val prefix: Tpe,
+final class SuperType(
+    val prefix: SType,
     val symbol: Symbol
-) extends Tpe {
+) extends SType {
   override def toString: String =
     s"SuperType($prefix,$symbol)"
   override def equals(obj: Any): Boolean =
     this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
-      case s: SuperTpe =>
+      case s: SuperType =>
         this.prefix == s.prefix &&
           this.symbol == s.symbol
       case _ => false
@@ -90,14 +90,14 @@ final class SuperTpe(
   }
 }
 
-final class ConstantTpe(
+final class ConstantType(
     val constant: Constant
-) extends Tpe {
+) extends SType {
   override def toString: String =
     s"ConstantType($constant)"
   override def equals(obj: Any): Boolean =
     this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
-      case s: ConstantTpe =>
+      case s: ConstantType =>
         this.constant == s.constant
       case _ => false
     })
@@ -108,14 +108,14 @@ final class ConstantTpe(
   }
 }
 
-final class IntersectionTpe(
-    val types: List[Tpe]
-) extends Tpe {
+final class IntersectionType(
+    val types: List[SType]
+) extends SType {
   override def toString: String =
     s"IntersectionType($types)"
   override def equals(obj: Any): Boolean =
     this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
-      case s: IntersectionTpe =>
+      case s: IntersectionType =>
         this.types == s.types
       case _ => false
     })
@@ -126,14 +126,14 @@ final class IntersectionTpe(
   }
 }
 
-final class UnionTpe(
-    val types: List[Tpe]
-) extends Tpe {
+final class UnionType(
+    val types: List[SType]
+) extends SType {
   override def toString: String =
     s"UnionType($types)"
   override def equals(obj: Any): Boolean =
     this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
-      case s: UnionTpe =>
+      case s: UnionType =>
         this.types == s.types
       case _ => false
     })
@@ -144,14 +144,14 @@ final class UnionTpe(
   }
 }
 
-final class WithTpe(
-    val types: List[Tpe]
-) extends Tpe {
+final class WithType(
+    val types: List[SType]
+) extends SType {
   override def toString: String =
     s"WithType($types)"
   override def equals(obj: Any): Boolean =
     this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
-      case s: WithTpe =>
+      case s: WithType =>
         this.types == s.types
       case _ => false
     })
@@ -162,15 +162,15 @@ final class WithTpe(
   }
 }
 
-final class StructuralTpe(
-    val tpe: Tpe,
+final class StructuralType(
+    val tpe: SType,
     val declarations: List[SymbolInfo]
-) extends Tpe {
+) extends SType {
   override def toString: String =
     s"StructuralType($tpe,$declarations)"
   override def equals(obj: Any): Boolean =
     this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
-      case s: StructuralTpe =>
+      case s: StructuralType =>
         this.declarations == s.declarations &&
           this.tpe == s.tpe
       case _ => false
@@ -183,15 +183,15 @@ final class StructuralTpe(
   }
 }
 
-final class AnnotatedTpe(
+final class AnnotatedType(
     val annotations: List[Annotation],
-    val tpe: Tpe
-) extends Tpe {
+    val tpe: SType
+) extends SType {
   override def toString: String =
     s"AnnotatedType($annotations,$tpe)"
   override def equals(obj: Any): Boolean =
     this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
-      case s: AnnotatedTpe =>
+      case s: AnnotatedType =>
         this.annotations == s.annotations &&
           this.tpe == s.tpe
       case _ => false
@@ -204,15 +204,15 @@ final class AnnotatedTpe(
   }
 }
 
-final class ExistentialTpe(
-    val tpe: Tpe,
+final class ExistentialType(
+    val tpe: SType,
     val declarations: List[SymbolInfo]
-) extends Tpe {
+) extends SType {
   override def toString: String =
     s"ExistentialType($tpe,$declarations)"
   override def equals(obj: Any): Boolean =
     this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
-      case s: ExistentialTpe =>
+      case s: ExistentialType =>
         this.declarations == s.declarations &&
           this.tpe == s.tpe
       case _ => false
@@ -225,15 +225,15 @@ final class ExistentialTpe(
   }
 }
 
-final class UniversalTpe(
+final class UniversalType(
     val typeParameters: List[SymbolInfo],
-    val tpe: Tpe
-) extends Tpe {
+    val tpe: SType
+) extends SType {
   override def toString: String =
     s"UniversalType($tpe,$typeParameters)"
   override def equals(obj: Any): Boolean =
     this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
-      case s: UniversalTpe =>
+      case s: UniversalType =>
         this.typeParameters == s.typeParameters &&
           this.tpe == s.tpe
       case _ => false
@@ -246,14 +246,14 @@ final class UniversalTpe(
   }
 }
 
-final class ByNameTpe(
-    val tpe: Tpe
-) extends Tpe {
+final class ByNameType(
+    val tpe: SType
+) extends SType {
   override def toString: String =
     s"ByNameType($tpe)"
   override def equals(obj: Any): Boolean =
     this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
-      case s: ByNameTpe =>
+      case s: ByNameType =>
         this.tpe == s.tpe
       case _ => false
     })
@@ -264,14 +264,14 @@ final class ByNameTpe(
   }
 }
 
-final class RepeatedTpe(
-    val tpe: Tpe
-) extends Tpe {
+final class RepeatedType(
+    val tpe: SType
+) extends SType {
   override def toString: String =
     s"RepeatedType($tpe)"
   override def equals(obj: Any): Boolean =
     this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
-      case s: ByNameTpe =>
+      case s: ByNameType =>
         this.tpe == s.tpe
       case _ => false
     })

--- a/scalafix-core/src/main/scala/scalafix/v1/Signature.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/Signature.scala
@@ -8,8 +8,8 @@ case object NoSignature extends Signature
 
 final class ClassSignature(
     val typeParameters: List[SymbolInfo],
-    val parents: List[Tpe],
-    val self: Tpe,
+    val parents: List[SType],
+    val self: SType,
     val declarations: List[SymbolInfo]
 ) extends Signature {
   override def toString: String =
@@ -35,7 +35,7 @@ final class ClassSignature(
 final class MethodSignature(
     val typeParameters: List[SymbolInfo],
     val parameterLists: List[List[SymbolInfo]],
-    val returnType: Tpe
+    val returnType: SType
 ) extends Signature {
   override def toString: String =
     s"MethodSignature($typeParameters,$parameterLists,$returnType)"
@@ -57,8 +57,8 @@ final class MethodSignature(
 
 final class TypeSignature(
     val typeParameters: List[SymbolInfo],
-    val lowerBound: Tpe,
-    val upperBound: Tpe
+    val lowerBound: SType,
+    val upperBound: SType
 ) extends Signature {
   override def toString: String =
     s"TypeSignature($typeParameters,$lowerBound,$upperBound)"
@@ -80,7 +80,7 @@ final class TypeSignature(
 }
 
 final class ValueSignature(
-    val tpe: Tpe
+    val tpe: SType
 ) extends Signature {
   override def toString: String =
     s"ValueSignature($tpe)"


### PR DESCRIPTION
It can't be called `Type` becuase that would conflict with
`scala.meta.Type`. However, `Tpe` is difficult to pronounce/read.
Instead, `SType` is easier to read and understand and the "S" can be
interpreted as "Scalafix" or "SemanticDB".