### PR TITLE
Expose synthetics in v1 API

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/internal/util/PositionSyntax.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/util/PositionSyntax.scala
@@ -9,6 +9,11 @@ object PositionSyntax {
   implicit class XtensionPositionsScalafix(private val pos: Position)
       extends AnyVal {
 
+    def contains(other: Position): Boolean = {
+      pos.start <= other.start &&
+      pos.end >= other.end
+    }
+
     /** Returns a formatted string of this position including filename/line/caret. */
     def formatMessage(severity: String, message: String): String = pos match {
       case Position.None =>

--- a/scalafix-core/src/main/scala/scalafix/internal/v0/LegacySyntacticRule.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/v0/LegacySyntacticRule.scala
@@ -1,6 +1,5 @@
 package scalafix.internal.v0
 
-import metaconfig.Conf
 import metaconfig.Configured
 import scalafix.patch.Patch
 import scalafix.v0

--- a/scalafix-core/src/main/scala/scalafix/internal/v1/DocFromProtobuf.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/v1/DocFromProtobuf.scala
@@ -1,0 +1,67 @@
+package scalafix.internal.v1
+
+import scala.meta.Tree
+import scala.meta.internal.ScalametaInternals
+import scala.meta.internal.{semanticdb => s}
+import scalafix.v1._
+
+object DocFromProtobuf {
+  def apply(doc: InternalSemanticDoc): DocFromProtobuf =
+    new DocFromProtobuf()(new SemanticDoc(doc))
+}
+final class DocFromProtobuf()(implicit doc: SemanticDoc) {
+  val convert = new SymtabFromProtobuf(doc)
+  def stree(t: s.Tree): STree = {
+    t match {
+      case t: s.ApplyTree =>
+        new ApplyTree(t, t.fn.convert, t.args.convert)
+      case t: s.FunctionTree =>
+        new FunctionTree(t, t.params.convert, t.term.convert)
+      case t: s.IdTree =>
+        sid(t)
+      case t: s.LiteralTree =>
+        val const = convert.sconstant(t.const)
+        new LiteralTree(t, const)
+      case t: s.MacroExpansionTree =>
+        val tpe = convert.stype(t.tpe)
+        new MacroExpansionTree(t, t.expandee.convert, tpe)
+      case t: s.OriginalTree =>
+        soriginal(t.range) match {
+          case Some(tree) => new OriginalTree(t, tree)
+          case None => NoTree
+        }
+      case t: s.SelectTree =>
+        t.id match {
+          case Some(id) =>
+            new SelectTree(t, t.qual.convert, sid(id))
+          case None =>
+            NoTree
+        }
+      case t: s.TypeApplyTree =>
+        val targs = t.targs.iterator.map(tpe => convert.stype(tpe)).toList
+        new TypeApplyTree(t, t.fn.convert, targs)
+      case s.NoTree =>
+        NoTree
+    }
+  }
+
+  private def sid(id: s.IdTree): IdTree =
+    new IdTree(id, Symbol(id.sym))
+
+  private def soriginal(range: Option[s.Range]): Option[Tree] = {
+    val pos = ScalametaInternals.positionFromRange(doc.input, range)
+    PositionSearch.find(doc.tree, pos)
+  }
+
+  private implicit class RichTree(tree: s.Tree) {
+    def convert: STree = stree(tree)
+  }
+  private implicit class RichIds(ids: Seq[s.IdTree]) {
+    def convert: List[IdTree] =
+      ids.iterator.map(sid).toList
+  }
+  private implicit class RichTrees(trees: Seq[s.Tree]) {
+    def convert: List[STree] = trees.iterator.map(stree).toList
+  }
+
+}

--- a/scalafix-core/src/main/scala/scalafix/internal/v1/PositionSearch.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/v1/PositionSearch.scala
@@ -1,0 +1,32 @@
+package scalafix.internal.v1
+
+import scala.meta.Tree
+import scala.meta.Term
+import scala.meta.Position
+import scalafix.internal.util.PositionSyntax._
+
+object PositionSearch {
+  def find(tree: Tree, pos: Position): Option[Tree] = {
+    val extrapos = tree match {
+      case Term.ApplyInfix(lhs, op, Nil, _) =>
+        List(Position.Range(lhs.pos.input, lhs.pos.start, op.pos.end))
+      case _ =>
+        List()
+    }
+    if (tree.pos == pos || extrapos.contains(pos)) Some(tree)
+    else if (tree.pos.contains(pos)) loop(tree.children, pos)
+    else None
+  }
+
+  private def loop(trees: List[Tree], pos: Position): Option[Tree] = {
+    trees match {
+      case Nil =>
+        None
+      case head :: tail =>
+        find(head, pos) match {
+          case None => loop(tail, pos)
+          case x => x
+        }
+    }
+  }
+}

--- a/scalafix-core/src/main/scala/scalafix/internal/v1/package.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/v1/package.scala
@@ -8,6 +8,7 @@ import scala.meta.io.AbsolutePath
 import scala.meta.io.RelativePath
 import scala.collection.JavaConverters._
 import scala.meta.inputs.Input
+import scala.meta.internal.io.FileIO
 import scala.meta.internal.{semanticdb => s}
 
 package object v1 {
@@ -23,11 +24,12 @@ package object v1 {
   }
 
   implicit class XtensionTextDocumentFix(sdoc: s.TextDocument) {
-    def input(sourceroot: URI): Input = {
+    def abspath(sourceroot: URI): AbsolutePath = {
       val absuri = sourceroot.resolve(URI.create(sdoc.uri))
-      val abspath = Paths.get(absuri)
-      val text =
-        new String(Files.readAllBytes(abspath), StandardCharsets.UTF_8)
+      AbsolutePath(Paths.get(absuri))
+    }
+    def input(abspath: AbsolutePath): Input = {
+      val text = FileIO.slurp(abspath, StandardCharsets.UTF_8)
       val textMD5 = FingerprintOps.md5(text)
       require(
         textMD5 == sdoc.md5,

--- a/scalafix-core/src/main/scala/scalafix/v1/STree.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/STree.scala
@@ -1,0 +1,184 @@
+package scalafix.v1
+
+import scala.meta.Tree
+import scala.meta.internal.{semanticdb => s}
+import scala.runtime.Statics
+
+sealed abstract class STree
+
+case object NoTree extends STree
+
+final class IdTree(
+    value: s.IdTree,
+    val symbol: Symbol
+)(implicit symtab: Symtab)
+    extends STree {
+  override def toString: String =
+    s"IdTree($symbol)"
+  override def equals(obj: Any): Boolean =
+    this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
+      case s: IdTree =>
+        this.symbol == s.symbol
+      case _ => false
+    })
+  override def hashCode(): Int = {
+    var acc = -889275714
+    acc = Statics.mix(acc, Statics.anyHash(symbol))
+    Statics.finalizeHash(acc, 1)
+  }
+}
+
+final class SelectTree(
+    value: s.SelectTree,
+    val qual: STree,
+    val id: IdTree
+)(implicit symtab: Symtab)
+    extends STree {
+  override def toString: String =
+    s"SelectTree($qual, $id)"
+  override def equals(obj: Any): Boolean =
+    this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
+      case s: SelectTree =>
+        this.qual == s.qual &&
+          this.id == s.id
+      case _ => false
+    })
+  override def hashCode(): Int = {
+    var acc = -889275714
+    acc = Statics.mix(acc, Statics.anyHash(qual))
+    acc = Statics.mix(acc, Statics.anyHash(id))
+    Statics.finalizeHash(acc, 2)
+  }
+}
+
+final class ApplyTree(
+    value: s.ApplyTree,
+    val fn: STree,
+    val args: List[STree]
+)(implicit symtab: Symtab)
+    extends STree {
+  override def toString: String =
+    s"ApplyTree($fn, $args)"
+  override def equals(obj: Any): Boolean =
+    this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
+      case s: ApplyTree =>
+        this.fn == s.fn &&
+          this.args == s.args
+      case _ => false
+    })
+  override def hashCode(): Int = {
+    var acc = -889275714
+    acc = Statics.mix(acc, Statics.anyHash(fn))
+    acc = Statics.mix(acc, Statics.anyHash(args))
+    Statics.finalizeHash(acc, 2)
+  }
+}
+
+final class TypeApplyTree(
+    value: s.TypeApplyTree,
+    val fn: STree,
+    val targs: List[SType]
+)(implicit symtab: Symtab)
+    extends STree {
+  override def toString: String =
+    s"TypeApplyTree($fn, $targs)"
+  override def equals(obj: Any): Boolean =
+    this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
+      case s: TypeApplyTree =>
+        this.fn == s.fn &&
+          this.targs == s.targs
+      case _ => false
+    })
+  override def hashCode(): Int = {
+    var acc = -889275714
+    acc = Statics.mix(acc, Statics.anyHash(fn))
+    acc = Statics.mix(acc, Statics.anyHash(targs))
+    Statics.finalizeHash(acc, 2)
+  }
+}
+
+final class FunctionTree(
+    value: s.FunctionTree,
+    val params: List[IdTree],
+    val term: STree
+)(implicit symtab: Symtab)
+    extends STree {
+  override def toString: String =
+    s"FunctionTree($params, $term)"
+  override def equals(obj: Any): Boolean =
+    this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
+      case s: FunctionTree =>
+        this.params == s.params &&
+          this.term == s.term
+      case _ => false
+    })
+  override def hashCode(): Int = {
+    var acc = -889275714
+    acc = Statics.mix(acc, Statics.anyHash(params))
+    acc = Statics.mix(acc, Statics.anyHash(term))
+    Statics.finalizeHash(acc, 2)
+  }
+}
+
+final class LiteralTree(
+    value: s.LiteralTree,
+    val const: Constant
+)(implicit symtab: Symtab)
+    extends STree {
+  override def toString: String =
+    s"IdTree($const)"
+  override def equals(obj: Any): Boolean =
+    this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
+      case s: LiteralTree =>
+        this.const == s.const
+      case _ => false
+    })
+  override def hashCode(): Int = {
+    var acc = -889275714
+    acc = Statics.mix(acc, Statics.anyHash(const))
+    Statics.finalizeHash(acc, 1)
+  }
+}
+
+final class MacroExpansionTree(
+    value: s.MacroExpansionTree,
+    val expandee: STree,
+    val tpe: SType
+)(implicit symtab: Symtab)
+    extends STree {
+  override def toString: String =
+    s"MacroExpansionTree($expandee, $tpe)"
+  override def equals(obj: Any): Boolean =
+    this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
+      case s: MacroExpansionTree =>
+        this.expandee == s.expandee &&
+          this.tpe == s.tpe
+      case _ => false
+    })
+  override def hashCode(): Int = {
+    var acc = -889275714
+    acc = Statics.mix(acc, Statics.anyHash(expandee))
+    acc = Statics.mix(acc, Statics.anyHash(tpe))
+    Statics.finalizeHash(acc, 2)
+  }
+}
+
+final class OriginalTree(
+    value: s.OriginalTree,
+    val tree: Tree
+)(implicit symtab: Symtab)
+    extends STree {
+  override def toString: String =
+    s"OriginalTree($tree)"
+  override def equals(obj: Any): Boolean =
+    this.eq(obj.asInstanceOf[AnyRef]) || (obj match {
+      case s: OriginalTree =>
+        this.tree == s.tree
+      case _ => false
+    })
+  override def hashCode(): Int = {
+    var acc = -889275714
+    acc = Statics.mix(acc, Statics.anyHash(tree))
+    Statics.finalizeHash(acc, 1)
+  }
+}

