### PR TITLE
Add --blame to show offending commit of Diagnostic (fix #485)

### DIFF
--- a/scalafix-cli/src/main/scala/scalafix/internal/jgit/JGitBlame.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/jgit/JGitBlame.scala
@@ -1,47 +1,27 @@
 package scalafix.internal.jgit
 
-import scalafix.lint.{RuleDiagnostic, Diagnostic}
-
-import scala.meta.Input
+import scalafix.lint.RuleDiagnostic
 
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import org.eclipse.jgit.blame.{BlameGenerator, BlameResult}
 import org.eclipse.jgit.lib.Constants
 
-import java.util.Date
 import java.text.SimpleDateFormat
-import java.nio.file.{Path, Paths}
+import java.nio.file.Path
+import scala.meta.io.RelativePath
 
 import org.eclipse.jgit.revwalk.RevCommit
 
-class JGitBlame(workingDir: Path, diffBase: Option[String]) {
+class JGitBlame(
+    workingDirectory: Path,
+    filePath: RelativePath,
+    diffBase: Option[String]) {
+
+  private val workTree = workingDirectory.toFile
   private val builder = new FileRepositoryBuilder()
   private val repository =
-    builder.readEnvironment().setWorkTree(workingDir.toFile).build()
+    builder.readEnvironment().setWorkTree(workTree).build()
   private val dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm")
-
-  def apply(diagnostics: List[RuleDiagnostic]): List[RuleDiagnostic] = {
-
-    val diagnosticsByFilePath: List[(Path, List[RuleDiagnostic])] =
-      diagnostics.groupBy { diagnostic =>
-        val path =
-          diagnostic.position.input match {
-            case Input.VirtualFile(path, _) =>
-              Paths.get(path)
-            case Input.File(path, _) =>
-              path.toNIO
-            case input =>
-              throw new Exception("cannot extract path from input: " + input)
-          }
-
-        workingDir.relativize(path)
-      }.toList
-
-    diagnosticsByFilePath.flatMap {
-      case (filePath, diagnosticsForFilePath) =>
-        blame(filePath, diagnosticsForFilePath)
-    }
-  }
 
   def formatCommit(commit: RevCommit): String = {
     val commitMsg = commit.getShortMessage()
@@ -49,12 +29,10 @@ class JGitBlame(workingDir: Path, diffBase: Option[String]) {
     val author = commit.getAuthorIdent()
     val authorName = author.getName
     val date = dateFormat.format(author.getWhen)
-    s"$date $authorName $shortSha - $commitMsg"
+    s"\nIntroduced by $authorName on $date in commit $shortSha - $commitMsg"
   }
 
-  private def blame(
-      filePath: Path,
-      diagnostics: List[RuleDiagnostic]): List[RuleDiagnostic] = {
+  def apply(diagnostics: List[RuleDiagnostic]): List[RuleDiagnostic] = {
     val blameGenerator = new BlameGenerator(repository, filePath.toString)
     val startRev = diffBase.getOrElse(Constants.HEAD)
     blameGenerator.push("", repository.resolve(startRev))
@@ -68,20 +46,7 @@ class JGitBlame(workingDir: Path, diffBase: Option[String]) {
       diagnostics.map { diagnostic =>
         val line = diagnostic.position.startLine
         val commit = blameResult.getSourceCommit(line)
-        val blameLine = formatCommit(commit)
-
-        val diag = diagnostic.diagnostic
-        RuleDiagnostic(
-          Diagnostic(
-            diag.categoryID,
-            "\n" + blameLine + "\n" + diag.message,
-            diag.position,
-            diag.explanation,
-            diag.severity
-          ),
-          diagnostic.rule,
-          diagnostic.overriddenSeverity
-        )
+        diagnostic.withBlame(formatCommit(commit))
       }
 
     lintsWithBlame

--- a/scalafix-cli/src/main/scala/scalafix/internal/jgit/JGitBlame.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/jgit/JGitBlame.scala
@@ -1,0 +1,89 @@
+package scalafix.internal.jgit
+
+import scalafix.lint.{RuleDiagnostic, Diagnostic}
+
+import scala.meta.Input
+
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder
+import org.eclipse.jgit.blame.{BlameGenerator, BlameResult}
+import org.eclipse.jgit.lib.Constants
+
+import java.util.Date
+import java.text.SimpleDateFormat
+import java.nio.file.{Path, Paths}
+
+import org.eclipse.jgit.revwalk.RevCommit
+
+class JGitBlame(workingDir: Path, diffBase: Option[String]) {
+  private val builder = new FileRepositoryBuilder()
+  private val repository =
+    builder.readEnvironment().setWorkTree(workingDir.toFile).build()
+  private val dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm")
+
+  def apply(diagnostics: List[RuleDiagnostic]): List[RuleDiagnostic] = {
+
+    val diagnosticsByFilePath: List[(Path, List[RuleDiagnostic])] =
+      diagnostics.groupBy { diagnostic =>
+        val path =
+          diagnostic.position.input match {
+            case Input.VirtualFile(path, _) =>
+              Paths.get(path)
+            case Input.File(path, _) =>
+              path.toNIO
+            case input =>
+              throw new Exception("cannot extract path from input: " + input)
+          }
+
+        workingDir.relativize(path)
+      }.toList
+
+    diagnosticsByFilePath.flatMap {
+      case (filePath, diagnosticsForFilePath) =>
+        blame(filePath, diagnosticsForFilePath)
+    }
+  }
+
+  def formatCommit(commit: RevCommit): String = {
+    val commitMsg = commit.getShortMessage()
+    val shortSha = commit.abbreviate(8).name()
+    val author = commit.getAuthorIdent()
+    val authorName = author.getName
+    val date = dateFormat.format(author.getWhen)
+    s"$date $authorName $shortSha - $commitMsg"
+  }
+
+  private def blame(
+      filePath: Path,
+      diagnostics: List[RuleDiagnostic]): List[RuleDiagnostic] = {
+    val blameGenerator = new BlameGenerator(repository, filePath.toString)
+    val startRev = diffBase.getOrElse(Constants.HEAD)
+    blameGenerator.push("", repository.resolve(startRev))
+    val blameResult = BlameResult.create(blameGenerator)
+    diagnostics.foreach(
+      diagnostic =>
+        blameResult.computeRange(
+          diagnostic.position.startLine,
+          diagnostic.position.startLine + 1))
+    val lintsWithBlame =
+      diagnostics.map { diagnostic =>
+        val line = diagnostic.position.startLine
+        val commit = blameResult.getSourceCommit(line)
+        val blameLine = formatCommit(commit)
+
+        val diag = diagnostic.diagnostic
+        RuleDiagnostic(
+          Diagnostic(
+            diag.categoryID,
+            "\n" + blameLine + "\n" + diag.message,
+            diag.position,
+            diag.explanation,
+            diag.severity
+          ),
+          diagnostic.rule,
+          diagnostic.overriddenSeverity
+        )
+      }
+
+    lintsWithBlame
+  }
+}

--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
@@ -63,6 +63,9 @@ case class Args(
     @Description(
       "If set, only apply scalafix to added and edited files in git diff against a provided branch, commit or tag.")
     diffBase: Option[String] = None,
+    @Description(
+      "Add git blame information in lint message, uses diffBase if set")
+    blame: Boolean = false,
     @Description("Print out additional diagnostics while running scalafix.")
     verbose: Boolean = false,
     @Description("Print out this help message and exit")

--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/MainOps.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/MainOps.scala
@@ -34,6 +34,7 @@ import scalafix.internal.config.PrintStreamReporter
 import scalafix.internal.diff.DiffUtils
 import scalafix.v1.SyntacticDocument
 import scalafix.v1.SemanticDocument
+import scalafix.internal.jgit.JGitBlame
 
 object MainOps {
 
@@ -198,7 +199,13 @@ object MainOps {
       }
 
     if (!args.args.autoSuppressLinterErrors) {
-      messages.foreach { diag =>
+      val messagesWithBlame =
+        if (args.args.blame) {
+          val blame = new JGitBlame(args.args.cwd.toNIO, args.args.diffBase)
+          blame(messages)
+        } else messages
+
+      messagesWithBlame.foreach { diag =>
         args.config.reporter.lint(diag)
       }
     }

--- a/scalafix-core/src/main/scala/scalafix/lint/RuleDiagnostic.scala
+++ b/scalafix-core/src/main/scala/scalafix/lint/RuleDiagnostic.scala
@@ -13,24 +13,31 @@ import scalafix.rule.RuleName
 final class RuleDiagnostic private (
     val diagnostic: Diagnostic,
     val rule: RuleName,
-    val overriddenSeverity: Option[LintSeverity]
+    val overriddenSeverity: Option[LintSeverity],
+    val blameMessage: Option[String]
 ) {
   override def toString: String = formattedMessage
-  def message: String = diagnostic.message
+  def message: String =
+    diagnostic.message + blameMessage.map("\n" + _).getOrElse("")
   def position: Position = diagnostic.position
   def severity: LintSeverity = overriddenSeverity.getOrElse(diagnostic.severity)
   def explanation: String = diagnostic.explanation
   def id: LintID = LintID(rule.value, diagnostic.categoryID)
 
+  def withBlame(msg: String): RuleDiagnostic =
+    new RuleDiagnostic(diagnostic, rule, overriddenSeverity, Some(msg))
+
   /** A pretty-printed representation of this diagnostic without detailed explanation. */
   def formattedMessage: String = {
-    val msg = new StringBuilder()
+    val msg0 = new StringBuilder()
       .append("[")
       .append(id.fullID)
       .append("]:")
       .append(if (message.isEmpty || message.startsWith("\n")) "" else " ")
       .append(message)
-      .toString()
+
+    val msg = blameMessage.map(msg0.append).getOrElse(msg0).toString()
+
     position.formatMessage(severity.toString, msg)
   }
 }
@@ -40,6 +47,6 @@ object RuleDiagnostic {
       diagnostic: Diagnostic,
       rule: RuleName,
       configuredSeverity: Option[LintSeverity]): RuleDiagnostic = {
-    new RuleDiagnostic(diagnostic, rule, configuredSeverity)
+    new RuleDiagnostic(diagnostic, rule, configuredSeverity, None)
   }
 }

--- a/scalafix-tests/unit/src/main/scala/scalafix/internal/tests/utils/Fs.scala
+++ b/scalafix-tests/unit/src/main/scala/scalafix/internal/tests/utils/Fs.scala
@@ -42,6 +42,6 @@ class Fs() {
     Files.write(path(filename), content.getBytes, op)
   }
 
-  private def path(filename: String): Path =
+  def path(filename: String): Path =
     workingDirectory.resolve(filename)
 }

--- a/scalafix-tests/unit/src/main/scala/scalafix/internal/tests/utils/Git.scala
+++ b/scalafix-tests/unit/src/main/scala/scalafix/internal/tests/utils/Git.scala
@@ -2,6 +2,8 @@ package scalafix.internal.tests.utils
 
 import java.nio.file.Path
 
+import org.eclipse.jgit.revwalk.RevCommit
+
 class Git(workingDirectory: Path) {
   import org.eclipse.jgit.api.{Git => JGit}
 
@@ -23,8 +25,9 @@ class Git(workingDirectory: Path) {
   def deleteBranch(branch: String): Unit =
     git.branchDelete().setBranchNames(branch).call()
 
-  def commit(): Unit = {
-    git.commit().setMessage(s"r$revision").call()
+  def commit(): RevCommit = {
+    val rev = git.commit().setMessage(s"r$revision").call()
     revision += 1
+    rev
   }
 }


### PR DESCRIPTION
Example output:

commit message: r0

```scala
object Code {
  val a = 42
}
```

commit message: r1

```scala
object Code {
  var a = 42
}
```

```
/tmp/scalafix1367068904944601960/code.scala:2:3: error: [DisableSyntax.keywords.var] 
2018-08-31 12:01 Guillaume Massé e27e0825 - r1
var is disabled
  var a = 42
  ^^^
```