### PR TITLE
Polish handling of trailing commas for removed imports

### DIFF
--- a/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixImpl.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixImpl.scala
@@ -5,7 +5,6 @@ import scalafix.interfaces.Scalafix
 import scalafix.interfaces.ScalafixError
 import scalafix.interfaces.ScalafixMainArgs
 import scalafix.internal.v1.MainOps
-import scalafix.internal.v1.Rules
 
 final class ScalafixImpl extends Scalafix {
 

--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/CompletionsOps.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/CompletionsOps.scala
@@ -4,7 +4,6 @@ import metaconfig.generic.Setting
 import metaconfig.generic.Settings
 import metaconfig.internal.Case
 import org.apache.commons.text.StringEscapeUtils
-import scalafix.internal.reflect.ClasspathOps
 
 object CompletionsOps {
   private def option(kebab: String): String =

--- a/scalafix-tests/input/src/main/scala-2.12/test/RemoveUnusedImportsTrailingCommas.scala
+++ b/scalafix-tests/input/src/main/scala-2.12/test/RemoveUnusedImportsTrailingCommas.scala
@@ -1,0 +1,13 @@
+/*
+rule = RemoveUnused
+ */
+package test
+
+import scala.util.{
+  Failure,
+  Success,
+}
+
+object RemoveUnusedImportsTrailingCommas {
+  Success(1)
+}

--- a/scalafix-tests/input/src/main/scala/test/RemoveUnusedImportsCommas.scala
+++ b/scalafix-tests/input/src/main/scala/test/RemoveUnusedImportsCommas.scala
@@ -1,0 +1,28 @@
+/*
+rule = RemoveUnused
+ */
+package test
+
+import Unused.b, Unused.c, Unused.d
+import scala.util.Success  , scala.util.Failure
+import scala.concurrent.Future,
+       scala.concurrent.Await,
+       scala.concurrent.TimeoutException
+
+import scala.math.{
+  min
+  , E
+  , Pi
+}
+
+object RemoveUnusedImportsCommas {
+  println(b + d + Pi)
+  Failure(???)
+  null.asInstanceOf[TimeoutException]
+}
+
+object Unused {
+  val b = 1
+  val c = 1
+  val d = 1
+}

--- a/scalafix-tests/output/src/main/scala-2.12/test/RemoveUnusedImportsTrailingCommas.scala
+++ b/scalafix-tests/output/src/main/scala-2.12/test/RemoveUnusedImportsTrailingCommas.scala
@@ -1,0 +1,8 @@
+package test
+
+import scala.util.
+  Success
+
+object RemoveUnusedImportsTrailingCommas {
+  Success(1)
+}

--- a/scalafix-tests/output/src/main/scala/test/RemoveUnusedImports2.scala
+++ b/scalafix-tests/output/src/main/scala/test/RemoveUnusedImports2.scala
@@ -1,8 +1,6 @@
 package test
 
-import scala.sys.process.
-  FileProcessLogger
-
+import scala.sys.process.FileProcessLogger
 import scala.math.{
   Ordered,
   Pi

--- a/scalafix-tests/output/src/main/scala/test/RemoveUnusedImportsCommas.scala
+++ b/scalafix-tests/output/src/main/scala/test/RemoveUnusedImportsCommas.scala
@@ -1,0 +1,21 @@
+package test
+
+import Unused.b, Unused.d
+import scala.util.Failure
+import
+       scala.concurrent.TimeoutException
+
+import scala.math.
+   Pi
+
+object RemoveUnusedImportsCommas {
+  println(b + d + Pi)
+  Failure(???)
+  null.asInstanceOf[TimeoutException]
+}
+
+object Unused {
+  val b = 1
+  val c = 1
+  val d = 1
+}

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/BaseCliSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/BaseCliSuite.scala
@@ -151,6 +151,14 @@ trait BaseCliSuite extends FunSuite with DiffAssertions {
     )
   }
 
+  def sourceDirectory: AbsolutePath =
+    props.inputSourceDirectories
+      .find(dir => dir.toNIO.endsWith("scala")) // Skip scala-2.12
+      .getOrElse {
+        throw new IllegalArgumentException(
+          props.inputSourceDirectories.toString())
+      }
+
   case class Result(
       exit: ExitStatus,
       original: String,
@@ -168,6 +176,7 @@ trait BaseCliSuite extends FunSuite with DiffAssertions {
       assertObtained: Result => Unit = { result =>
         if (result.exit.isOk) {
           assertNoDiff(result.obtained, result.expected)
+
         }
       }
   ): Unit = {
@@ -180,7 +189,7 @@ trait BaseCliSuite extends FunSuite with DiffAssertions {
       val root = AbsolutePath(inputSourceDirectory)
       val out = new ByteArrayOutputStream()
       root.toFile.deleteOnExit()
-      copyRecursively(source = props.inputSourceDirectories.head, target = root)
+      copyRecursively(source = sourceDirectory, target = root)
       val rootNIO = root
       writeTestkitConfiguration(rootNIO, rootNIO.resolve(path))
       preprocess(root)


### PR DESCRIPTION
This was awfully painful since the code is tricky to follow. It would
probably be significantly simpler if we simply removed all import tokens
and synthesized tokens for remaining comments. Either way, the primary
improvement from this commit is that we have a slightly simpler rule for
deciding how to remove commas

- always remove leading comma (for importers + importees)
- remove trailing comma for the last unused importer/importee before
  the first used importer/importee.

Fixes #653