### PR TITLE
Unimport unused renames instead of removing them

### DIFF
--- a/scalafix-tests/input/src/main/scala/test/RemoveUnusedImportsRename.scala
+++ b/scalafix-tests/input/src/main/scala/test/RemoveUnusedImportsRename.scala
@@ -1,0 +1,11 @@
+/*
+rule = RemoveUnused
+ */
+package test
+
+import scala.util.{Success => UnusedSuccess, _}
+import scala.concurrent.{Future => UnusedSuccess, _}
+
+class RemoveUnusedImportsRename {
+  Failure(new Exception())
+}

--- a/scalafix-tests/output/src/main/scala/test/RemoveUnusedImportsRename.scala
+++ b/scalafix-tests/output/src/main/scala/test/RemoveUnusedImportsRename.scala
@@ -1,0 +1,8 @@
+package test
+
+import scala.util.{Success => _, _}
+import scala.concurrent.{Future => _}
+
+class RemoveUnusedImportsRename {
+  Failure(new Exception())
+}


### PR DESCRIPTION
Unused renames may still have significant meaning so removing them may
cause compile errors.

Fixes #614