### PR TITLE
Respect -P:semanticdb:targetroot

### DIFF
--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ClasspathOps.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ClasspathOps.scala
@@ -82,7 +82,15 @@ object ClasspathOps {
   }
 
   def toClassLoader(classpath: Classpath): URLClassLoader = {
+    toClassLoaderWithParent(classpath, this.getClass.getClassLoader)
+  }
+  def toOrphanClassLoader(classpath: Classpath): URLClassLoader = {
+    toClassLoaderWithParent(classpath, null)
+  }
+  private def toClassLoaderWithParent(
+      classpath: Classpath,
+      parent: ClassLoader): URLClassLoader = {
     val urls = classpath.entries.map(_.toNIO.toUri.toURL).toArray
-    new URLClassLoader(urls, this.getClass.getClassLoader)
+    new URLClassLoader(urls, parent)
   }
 }

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/TestkitProperties.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/TestkitProperties.scala
@@ -49,7 +49,7 @@ final class TestkitProperties(
   private def resolveFrom(
       directories: List[AbsolutePath],
       path: RelativePath): AbsolutePath = {
-    outputSourceDirectories
+    directories
       .collectFirst {
         case dir if Files.exists(dir.resolve(path).toNIO) =>
           dir.resolve(path)

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/BaseCliSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/BaseCliSuite.scala
@@ -176,7 +176,6 @@ trait BaseCliSuite extends FunSuite with DiffAssertions {
       assertObtained: Result => Unit = { result =>
         if (result.exit.isOk) {
           assertNoDiff(result.obtained, result.expected)
-
         }
       }
   ): Unit = {
@@ -215,7 +214,6 @@ trait BaseCliSuite extends FunSuite with DiffAssertions {
         } else {
           fixed
         }
-
       }
       val expected =
         if (fileIsFixed) slurpOutput(path)

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSemanticSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSemanticSuite.scala
@@ -19,6 +19,21 @@ class CliSemanticSuite extends BaseCliSuite {
   )
 
   checkSemantic(
+    name = "-P:semanticdb:targetroot",
+    args = {
+      val (targetroot :: Nil, jars) =
+        props.inputClasspath.entries.partition(_.isDirectory)
+      Array(
+        s"--scalacOptions",
+        s"-P:semanticdb:targetroot:${targetroot.toString()}",
+        "--classpath",
+        Classpath(jars).syntax
+      )
+    },
+    expectedExit = ExitStatus.Ok
+  )
+
+  checkSemantic(
     name = "--auto-classpath ok",
     args = Array(
       "--auto-classpath-roots",
@@ -41,6 +56,12 @@ class CliSemanticSuite extends BaseCliSuite {
       assert(out.contains("--sourceroot"))
       assert(out.contains("bogus"))
     }
+  )
+
+  checkSemantic(
+    name = "missing --classpath",
+    args = Array(),
+    expectedExit = ExitStatus.MissingSemanticdbError
   )
 
   test("MissingSemanticDB") {


### PR DESCRIPTION
This makes it possible for users to place SemanticDB files in a
different directory than classDirectory and still use Scalafix.

It turns out some cli tests were passing by accident because the
classloader we used to load SemanticDB already included the missing
SemanticDB files thanks to the parent classloader. After this commit,
the classloader has no parent so that the test fixture doesn't
accidentally pick up resources from the parent classloader.

Fixes #879