### PR TITLE
Remove unused on top-level template statements

### DIFF
--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
@@ -75,6 +75,12 @@ class RemoveUnused(config: RemoveUnusedConfig)
           }
         case i: Defn if isUnusedTerm(i.pos) =>
           defnTokensToRemove(i).map(Patch.removeTokens).asPatch.atomic
+        case i @ Defn.Val(_, List(pat), _, _)
+            if isUnusedTerm.exists(p => p.start == pat.pos.start) =>
+          defnTokensToRemove(i).map(Patch.removeTokens).asPatch.atomic
+        case i @ Defn.Var(_, List(pat), _, _)
+            if isUnusedTerm.exists(p => p.start == pat.pos.start) =>
+          defnTokensToRemove(i).map(Patch.removeTokens).asPatch.atomic
       }.asPatch
     }
   }

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
@@ -53,8 +53,6 @@ class RemoveUnused(config: RemoveUnusedConfig)
         diagnostic.message.startsWith("local") &&
         diagnostic.message.endsWith("is never used")) {
         isUnusedTerm += diagnostic.position
-      } else {
-        () // ignore
       }
     }
 

--- a/scalafix-tests/input/src/main/scala/test/RemoveUnusedStatements.scala
+++ b/scalafix-tests/input/src/main/scala/test/RemoveUnusedStatements.scala
@@ -1,0 +1,27 @@
+/*
+rule = RemoveUnused
+*/
+
+class A {
+  private val a = 1
+  private def a2 = 1
+  private var a3 = 1
+}
+
+object B {
+  private val b = 1
+  private def b2 = 1
+  private var b3 = 1
+}
+
+package object C {
+  private val c = 1
+  private def c2 = 1
+  private var c3 = 1
+}
+
+trait D {
+  private val d = 1
+  private def d2 = 1
+  private var d3 = 1
+}

--- a/scalafix-tests/output/src/main/scala/test/RemoveUnusedStatements.scala
+++ b/scalafix-tests/output/src/main/scala/test/RemoveUnusedStatements.scala
@@ -1,0 +1,23 @@
+class A {
+  
+  
+  
+}
+
+object B {
+  
+  
+  
+}
+
+package object C {
+  
+  
+  
+}
+
+trait D {
+  
+  
+  
+}


### PR DESCRIPTION
Fixes #626 

This is a workaround that tries to match by pos.start instead of full position.

I'm sure there are edge cases I haven't thought of, wdyt @olafurpg?

/cc @joan38 