### PR TITLE
Rename MetaconfigPendingUpstream to MetaconfigOps (fix #499)

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/internal/config/MetaconfigOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/config/MetaconfigOps.scala
@@ -9,8 +9,7 @@ import metaconfig.ConfError
 import metaconfig.Configured
 import metaconfig.internal.ConfGet
 
-// TODO(olafur) contribute upstream to metaconfig.
-object MetaconfigPendingUpstream {
+object MetaconfigOps {
   def traverse[T](lst: Seq[Configured[T]]): Configured[List[T]] = {
     val buf = List.newBuilder[T]
     var err = List.newBuilder[ConfError]

--- a/scalafix-core/src/main/scala/scalafix/internal/config/ScalafixMetaconfigReaders.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/config/ScalafixMetaconfigReaders.scala
@@ -114,7 +114,7 @@ trait ScalafixMetaconfigReaders {
       singleRuleDecoder: ConfDecoder[Rule]): ConfDecoder[Rule] = {
     ConfDecoder.instance[Rule] {
       case Conf.Lst(values) =>
-        MetaconfigPendingUpstream
+        MetaconfigOps
           .flipSeq(values.map(singleRuleDecoder.read))
           .map(rules => Rule.combine(rules))
       case rule @ Conf.Str(_) => singleRuleDecoder.read(rule)
@@ -146,7 +146,7 @@ trait ScalafixMetaconfigReaders {
       str.parse[T] match {
         case parsers.Parsed.Success(x) => Configured.Ok(x)
         case parsers.Parsed.Error(pos, msg, _) =>
-          import MetaconfigPendingUpstream._
+          import MetaconfigOps._
           ConfError.parseError(pos.toMetaconfig, msg).notOk
       }
     }

--- a/scalafix-core/src/main/scala/scalafix/internal/v1/Rules.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/v1/Rules.scala
@@ -3,7 +3,7 @@ package scalafix.internal.v1
 import java.util.ServiceLoader
 import metaconfig.Configured
 import scala.meta.tokens.Tokens
-import scalafix.internal.config.MetaconfigPendingUpstream
+import scalafix.internal.config.MetaconfigOps
 import scalafix.internal.util.SuppressOps
 import scalafix.lint.RuleDiagnostic
 import scalafix.lint.Diagnostic
@@ -22,7 +22,7 @@ case class Rules(rules: List[Rule] = Nil) {
   def isEmpty: Boolean = rules.isEmpty
   def isSemantic: Boolean = semanticRules.nonEmpty
   def withConfiguration(config: Configuration): Configured[Rules] =
-    MetaconfigPendingUpstream
+    MetaconfigOps
       .traverse(rules.map(_.withConfiguration(config)))
       .map(Rules(_))
   def semanticRules: List[SemanticRule] = rules.collect {

--- a/scalafix-core/src/main/scala/scalafix/v0/Rule.scala
+++ b/scalafix-core/src/main/scala/scalafix/v0/Rule.scala
@@ -1,7 +1,7 @@
 package scalafix.v0
 
 import scala.meta._
-import scalafix.internal.config.MetaconfigPendingUpstream
+import scalafix.internal.config.MetaconfigOps
 import scalafix.internal.config.ScalafixConfig
 import scalafix.syntax._
 import metaconfig.Conf
@@ -124,7 +124,7 @@ object Rule {
   private[scalafix] class CompositeRule(val rules: List[Rule])
       extends Rule(rules.foldLeft(RuleName.empty)(_ + _.name)) {
     override def init(config: Conf): Configured[Rule] = {
-      MetaconfigPendingUpstream
+      MetaconfigOps
         .flipSeq(rules.map(_.init(config)))
         .map(x => new CompositeRule(x.toList))
     }

--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/RuleInstrumentation.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/RuleInstrumentation.scala
@@ -5,7 +5,7 @@ import scalafix.internal.config.ScalafixConfig.DefaultDialect
 import scala.meta._
 import metaconfig.ConfError
 import metaconfig.Configured
-import scalafix.internal.config.MetaconfigPendingUpstream._
+import scalafix.internal.config.MetaconfigOps._
 
 object RuleInstrumentation {
 

--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ScalafixToolbox.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ScalafixToolbox.scala
@@ -5,7 +5,7 @@ import java.net.URLClassLoader
 import java.util.function
 import metaconfig.Configured
 import metaconfig.Input
-import scalafix.internal.config.MetaconfigPendingUpstream._
+import scalafix.internal.config.MetaconfigOps._
 
 object ScalafixToolbox extends ScalafixToolbox
 class ScalafixToolbox {

--- a/scalafix-reflect/src/main/scala/scalafix/v1/RuleDecoder.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/v1/RuleDecoder.scala
@@ -7,7 +7,7 @@ import metaconfig.ConfError
 import metaconfig.Configured
 import scala.meta.internal.io.PathIO
 import scala.meta.io.AbsolutePath
-import scalafix.internal.config.MetaconfigPendingUpstream._
+import scalafix.internal.config.MetaconfigOps._
 import scalafix.internal.config._
 import scalafix.internal.reflect.RuleDecoderOps.FromSourceRule
 import scalafix.internal.reflect.RuleDecoderOps.tryClassload
@@ -113,7 +113,7 @@ object RuleDecoder {
             case err =>
               ConfError.typeMismatch("String", err).notOk :: Nil
           }
-          MetaconfigPendingUpstream.traverse(decoded).map { rules =>
+          MetaconfigOps.traverse(decoded).map { rules =>
             settings.config.patches.all match {
               case Nil => Rules(rules)
               case patches =>


### PR DESCRIPTION
Those methods can't easily be upstreamed since some of them are
scalameta/scalafix specific.