### PR TITLE
Rename Doc and SemanticDoc to SyntacticDocument and SemanticDocument

### DIFF
--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/MainOps.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/MainOps.scala
@@ -32,8 +32,8 @@ import scalafix.Versions
 import scalafix.cli.ExitStatus
 import scalafix.internal.config.PrintStreamReporter
 import scalafix.internal.diff.DiffUtils
-import scalafix.v1.Doc
-import scalafix.v1.SemanticDoc
+import scalafix.v1.SyntacticDocument
+import scalafix.v1.SemanticDocument
 
 object MainOps {
 
@@ -179,11 +179,11 @@ object MainOps {
     val tree = LazyValue.later { () =>
       args.parse(input).get: Tree
     }
-    val doc = Doc(input, tree, args.diffDisable, args.config)
+    val doc = SyntacticDocument(input, tree, args.diffDisable, args.config)
     val (fixed, messages) =
       if (args.rules.isSemantic) {
         val relpath = file.toRelative(args.sourceroot)
-        val sdoc = SemanticDoc.fromPath(
+        val sdoc = SemanticDocument.fromPath(
           doc,
           relpath,
           args.classLoader,
@@ -238,7 +238,7 @@ object MainOps {
       case e: ParseException =>
         args.config.reporter.error(e.shortMessage, e.pos)
         ExitStatus.ParseError
-      case e: SemanticDoc.Error.MissingSemanticdb =>
+      case e: SemanticDocument.Error.MissingSemanticdb =>
         args.config.reporter.error(e.getMessage)
         ExitStatus.MissingSemanticdbError
       case e: StaleSemanticDB =>

--- a/scalafix-core/src/main/scala/scalafix/internal/v0/LegacyCodePrinter.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/v0/LegacyCodePrinter.scala
@@ -9,9 +9,9 @@ import scala.meta.internal.{semanticdb => s}
 import scalafix.v0
 import scalafix.v0.ResolvedName
 import scalafix.v1
-import scalafix.v1.SemanticDoc
+import scalafix.v1.SemanticDocument
 
-class LegacyCodePrinter(doc: SemanticDoc) {
+class LegacyCodePrinter(doc: SemanticDocument) {
   case class PositionedSymbol(symbol: v0.Symbol, start: Int, end: Int)
   private val buf = List.newBuilder[PositionedSymbol]
   private val text = new StringBuilder

--- a/scalafix-core/src/main/scala/scalafix/internal/v0/LegacyRuleCtx.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/v0/LegacyRuleCtx.scala
@@ -10,9 +10,11 @@ import scalafix.util.MatchingParens
 import scalafix.util.SemanticdbIndex
 import scalafix.util.TokenList
 import scalafix.v0.RuleCtx
-import scalafix.v1.Doc
+import scalafix.v1.SyntacticDocument
 
-class LegacyRuleCtx(doc: Doc) extends RuleCtx with DeprecatedPatchOps {
+class LegacyRuleCtx(doc: SyntacticDocument)
+    extends RuleCtx
+    with DeprecatedPatchOps {
   override def tree: Tree = doc.tree
   override def input: Input = doc.input
   override def tokens: Tokens = doc.tokens

--- a/scalafix-core/src/main/scala/scalafix/internal/v0/LegacySemanticRule.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/v0/LegacySemanticRule.scala
@@ -8,7 +8,7 @@ import scalafix.v0
 import scalafix.v0.SemanticdbIndex
 import scalafix.v1.Configuration
 import scalafix.v1.Rule
-import scalafix.v1.SemanticDoc
+import scalafix.v1.SemanticDocument
 import scalafix.v1.SemanticRule
 
 class LegacySemanticRule(name: RuleName, fn: v0.SemanticdbIndex => v0.Rule)
@@ -22,9 +22,9 @@ class LegacySemanticRule(name: RuleName, fn: v0.SemanticdbIndex => v0.Rule)
       this
     }
   }
-  override def fix(implicit sdoc: SemanticDoc): Patch = {
+  override def fix(implicit sdoc: SemanticDocument): Patch = {
     val ctx = new LegacyRuleCtx(sdoc.internal.doc)
-    val rule = fn(new DocSemanticdbIndex(sdoc)).init(this.conf).get
+    val rule = fn(new LegacySemanticdbIndex(sdoc)).init(this.conf).get
     rule.fix(ctx) + LegacyRule.lints(ctx, rule)
   }
 }

--- a/scalafix-core/src/main/scala/scalafix/internal/v0/LegacySyntacticRule.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/v0/LegacySyntacticRule.scala
@@ -4,7 +4,7 @@ import metaconfig.Configured
 import scalafix.patch.Patch
 import scalafix.v0
 import scalafix.v1.Configuration
-import scalafix.v1.Doc
+import scalafix.v1.SyntacticDocument
 import scalafix.v1.Rule
 import scalafix.v1.SyntacticRule
 
@@ -18,7 +18,7 @@ class LegacySyntacticRule(rule: v0.Rule) extends SyntacticRule(rule.name) {
       this
     }
   }
-  override def fix(implicit doc: Doc): Patch = {
+  override def fix(implicit doc: SyntacticDocument): Patch = {
     val ctx = new LegacyRuleCtx(doc)
     configuredRule.fix(ctx) + LegacyRule.lints(ctx, configuredRule)
   }

--- a/scalafix-core/src/main/scala/scalafix/internal/v1/DocFromProtobuf.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/v1/DocFromProtobuf.scala
@@ -7,9 +7,10 @@ import scalafix.v1._
 
 object DocFromProtobuf {
   def convert(synth: s.Synthetic, doc: InternalSemanticDoc): STree =
-    new DocFromProtobuf(synth)(new SemanticDoc(doc)).stree(synth.tree)
+    new DocFromProtobuf(synth)(new SemanticDocument(doc)).stree(synth.tree)
 }
-final class DocFromProtobuf(original: s.Synthetic)(implicit doc: SemanticDoc) {
+final class DocFromProtobuf(original: s.Synthetic)(
+    implicit doc: SemanticDocument) {
   val convert = new SymtabFromProtobuf(doc)
   def stree(t: s.Tree): STree = {
     t match {

--- a/scalafix-core/src/main/scala/scalafix/internal/v1/InternalSemanticDoc.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/v1/InternalSemanticDoc.scala
@@ -9,14 +9,14 @@ import scala.meta.internal.symtab.SymbolTable
 import scala.meta.internal.{semanticdb => s}
 import scalafix.internal.config.ScalafixConfig
 import scalafix.lint.Diagnostic
-import scalafix.v1.Doc
+import scalafix.v1.SyntacticDocument
 import scalafix.v1.STree
 import scalafix.v1.Symbol
 import scalafix.v1.SymbolInfo
 import scalafix.v1.Symtab
 
 final class InternalSemanticDoc(
-    val doc: Doc,
+    val doc: SyntacticDocument,
     val textDocument: s.TextDocument,
     val symtab: SymbolTable
 ) extends Symtab {

--- a/scalafix-core/src/main/scala/scalafix/internal/v1/Rules.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/v1/Rules.scala
@@ -10,9 +10,9 @@ import scalafix.lint.Diagnostic
 import scalafix.patch.Patch
 import scalafix.rule.RuleName
 import scalafix.v1.Configuration
-import scalafix.v1.Doc
+import scalafix.v1.SyntacticDocument
 import scalafix.v1.Rule
-import scalafix.v1.SemanticDoc
+import scalafix.v1.SemanticDocument
 import scalafix.v1.SemanticRule
 import scalafix.v1.SyntacticRule
 
@@ -45,7 +45,7 @@ case class Rules(rules: List[Rule] = Nil) {
   }
 
   def semanticPatch(
-      sdoc: SemanticDoc,
+      sdoc: SemanticDocument,
       suppress: Boolean): (String, List[RuleDiagnostic]) = {
     val fixes = rules.iterator.map {
       case rule: SemanticRule =>
@@ -57,7 +57,7 @@ case class Rules(rules: List[Rule] = Nil) {
   }
 
   def syntacticPatch(
-      doc: Doc,
+      doc: SyntacticDocument,
       suppress: Boolean): (String, List[RuleDiagnostic]) = {
     require(!isSemantic, semanticRules.map(_.name).mkString("+"))
     val fixes = syntacticRules.iterator.map { rule =>

--- a/scalafix-core/src/main/scala/scalafix/patch/Patch.scala
+++ b/scalafix-core/src/main/scala/scalafix/patch/Patch.scala
@@ -21,15 +21,15 @@ import scalafix.internal.config.ScalafixMetaconfigReaders
 import scalafix.internal.util.SuppressOps
 import scalafix.internal.util.SymbolOps.Root
 import scalafix.internal.v0.LegacyRuleCtx
-import scalafix.internal.v0.DocSemanticdbIndex
+import scalafix.internal.v0.LegacySemanticdbIndex
 import scalafix.lint.RuleDiagnostic
 import scalafix.patch.TreePatch.AddGlobalImport
 import scalafix.patch.TreePatch.RemoveGlobalImport
 import scalafix.rule.RuleCtx
 import scalafix.util.SemanticdbIndex
-import scalafix.v1.Doc
+import scalafix.v1.SyntacticDocument
 import scalafix.v1.SemanticContext
-import scalafix.v1.SemanticDoc
+import scalafix.v1.SemanticDocument
 import scalafix.v0.Signature
 import scalafix.v0.Symbol
 import scalafix.v1
@@ -234,7 +234,7 @@ object Patch {
 
   private[scalafix] def syntactic(
       patchesByName: Map[scalafix.rule.RuleName, scalafix.Patch],
-      doc: Doc,
+      doc: SyntacticDocument,
       suppress: Boolean
   ): (String, List[RuleDiagnostic]) = {
     apply(patchesByName, new LegacyRuleCtx(doc), None, suppress)
@@ -242,13 +242,13 @@ object Patch {
 
   private[scalafix] def semantic(
       patchesByName: Map[scalafix.rule.RuleName, scalafix.Patch],
-      doc: SemanticDoc,
+      doc: SemanticDocument,
       suppress: Boolean
   ): (String, List[RuleDiagnostic]) = {
     apply(
       patchesByName,
       new LegacyRuleCtx(doc.internal.doc),
-      Some(new DocSemanticdbIndex(doc)),
+      Some(new LegacySemanticdbIndex(doc)),
       suppress)
   }
 

--- a/scalafix-core/src/main/scala/scalafix/v1/Rule.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/Rule.scala
@@ -10,16 +10,16 @@ abstract class Rule(val name: RuleName) {
 }
 
 abstract class SyntacticRule(name: RuleName) extends Rule(name) {
-  def fix(implicit doc: Doc): Patch = Patch.empty
+  def fix(implicit doc: SyntacticDocument): Patch = Patch.empty
 }
 
 abstract class SemanticRule(name: RuleName) extends Rule(name) {
-  def fix(implicit doc: SemanticDoc): Patch = Patch.empty
+  def fix(implicit doc: SemanticDocument): Patch = Patch.empty
 }
 
 object SemanticRule {
   def constant(name: RuleName, patch: Patch): SemanticRule =
     new SemanticRule(name) {
-      override def fix(implicit doc: SemanticDoc): Patch = patch
+      override def fix(implicit doc: SemanticDocument): Patch = patch
     }
 }

--- a/scalafix-core/src/main/scala/scalafix/v1/STree.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/STree.scala
@@ -15,7 +15,7 @@ case object NoTree extends STree
 
 final class IdTree private[scalafix] (
     val symbol: Symbol
-)(implicit doc: SemanticDoc)
+)(implicit doc: SemanticDocument)
     extends STree {
   override def productArity: Int = 1
   override def productPrefix: String = "IdTree"
@@ -44,7 +44,7 @@ final class IdTree private[scalafix] (
 final class SelectTree private[scalafix] (
     val qualifier: STree,
     val id: IdTree
-)(implicit doc: SemanticDoc)
+)(implicit doc: SemanticDocument)
     extends STree {
   override def productArity: Int = 2
   override def productPrefix: String = "SelectTree"
@@ -77,7 +77,7 @@ final class SelectTree private[scalafix] (
 final class ApplyTree private[scalafix] (
     val function: STree,
     val arguments: List[STree]
-)(implicit doc: SemanticDoc)
+)(implicit doc: SemanticDocument)
     extends STree {
   override def productArity: Int = 2
   override def productPrefix: String = "ApplyTree"
@@ -110,7 +110,7 @@ final class ApplyTree private[scalafix] (
 final class TypeApplyTree private[scalafix] (
     val function: STree,
     val typeArguments: List[SType]
-)(implicit doc: SemanticDoc)
+)(implicit doc: SemanticDocument)
     extends STree {
   override def productArity: Int = 2
   override def productPrefix: String = "TypeApplyTree"
@@ -143,7 +143,7 @@ final class TypeApplyTree private[scalafix] (
 final class FunctionTree private[scalafix] (
     val parameters: List[IdTree],
     val body: STree
-)(implicit doc: SemanticDoc)
+)(implicit doc: SemanticDocument)
     extends STree {
   override def productArity: Int = 2
   override def productPrefix: String = "FunctionTree"
@@ -175,7 +175,7 @@ final class FunctionTree private[scalafix] (
 
 final class LiteralTree private[scalafix] (
     val constant: Constant
-)(implicit doc: SemanticDoc)
+)(implicit doc: SemanticDocument)
     extends STree {
   override def productArity: Int = 1
   override def productPrefix: String = "LiteralTree"
@@ -204,7 +204,7 @@ final class LiteralTree private[scalafix] (
 final class MacroExpansionTree private[scalafix] (
     val beforeExpansion: STree,
     val tpe: SType
-)(implicit doc: SemanticDoc)
+)(implicit doc: SemanticDocument)
     extends STree {
   override def productArity: Int = 2
   override def productPrefix: String = "MacroExpansionTree"
@@ -238,7 +238,7 @@ final class MacroExpansionTree private[scalafix] (
 final class OriginalTree private[scalafix] (
     val matchesFullOriginalRange: Boolean,
     val tree: Tree
-)(implicit doc: SemanticDoc)
+)(implicit doc: SemanticDocument)
     extends STree {
   override def productArity: Int = 1
   override def productPrefix: String = "OriginalTree"

--- a/scalafix-core/src/main/scala/scalafix/v1/SemanticDocument.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/SemanticDocument.scala
@@ -9,7 +9,7 @@ import scalafix.util.TokenList
 import scala.meta.internal.{semanticdb => s}
 import scalafix.internal.v1._
 
-final class SemanticDoc private[scalafix] (
+final class SemanticDocument private[scalafix] (
     private[scalafix] val internal: InternalSemanticDoc
 ) extends SemanticContext
     with Symtab {
@@ -36,10 +36,10 @@ final class SemanticDoc private[scalafix] (
   override def info(symbol: Symbol): Option[SymbolInfo] =
     internal.info(symbol)
   override def toString: String =
-    s"SemanticDoc(${input.syntax})"
+    s"SemanticDocument(${input.syntax})"
 }
 
-object SemanticDoc {
+object SemanticDocument {
   sealed abstract class Error(msg: String) extends Exception(msg)
   object Error {
     final case class MissingSemanticdb(reluri: String)
@@ -49,11 +49,11 @@ object SemanticDoc {
   }
 
   private[scalafix] def fromPath(
-      doc: Doc,
+      doc: SyntacticDocument,
       path: RelativePath,
       classLoader: ClassLoader,
       symtab: SymbolTable
-  ): SemanticDoc = {
+  ): SemanticDocument = {
     val semanticdbReluri = s"META-INF/semanticdb/$path.semanticdb"
     Option(classLoader.getResourceAsStream(semanticdbReluri)) match {
       case Some(inputStream) =>
@@ -65,7 +65,7 @@ object SemanticDoc {
           throw Error.MissingTextDocument(reluri)
         }
         val impl = new InternalSemanticDoc(doc, sdoc, symtab)
-        new SemanticDoc(impl)
+        new SemanticDocument(impl)
       case None =>
         throw Error.MissingSemanticdb(semanticdbReluri)
     }

--- a/scalafix-core/src/main/scala/scalafix/v1/Symbol.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/Symbol.scala
@@ -12,7 +12,7 @@ final class Symbol private (val value: String) {
   def isLocal: Boolean = value.isLocal
   def owner: Symbol = Symbol(value.owner)
   def displayName: String = value.desc.name.value
-  def info(implicit doc: SemanticDoc): Option[SymbolInfo] =
+  def info(implicit doc: SemanticDocument): Option[SymbolInfo] =
     doc.internal.info(this)
   def normalized: Symbol = SymbolOps.normalize(this)
   def asNonEmpty: Option[Symbol] =

--- a/scalafix-core/src/main/scala/scalafix/v1/SymbolMatcher.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/SymbolMatcher.scala
@@ -6,12 +6,12 @@ import scalafix.internal.util.SymbolOps
 trait SymbolMatcher {
 
   def matches(sym: Symbol): Boolean
-  final def matches(tree: Tree)(implicit sdoc: SemanticDoc): Boolean =
+  final def matches(tree: Tree)(implicit sdoc: SemanticDocument): Boolean =
     matches(sdoc.internal.symbol(tree))
 
   final def unapply(sym: Symbol): Boolean =
     matches(sym)
-  final def unapply(tree: Tree)(implicit sdoc: SemanticDoc): Boolean =
+  final def unapply(tree: Tree)(implicit sdoc: SemanticDocument): Boolean =
     unapply(sdoc.internal.symbol(tree))
 
   final def +(other: SymbolMatcher): SymbolMatcher = new SymbolMatcher {

--- a/scalafix-core/src/main/scala/scalafix/v1/SyntacticDocument.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/SyntacticDocument.scala
@@ -13,7 +13,7 @@ import scalafix.internal.v1.LazyValue
 import scalafix.util.MatchingParens
 import scalafix.util.TokenList
 
-final class Doc private[scalafix] (
+final class SyntacticDocument private[scalafix] (
     private[scalafix] val internal: InternalDoc
 ) {
   def input: Input = internal.input
@@ -22,19 +22,19 @@ final class Doc private[scalafix] (
   def comments: AssociatedComments = internal.comments.value
   def matchingParens: MatchingParens = internal.matchingParens.value
   def tokenList: TokenList = internal.tokenList.value
-  override def toString: String = s"Doc(${input.syntax})"
+  override def toString: String = s"SyntacticDocument(${input.syntax})"
 }
 
-object Doc {
-  def fromInput(input: Input): Doc = {
+object SyntacticDocument {
+  def fromInput(input: Input): SyntacticDocument = {
     fromInput(input, scala.meta.dialects.Scala212)
   }
-  def fromInput(input: Input, dialect: Dialect): Doc = {
+  def fromInput(input: Input, dialect: Dialect): SyntacticDocument = {
     import scala.meta._
     val tree = LazyValue.later { () =>
       parsers.Parse.parseSource.apply(input, dialect).get: Tree
     }
-    Doc(
+    SyntacticDocument(
       input,
       tree,
       DiffDisable.empty,
@@ -42,8 +42,8 @@ object Doc {
     )
   }
 
-  def fromTree(tree: Tree): Doc = {
-    Doc(
+  def fromTree(tree: Tree): SyntacticDocument = {
+    SyntacticDocument(
       tree.pos.input,
       LazyValue.now(tree),
       DiffDisable.empty,
@@ -55,7 +55,7 @@ object Doc {
       input: Input,
       tree: LazyValue[Tree],
       diffDisable: DiffDisable,
-      config: ScalafixConfig): Doc = {
+      config: ScalafixConfig): SyntacticDocument = {
     val tokens = LazyValue.later { () =>
       tree.value.tokens
     }
@@ -81,6 +81,6 @@ object Doc {
       matchingParens = matchingParens,
       tokenList = tokenList
     )
-    new Doc(internal)
+    new SyntacticDocument(internal)
   }
 }

--- a/scalafix-core/src/main/scala/scalafix/v1/package.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/package.scala
@@ -7,15 +7,16 @@ import scalafix.util.Api
 
 package object v1 extends Api {
   implicit class XtensionTreeScalafixSemantic(tree: Tree) {
-    def symbol(implicit doc: SemanticDoc): Symbol = doc.internal.symbol(tree)
+    def symbol(implicit doc: SemanticDocument): Symbol =
+      doc.internal.symbol(tree)
   }
   implicit class XtensionTermScalafixSemantic(term: Term) {
-    def synthetic(implicit doc: SemanticDoc): Option[STree] =
+    def synthetic(implicit doc: SemanticDocument): Option[STree] =
       doc.internal.synthetic(term.pos)
   }
   implicit class XtensionTermApplyInfixScalafixSemantic(
       infix: Term.ApplyInfix) {
-    def syntheticOperator(implicit doc: SemanticDoc): Option[STree] = {
+    def syntheticOperator(implicit doc: SemanticDocument): Option[STree] = {
       val operatorPosition =
         Position.Range(infix.pos.input, infix.pos.start, infix.op.pos.end)
       doc.internal.synthetic(operatorPosition)
@@ -23,7 +24,7 @@ package object v1 extends Api {
   }
 
   implicit class XtensionSyntheticTree(tree: STree) {
-    def symbol(implicit sdoc: SemanticDoc): Option[Symbol] = tree match {
+    def symbol(implicit sdoc: SemanticDocument): Option[Symbol] = tree match {
       case t: ApplyTree =>
         t.function.symbol
       case t: TypeApplyTree =>

--- a/scalafix-reflect/src/main/scala/scalafix/internal/v0/LegacyInMemorySemanticdbIndex.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/v0/LegacyInMemorySemanticdbIndex.scala
@@ -27,7 +27,7 @@ case class LegacyInMemorySemanticdbIndex(
 
   override def inputs: Seq[m.Input] = {
     index.values.collect {
-      case s: DocSemanticdbIndex =>
+      case s: LegacySemanticdbIndex =>
         s.doc.input
     }.toSeq
   }
@@ -56,7 +56,7 @@ case class LegacyInMemorySemanticdbIndex(
           )
         }
       case _ =>
-        // global symbol, use any SemanticDoc
+        // global symbol, use any SemanticDocument
         index.head._2.denotation(symbol)
     }
   override def denotation(tree: Tree): Option[Denotation] =
@@ -104,11 +104,11 @@ object LegacyInMemorySemanticdbIndex {
               val abspath = textDocument.abspath(sourceuri)
               if (abspath.isFile) {
                 val input = textDocument.input(abspath)
-                val doc = v1.Doc.fromInput(input, dialect)
+                val doc = v1.SyntacticDocument.fromInput(input, dialect)
                 val internal =
                   new InternalSemanticDoc(doc, textDocument, symtab)
-                val sdoc = new v1.SemanticDoc(internal)
-                buf += (textDocument.uri -> new DocSemanticdbIndex(sdoc))
+                val sdoc = new v1.SemanticDocument(internal)
+                buf += (textDocument.uri -> new LegacySemanticdbIndex(sdoc))
               }
             }
           }

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/ExplicitResultTypes.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/ExplicitResultTypes.scala
@@ -57,7 +57,7 @@ case class ExplicitResultTypes(config: ExplicitResultTypesConfig)
   }
   import scala.meta.internal.{semanticdb => s}
   def unsafeToType(
-      ctx: SemanticDoc,
+      ctx: SemanticDocument,
       pos: Position,
       symbol: Symbol
   ): PrettyResult[Type] = {
@@ -84,7 +84,7 @@ case class ExplicitResultTypes(config: ExplicitResultTypesConfig)
   def toType(
       pos: Position,
       symbol: Symbol
-  )(implicit ctx: SemanticDoc): Option[PrettyResult[Type]] = {
+  )(implicit ctx: SemanticDocument): Option[PrettyResult[Type]] = {
     try {
       Some(unsafeToType(ctx, pos, symbol))
     } catch {
@@ -99,7 +99,7 @@ case class ExplicitResultTypes(config: ExplicitResultTypesConfig)
     }
   }
 
-  override def fix(implicit ctx: SemanticDoc): Patch = {
+  override def fix(implicit ctx: SemanticDocument): Patch = {
     def defnType(defn: Defn): Option[(Type, Patch)] =
       for {
         name <- defnName(defn)

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/LeakingImplicitClassVal.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/LeakingImplicitClassVal.scala
@@ -8,7 +8,7 @@ class LeakingImplicitClassVal extends SyntacticRule("LeakingImplicitClassVal") {
   override def description: String =
     "Add private access modifier to val parameters of implicit value classes in order to prevent public access"
 
-  override def fix(implicit doc: Doc): Patch = {
+  override def fix(implicit doc: SyntacticDocument): Patch = {
     doc.tree.collect {
       case Defn.Class(
           cMods,

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/NoAutoTupling.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/NoAutoTupling.scala
@@ -15,7 +15,7 @@ class NoAutoTupling extends SemanticRule("NoAutoTupling") {
   private[this] def insertUnit(t: Term.Apply): Patch =
     Patch.addRight(t.tokens.init.last, "()")
 
-  override def fix(implicit doc: SemanticDoc): Patch = {
+  override def fix(implicit doc: SemanticDocument): Patch = {
     val unitAdaptations: Set[Position] =
       doc.diagnostics.toIterator.collect {
         case message

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/NoValInForComprehension.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/NoValInForComprehension.scala
@@ -9,7 +9,7 @@ class NoValInForComprehension extends SyntacticRule("NoValInForComprehension") {
   override def description: String =
     "Rewrite that removes redundant val inside for-comprehensions"
 
-  override def fix(implicit doc: Doc): Patch = {
+  override def fix(implicit doc: SyntacticDocument): Patch = {
     doc.tree.collect {
       case v: Enumerator.Val =>
         val valTokens =

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/ProcedureSyntax.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/ProcedureSyntax.scala
@@ -9,7 +9,7 @@ class ProcedureSyntax extends SyntacticRule("ProcedureSyntax") {
   override def description: String =
     "Rewrite that inserts explicit : Unit = for soon-to-be-deprecated procedure syntax def foo { ... }"
 
-  override def fix(implicit doc: Doc): Patch = {
+  override def fix(implicit doc: SyntacticDocument): Patch = {
     doc.tree.collect {
       case t: Decl.Def if t.decltpe.tokens.isEmpty =>
         Patch.addRight(t.tokens.last, s": Unit").atomic

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
@@ -36,7 +36,7 @@ class RemoveUnused(config: RemoveUnusedConfig)
         .map(new RemoveUnused(_))
     }
 
-  override def fix(implicit doc: SemanticDoc): Patch = {
+  override def fix(implicit doc: SemanticDocument): Patch = {
     val isUnusedTerm = mutable.Set.empty[Position]
     val isUnusedImport = mutable.Set.empty[Position]
 

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/RuleTest.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/RuleTest.scala
@@ -15,7 +15,7 @@ import scalafix.v1.RuleDecoder
 
 final class RuleTest(
     val path: TestkitPath,
-    val run: () => (Rules, v1.SemanticDoc)
+    val run: () => (Rules, v1.SemanticDocument)
 )
 
 object RuleTest {
@@ -24,21 +24,25 @@ object RuleTest {
       test: TestkitPath,
       classLoader: ClassLoader,
       symtab: SymbolTable): RuleTest = {
-    val run: () => (Rules, v1.SemanticDoc) = { () =>
+    val run: () => (Rules, v1.SemanticDocument) = { () =>
       val input = test.toInput
       val tree = input.parse[Source].get
       val comment = SemanticRuleSuite.findTestkitComment(tree.tokens)
       val syntax = comment.syntax.stripPrefix("/*").stripSuffix("*/")
       val conf = Conf.parseString(test.testName, syntax).get
       val scalafixConfig = conf.as[ScalafixConfig].get
-      val doc = v1.Doc(
+      val doc = v1.SyntacticDocument(
         tree.pos.input,
         LazyValue.now(tree),
         DiffDisable.empty,
         scalafixConfig
       )
       val sdoc =
-        v1.SemanticDoc.fromPath(doc, test.semanticdbPath, classLoader, symtab)
+        v1.SemanticDocument.fromPath(
+          doc,
+          test.semanticdbPath,
+          classLoader,
+          symtab)
       val decoderSettings =
         RuleDecoder.Settings().withConfig(scalafixConfig)
       val decoder = RuleDecoder.decoder(decoderSettings)

--- a/scalafix-tests/unit/src/main/scala/scalafix/test/ExplicitSynthetic.scala
+++ b/scalafix-tests/unit/src/main/scala/scalafix/test/ExplicitSynthetic.scala
@@ -18,7 +18,7 @@ class ExplicitSynthetic(insertInfixTypeParam: Boolean)
         insertInfixTypeParam = !config.scalaVersion.startsWith("2.11"))
     )
 
-  override def fix(implicit doc: SemanticDoc): Patch = {
+  override def fix(implicit doc: SemanticDocument): Patch = {
     val patches = doc.tree.collect {
       case Term.Select(_, Term.Name("apply")) =>
         // happens for explicit "List.apply" because Synthetic.symbol returns Some(symbol)

--- a/scalafix-tests/unit/src/main/scala/scalafix/test/FqnRule.scala
+++ b/scalafix-tests/unit/src/main/scala/scalafix/test/FqnRule.scala
@@ -39,13 +39,13 @@ case object PatchTokenWithEmptyRange
 }
 
 class SemanticRuleV1 extends v1.SemanticRule("SemanticRuleV1") {
-  override def fix(implicit doc: v1.SemanticDoc): Patch = {
+  override def fix(implicit doc: v1.SemanticDocument): Patch = {
     Patch.addRight(doc.tree, "\nobject SemanticRuleV1")
   }
 }
 
 class SyntacticRuleV1 extends v1.SyntacticRule("SyntacticRuleV1") {
-  override def fix(implicit doc: v1.Doc): Patch = {
+  override def fix(implicit doc: v1.SyntacticDocument): Patch = {
     Patch.addRight(doc.tree, "\nobject SyntacticRuleV1")
   }
 }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSuppressSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSuppressSuite.scala
@@ -3,11 +3,11 @@ package scalafix.tests.cli
 import scala.meta.{Defn, Lit}
 import scalafix.patch.Patch
 import scalafix.v0.LintCategory
-import scalafix.v1.Doc
+import scalafix.v1.SyntacticDocument
 import scalafix.v1.SyntacticRule
 
 class NoVars extends SyntacticRule("NoVars") {
-  override def fix(implicit doc: Doc): Patch = {
+  override def fix(implicit doc: SyntacticDocument): Patch = {
     val error = LintCategory.error("No vars!")
     doc.tree.collect {
       case v @ Defn.Var(_, _, _, _) => Patch.lint(error.at("no vars", v.pos))
@@ -16,7 +16,7 @@ class NoVars extends SyntacticRule("NoVars") {
 }
 
 class NoInts extends SyntacticRule("NoInts") {
-  override def fix(implicit doc: Doc): Patch = {
+  override def fix(implicit doc: SyntacticDocument): Patch = {
     val error = LintCategory.error("No ints!")
     doc.tree.collect {
       case i @ Lit.Int(_) => Patch.lint(error.at("no ints", i.pos))

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSyntacticSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSyntacticSuite.scala
@@ -6,7 +6,7 @@ import scalafix.patch.Patch
 import scalafix.rule.RuleName
 import scalafix.v1
 import scalafix.v1.Configuration
-import scalafix.v1.Doc
+import scalafix.v1.SyntacticDocument
 import scalafix.v1.Rule
 import scalafix.v1.SyntacticRule
 
@@ -392,7 +392,7 @@ class CliSyntacticSuite extends BaseCliSuite {
 }
 
 class NoOpRule extends SyntacticRule("NoOpRule") {
-  override def fix(implicit doc: Doc): _root_.scalafix.v1.Patch =
+  override def fix(implicit doc: SyntacticDocument): _root_.scalafix.v1.Patch =
     Patch.empty
 }
 
@@ -402,7 +402,7 @@ class DeprecatedName
         "OldDeprecatedName",
         "Use DeprecatedName instead",
         "1.0")) {
-  override def fix(implicit doc: Doc): _root_.scalafix.v1.Patch =
+  override def fix(implicit doc: SyntacticDocument): _root_.scalafix.v1.Patch =
     Patch.empty
 }
 

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/Disable.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/Disable.scala
@@ -14,7 +14,7 @@ class Disable(symbols: List[Symbol]) extends SemanticRule("Disable") {
       new Disable(
         config.conf.dynamic.Disable.symbols.as[List[Symbol]].getOrElse(Nil))
     )
-  override def fix(implicit doc: SemanticDoc): Patch = {
+  override def fix(implicit doc: SemanticDocument): Patch = {
     doc.internal.textDocument.occurrences.collect {
       case o if symbols.contains(SymbolOps.normalize(Symbol(o.symbol))) =>
         val r = o.range.get

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/TestRules.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/TestRules.scala
@@ -4,14 +4,14 @@ import scalafix.v0.LintCategory
 import scalafix.v1._
 
 class LintError extends SyntacticRule("LintError") {
-  override def fix(implicit doc: Doc): Patch = {
+  override def fix(implicit doc: SyntacticDocument): Patch = {
     val failure = LintCategory.error("failure", "Error!")
     Patch.lint(failure.at(doc.tree.pos))
   }
 }
 
 class LintWarning extends SyntacticRule("LintWarning") {
-  override def fix(implicit doc: Doc): Patch = {
+  override def fix(implicit doc: SyntacticDocument): Patch = {
     val failure = LintCategory.warning("warning", "Warning!")
     Patch.lint(failure.at(doc.tree.pos))
   }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/BaseSemanticSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/BaseSemanticSuite.scala
@@ -9,20 +9,24 @@ import scalafix.internal.v0.LegacyInMemorySemanticdbIndex
 import scalafix.syntax._
 import scalafix.testkit.DiffAssertions
 import scalafix.tests.BuildInfo
-import scalafix.v1.Doc
-import scalafix.v1.SemanticDoc
+import scalafix.v1.SyntacticDocument
+import scalafix.v1.SemanticDocument
 
 object BaseSemanticSuite {
-  def loadDoc(filename: String): SemanticDoc = {
+  def loadDoc(filename: String): SemanticDocument = {
     val root = AbsolutePath(BuildInfo.sharedSourceroot).resolve("scala/test")
     val abspath = root.resolve(filename)
     val relpath = abspath.toRelative(AbsolutePath(BuildInfo.baseDirectory))
     val input = Input.File(abspath)
-    val doc = Doc.fromInput(input)
+    val doc = SyntacticDocument.fromInput(input)
     val classpath =
       Classpaths.withDirectory(AbsolutePath(BuildInfo.sharedClasspath))
     val symtab = ClasspathOps.newSymbolTable(classpath).get
-    SemanticDoc.fromPath(doc, relpath, ClasspathOps.thisClassLoader, symtab)
+    SemanticDocument.fromPath(
+      doc,
+      relpath,
+      ClasspathOps.thisClassLoader,
+      symtab)
   }
 }
 

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/util/ExpectSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/util/ExpectSuite.scala
@@ -6,7 +6,7 @@ import scala.meta.io.AbsolutePath
 import scalafix.testkit.DiffAssertions
 import scalafix.tests.BuildInfo
 import scalafix.tests.core.BaseSemanticSuite
-import scalafix.v1.SemanticDoc
+import scalafix.v1.SemanticDocument
 
 trait ExpectSuite extends FunSuite with DiffAssertions {
   def filename: String
@@ -16,7 +16,7 @@ trait ExpectSuite extends FunSuite with DiffAssertions {
     AbsolutePath(BuildInfo.unitResourceDirectory)
       .resolve("expect")
       .resolve(filename.stripSuffix("Test.scala") + ".expect")
-  final implicit lazy val sdoc: SemanticDoc =
+  final implicit lazy val sdoc: SemanticDocument =
     BaseSemanticSuite.loadDoc(filename)
   final def expected(): String =
     FileIO.slurp(path, StandardCharsets.UTF_8)


### PR DESCRIPTION
I started using `Doc` to avoid ambiguous references to
`scala.meta.Document`. That is no longer a problem so let's use the more
self-descriptive names. This has a nice synchrony with SyntacticRule and
SemanticRule.

Fixes #379