--- a/scalafix-core/src/main/scala/scalafix/v1/SType.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/SType.scala
@@ -4,7 +4,7 @@ import scala.runtime.Statics
 
 sealed abstract class SType
 
-case object NoTpe extends SType
+case object NoType extends SType
 
 final class TypeRef(
     val prefix: SType,

--- a/scalafix-core/src/main/scala/scalafix/v1/SemanticDoc.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/SemanticDoc.scala
@@ -13,15 +13,28 @@ final class SemanticDoc private[scalafix] (
     private[scalafix] val internal: InternalSemanticDoc
 ) extends SemanticContext
     with Symtab {
-  def diagnostics: List[Diagnostic] = internal.messages
-  def tree: Tree = internal.doc.tree
-  def tokens: Tokens = internal.doc.tokens
-  def input: Input = internal.doc.input
-  def matchingParens: MatchingParens = internal.doc.matchingParens
-  def tokenList: TokenList = internal.doc.tokenList
-  def comments: AssociatedComments = internal.doc.comments
-  override def info(symbol: Symbol): Option[SymbolInfo] = internal.info(symbol)
-  override def toString: String = s"SemanticDoc(${input.syntax})"
+
+  def tree: Tree =
+    internal.doc.internal.tree.value
+  def tokens: Tokens =
+    tree.tokens
+  def input: Input =
+    internal.doc.internal.input
+
+  def matchingParens: MatchingParens =
+    internal.doc.internal.matchingParens.value
+  def tokenList: TokenList =
+    internal.doc.internal.tokenList.value
+  def comments: AssociatedComments =
+    internal.doc.internal.comments.value
+
+  def diagnostics: Iterator[Diagnostic] =
+    internal.messages
+
+  override def info(symbol: Symbol): Option[SymbolInfo] =
+    internal.info(symbol)
+  override def toString: String =
+    s"SemanticDoc(${input.syntax})"
 }
 
 object SemanticDoc {

--- a/scalafix-core/src/main/scala/scalafix/v1/SymbolInfo.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/SymbolInfo.scala
@@ -3,7 +3,7 @@ package scalafix.v1
 import scala.meta.internal.metap.PrinterSymtab
 import scala.meta.internal.{semanticdb => s}
 import scala.meta.internal.semanticdb._
-import scalafix.internal.v1.FromProtobuf
+import scalafix.internal.v1.SymtabFromProtobuf
 import scala.meta.metap.Format
 
 final class SymbolInfo private[scalafix] (
@@ -14,7 +14,7 @@ final class SymbolInfo private[scalafix] (
   def owner: Symbol = Symbol(info.symbol).owner
   def displayName: String = info.displayName
   def signature(implicit doc: SemanticDoc): Signature =
-    new FromProtobuf().ssignature(info.signature)
+    new SymtabFromProtobuf(symtab).ssignature(info.signature)
 
   def isScala: Boolean = info.isScala
   def isJava: Boolean = info.isJava

--- a/scalafix-core/src/main/scala/scalafix/v1/package.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/package.scala
@@ -1,9 +1,41 @@
 package scalafix
 
+import scala.meta.Term
 import scala.meta.Tree
+import scala.meta.inputs.Position
 import scalafix.util.Api
+
 package object v1 extends Api {
-  implicit class XtensionTreeSymbol(tree: Tree) {
+  implicit class XtensionTreeScalafixSemantic(tree: Tree) {
     def symbol(implicit doc: SemanticDoc): Symbol = doc.internal.symbol(tree)
+  }
+  implicit class XtensionTermScalafixSemantic(term: Term) {
+    def synthetic(implicit doc: SemanticDoc): Option[STree] =
+      doc.internal.synthetic(term.pos)
+  }
+  implicit class XtensionTermApplyInfixScalafixSemantic(
+      infix: Term.ApplyInfix) {
+    def syntheticOperator(implicit doc: SemanticDoc): Option[STree] = {
+      val operatorPosition =
+        Position.Range(infix.pos.input, infix.pos.start, infix.op.pos.end)
+      doc.internal.synthetic(operatorPosition)
+    }
+  }
+
+  implicit class XtensionSyntheticTree(tree: STree) {
+    def symbol(implicit sdoc: SemanticDoc): Option[Symbol] = tree match {
+      case t: ApplyTree =>
+        t.fn.symbol
+      case t: TypeApplyTree =>
+        t.fn.symbol
+      case t: SelectTree =>
+        Some(t.id.symbol)
+      case t: IdTree =>
+        Some(t.symbol)
+      case t: OriginalTree =>
+        t.tree.symbol.asNonEmpty
+      case _: MacroExpansionTree | _: LiteralTree | _: FunctionTree | NoTree =>
+        None
+    }
   }
 }

--- a/scalafix-reflect/src/main/scala/scalafix/internal/v0/LegacyInMemorySemanticdbIndex.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/v0/LegacyInMemorySemanticdbIndex.scala
@@ -101,11 +101,15 @@ object LegacyInMemorySemanticdbIndex {
           if (PathIO.extension(file.toNIO) == "semanticdb") {
             val textDocument = s.TextDocuments.parseFromFile(file)
             textDocument.documents.foreach { textDocument =>
-              val input = textDocument.input(sourceuri)
-              val doc = v1.Doc.fromInput(input, dialect)
-              val internal = new InternalSemanticDoc(doc, textDocument, symtab)
-              val sdoc = new v1.SemanticDoc(internal)
-              buf += (textDocument.uri -> new DocSemanticdbIndex(sdoc))
+              val abspath = textDocument.abspath(sourceuri)
+              if (abspath.isFile) {
+                val input = textDocument.input(abspath)
+                val doc = v1.Doc.fromInput(input, dialect)
+                val internal =
+                  new InternalSemanticDoc(doc, textDocument, symtab)
+                val sdoc = new v1.SemanticDoc(internal)
+                buf += (textDocument.uri -> new DocSemanticdbIndex(sdoc))
+              }
             }
           }
         }

--- a/scalafix-tests/input/src/main/scala/test/ExplicitSynthetic.scala
+++ b/scalafix-tests/input/src/main/scala/test/ExplicitSynthetic.scala
@@ -1,0 +1,11 @@
+/*
+rules = ExplicitSynthetic
+ */
+package test
+
+object ExplicitSynthetic {
+  val list = List(1)
+  val apply = List.apply(1)
+  def +[T](e: T): String = e.toString
+  ExplicitSynthetic + 42
+}

--- a/scalafix-tests/output/src/main/scala-2.11/test/ExplicitSynthetic.scala
+++ b/scalafix-tests/output/src/main/scala-2.11/test/ExplicitSynthetic.scala
@@ -1,0 +1,8 @@
+package test
+
+object ExplicitSynthetic {
+  val list = List.apply(1)
+  val apply = List.apply(1)
+  def +[T](e: T): String = e.toString
+  ExplicitSynthetic + 42
+}

--- a/scalafix-tests/output/src/main/scala-2.12/test/ExplicitSynthetic.scala
+++ b/scalafix-tests/output/src/main/scala-2.12/test/ExplicitSynthetic.scala
@@ -1,0 +1,8 @@
+package test
+
+object ExplicitSynthetic {
+  val list = List.apply(1)
+  val apply = List.apply(1)
+  def +[T](e: T): String = e.toString
+  ExplicitSynthetic +[Int] 42
+}

--- a/scalafix-tests/unit/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/scalafix-tests/unit/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,5 +1,6 @@
 banana.rule.SemanticRuleV1
 banana.rule.SyntacticRuleV1
+scalafix.test.ExplicitSynthetic
 scalafix.tests.cli.NoOpRule
 scalafix.tests.cli.DeprecatedName
 scalafix.tests.cli.Scala2_9

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/BaseSemanticSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/BaseSemanticSuite.scala
@@ -4,16 +4,23 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FunSuite
 import scala.meta._
 import scala.meta.internal.io.PathIO
+import scalafix.internal.v0.DocSemanticdbIndex
 import scalafix.internal.v0.LegacyInMemorySemanticdbIndex
 import scalafix.syntax._
 import scalafix.testkit.DiffAssertions
+import scalafix.v1.SemanticDoc
 
 abstract class BaseSemanticSuite(filename: String)
     extends FunSuite
     with BeforeAndAfterAll
     with DiffAssertions {
-  private var _db: LegacyInMemorySemanticdbIndex = _
-  private var _input: Input = _
+  var _db: LegacyInMemorySemanticdbIndex = _
+  var _input: Input = _
+  implicit def doc: SemanticDoc =
+    _db.index(_input.syntax) match {
+      case sdoc: DocSemanticdbIndex => sdoc.doc
+      case els => throw new IllegalArgumentException(els.toString)
+    }
   implicit def index: LegacyInMemorySemanticdbIndex = _db
   def input: Input = _input
   def source: Source = {

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/util/InspectSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/util/InspectSuite.scala
@@ -18,14 +18,16 @@ class InspectSuite extends FunSuite with DiffAssertions {
          |    Term.Name("c")
          |  ),
          |  Term.Name("d")
-         |)""".stripMargin
-    assert(obtained == expected)
+         |)
+         |""".stripMargin
+    assertNoDiff(obtained, expected)
   }
 
   test("pretty(t, showFieldNames = true)") {
     val obtained = q"a.b.c.d".inspectLabeled
     val expected =
-      """|Term.Select(
+      """|
+         |Term.Select(
          |  qual = Term.Select(
          |    qual = Term.Select(
          |      qual = Term.Name("a"),
@@ -34,8 +36,9 @@ class InspectSuite extends FunSuite with DiffAssertions {
          |    name = Term.Name("c")
          |  ),
          |  name = Term.Name("d")
-         |)""".stripMargin
-    assert(obtained == expected)
+         |)
+         |""".stripMargin
+    assertNoDiff(obtained, expected)
   }
 
   test("option") {


### PR DESCRIPTION
This commit exposes the new SemanticDB Synthetics in the public Scalafix
API. For reference, there is an example ExplicitSynthetic rule
that inserts explicit `.apply` and inferred type parameters for infix
operators. This kind of refactoring would have been significantly more
difficult with the v0 API.

Other fixes:
- Ignore non-existing files instead of throwing NoSuchFileException:
  This comes up when reading stale semanticdb files of removed files.
- s/NoTpe/NoType/
- render `.inspect` with width 80 instead of 1.
- make `diagnostics` an iterator instead of eager list