### PR TITLE
Improve regex integration with DisableSyntax 

### DIFF
--- a/docs/rules/DisableSyntax.md
+++ b/docs/rules/DisableSyntax.md
@@ -55,16 +55,17 @@ DisableSyntax.regex = [
 ]
 ```
 
-1. The first way has a simple object providing an `id`, `pattern`, and `message`.
+1. The first way has an object providing an `id`, `pattern`, and `message`.
 2. The second way is just the pattern.  When this is used, the `id` is set equal 
    to the pattern, and a generic message is provided for you.
-3. The third way allows you to specify what capture-group the problematic thing 
-   is in, in case your regex is complicated.
+3. The third way allows you to specify what capture-group the problematic piece 
+   of code is in, in case your regex is complicated and also matches characters 
+   not useful in an error message.
 
 ### Error Messages  
 
-Error messages have access to the capture groups of the regex. Simply use `{$n}` 
-where `n` is the index of the capture group you wish to appear in that part of 
-the message.
+Error messages have access to the capture groups of the regex. To access the 
+capture groups of the regex, use `{$n}` where `n` is the index of the capture 
+group you wish to appear in that part of the message.
 
 You can see this used in the 3rd example.

--- a/docs/rules/DisableSyntax.md
+++ b/docs/rules/DisableSyntax.md
@@ -36,7 +36,7 @@ scalafix.website.rule("DisableSyntax", DisableSyntaxConfig.default)
 
 Regex patterns have 3 available ways to be configured.  The example below shows 1 of each way.
 
-```json
+```hocon
 DisableSyntax.regex = [
   {
     id = offensive

--- a/docs/rules/DisableSyntax.md
+++ b/docs/rules/DisableSyntax.md
@@ -31,3 +31,40 @@ println(
 scalafix.website.rule("DisableSyntax", DisableSyntaxConfig.default)
 )
 ```
+
+## Regex
+
+Regex patterns have 3 available ways to be configured.  The example below shows 1 of each way.
+
+```json
+DisableSyntax.regex = [
+  {
+    id = offensive
+    pattern = "[Pp]imp"
+    message = "Please consider a less offensive word than ${0} such as Extension"
+  }
+  "Await\\.result"
+  {
+    id = magicNumbers
+    regex = {
+      pattern = "(?:(?:[,(]\\s)|(?:^\\s*))+(\\d+(\\.\\d+)?)"
+      captureGroup = 1
+    }
+    message = "Numbers ({$1} in this instance) should always have a named parameter attached, or be assigned to a val."
+  }
+]
+```
+
+1. The first way has a simple object providing an `id`, `pattern`, and `message`.
+2. The second way is just the pattern.  When this is used, the `id` is set equal 
+   to the pattern, and a generic message is provided for you.
+3. The third way allows you to specify what capture-group the problematic thing 
+   is in, in case your regex is complicated.
+
+### Error Messages  
+
+Error messages have access to the capture groups of the regex. Simply use `{$n}` 
+where `n` is the index of the capture group you wish to appear in that part of 
+the message.
+
+You can see this used in the 3rd example.

--- a/scalafix-core/src/main/scala/scalafix/config/CustomMessage.scala
+++ b/scalafix-core/src/main/scala/scalafix/config/CustomMessage.scala
@@ -2,6 +2,9 @@ package scalafix.config
 
 import metaconfig.Conf
 import metaconfig.ConfDecoder
+import metaconfig.ConfError
+import metaconfig.Configured.Ok
+import metaconfig.Configured.NotOk
 import scalafix.internal.config.ScalafixMetaconfigReaders._
 import scalafix.v0.Symbol
 
@@ -13,6 +16,40 @@ class CustomMessage[T](
 object CustomMessage {
   implicit val SymbolDecoder: ConfDecoder[CustomMessage[Symbol.Global]] =
     decoder[Symbol.Global](field = "symbol")
+
+  implicit def CustomMessageEitherDecoder[A, B](
+      implicit A: ConfDecoder[CustomMessage[A]],
+      B: ConfDecoder[CustomMessage[B]]) = {
+    def wrapRight(message: CustomMessage[B]): CustomMessage[Either[A, B]] =
+      new CustomMessage(Right(message.value), message.message, message.id)
+
+    def wrapLeft(message: CustomMessage[A]): CustomMessage[Either[A, B]] =
+      new CustomMessage(Left(message.value), message.message, message.id)
+
+    println("deriving")
+
+    ConfDecoder.instance[CustomMessage[Either[A, B]]] {
+      case conf: Conf.Obj =>
+        println("B")
+        B.read(conf).map(wrapRight) match {
+          case ok @ Ok(_) => ok
+          case NotOk(err) =>
+            println("A")
+            A.read(conf).map(wrapLeft) match {
+              case ok @ Ok(_) => ok
+              case NotOk(err2) =>
+                NotOk(
+                  ConfError
+                    .message(
+                      "Failed to decode configuration for either of the following:")
+                    .combine(err)
+                    .combine(err2)
+                )
+            }
+        }
+    }
+  }
+
   def decoder[T](field: String)(
       implicit ev: ConfDecoder[T]): ConfDecoder[CustomMessage[T]] =
     ConfDecoder.instance[CustomMessage[T]] {

--- a/scalafix-core/src/main/scala/scalafix/config/Regex.scala
+++ b/scalafix-core/src/main/scala/scalafix/config/Regex.scala
@@ -1,0 +1,24 @@
+package scalafix.config
+
+import metaconfig.Conf
+import metaconfig.ConfDecoder
+import java.util.regex.Pattern
+import scalafix.internal.config.ScalafixMetaconfigReaders._
+
+class Regex(
+  val pattern: Pattern,
+  val captureGroup: Option[Int]
+)
+
+object Regex {
+  implicit val regexDecoder: ConfDecoder[Regex] =
+    ConfDecoder.instance[Regex] {
+      case obj: Conf.Obj =>
+        (obj.get[Pattern]("pattern") |@| obj.getOption[Int]("captureGroup")).map {
+          case (pattern, groupIndex) => new Regex(pattern, groupIndex)
+        }
+    }
+
+  implicit val customMessageRegexDecoder: ConfDecoder[CustomMessage[Regex]] =
+    CustomMessage.decoder[Regex](field = "regex")
+}

--- a/scalafix-core/src/main/scala/scalafix/config/Regex.scala
+++ b/scalafix-core/src/main/scala/scalafix/config/Regex.scala
@@ -6,17 +6,18 @@ import java.util.regex.Pattern
 import scalafix.internal.config.ScalafixMetaconfigReaders._
 
 class Regex(
-  val pattern: Pattern,
-  val captureGroup: Option[Int]
+    val pattern: Pattern,
+    val captureGroup: Option[Int]
 )
 
 object Regex {
   implicit val regexDecoder: ConfDecoder[Regex] =
     ConfDecoder.instance[Regex] {
       case obj: Conf.Obj =>
-        (obj.get[Pattern]("pattern") |@| obj.getOption[Int]("captureGroup")).map {
-          case (pattern, groupIndex) => new Regex(pattern, groupIndex)
-        }
+        (obj.get[Pattern]("pattern") |@| obj.getOption[Int]("captureGroup"))
+          .map {
+            case (pattern, groupIndex) => new Regex(pattern, groupIndex)
+          }
     }
 
   implicit val customMessageRegexDecoder: ConfDecoder[CustomMessage[Regex]] =

--- a/scalafix-core/src/main/scala/scalafix/internal/config/ScalafixConfig.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/config/ScalafixConfig.scala
@@ -1,6 +1,8 @@
 package scalafix.internal.config
 
 import metaconfig._
+import metaconfig.Configured.Ok
+import metaconfig.Configured.NotOk
 import metaconfig.generic.Surface
 import scala.meta._
 import scala.meta.dialects.Scala212

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
@@ -34,7 +34,6 @@ final class DisableSyntax(config: DisableSyntaxConfig)
       (0 to matcher.groupCount).foldLeft(message) {
         case (msg, idx) =>
           val groupText = matcher.group(idx)
-          println(groupText)
           if (groupText != null) msg.replace(s"{$$$idx}", matcher.group(idx))
           else msg
       }

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
@@ -35,7 +35,7 @@ final class DisableSyntax(config: DisableSyntaxConfig)
         case (msg, idx) =>
           val groupText = matcher.group(idx)
           println(groupText)
-          if (groupText != null) msg.replace("$" + idx, matcher.group(idx))
+          if (groupText != null) msg.replace(s"{$$$idx}", matcher.group(idx))
           else msg
       }
 

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntaxConfig.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntaxConfig.scala
@@ -88,7 +88,7 @@ case class DisableSyntaxConfig(
          |    message = "Please consider a less offensive word such as 'extension' or 'enrichment'"
          |  }
          |]""".stripMargin)
-    regex: List[CustomMessage[Either[Pattern, Regex]]] = Nil
+    regex: List[CustomMessage[Either[Regex, Pattern]]] = Nil
 ) {
 
   def isDisabled(keyword: String): Boolean = keyword match {

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntaxConfig.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntaxConfig.scala
@@ -13,6 +13,7 @@ import metaconfig.annotation.ExampleValue
 import metaconfig.annotation.Hidden
 import pprint.TPrint
 import scalafix.config.CustomMessage
+import scalafix.config.Regex
 
 case class DisableSyntaxConfig(
     @Hidden
@@ -83,11 +84,11 @@ case class DisableSyntaxConfig(
       """|[
          |  {
          |    id = "offensive"
-         |    pattern = "[P|p]imp"
+         |    pattern = "[Pp]imp"
          |    message = "Please consider a less offensive word such as 'extension' or 'enrichment'"
          |  }
          |]""".stripMargin)
-    regex: List[CustomMessage[Pattern]] = Nil
+    regex: List[CustomMessage[Either[Pattern, Regex]]] = Nil
 ) {
 
   def isDisabled(keyword: String): Boolean = keyword match {

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/RuleTest.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/RuleTest.scala
@@ -53,7 +53,7 @@ object RuleTest {
         .withConf(conf)
         .withScalaVersion(props.scalaVersion)
         .withScalacOptions(props.scalacOptions)
-      val rules = decoder.read(rulesConf).get.withConfiguration(config).get
+        val rules = decoder.read(rulesConf).get.withConfiguration(config).get
       (rules, sdoc)
     }
 

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/RuleTest.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/RuleTest.scala
@@ -53,7 +53,7 @@ object RuleTest {
         .withConf(conf)
         .withScalaVersion(props.scalaVersion)
         .withScalacOptions(props.scalacOptions)
-        val rules = decoder.read(rulesConf).get.withConfiguration(config).get
+      val rules = decoder.read(rulesConf).get.withConfiguration(config).get
       (rules, sdoc)
     }
 

--- a/scalafix-tests/input/src/main/scala/test/disableSyntax/DisableSyntaxBase.scala
+++ b/scalafix-tests/input/src/main/scala/test/disableSyntax/DisableSyntaxBase.scala
@@ -60,7 +60,10 @@ case object DisableSyntaxBase {
     def -(other: String): String = s"$value - $other"
   }
 
-  5 // assert: DisableSyntax.magicNumbers
+  5 /* assert: DisableSyntax.magicNumbers
+  ^
+Numbers (5 in this instance) should always have a named parameter attached, or be assigned to a val.
+   */
 
   val fortyTwo = 42
   val someDays = 75.days

--- a/scalafix-tests/input/src/main/scala/test/disableSyntax/DisableSyntaxBase.scala
+++ b/scalafix-tests/input/src/main/scala/test/disableSyntax/DisableSyntaxBase.scala
@@ -18,10 +18,10 @@ DisableSyntax.regex = [
   {
     id = magicNumbers
     regex = {
-      pattern = "[^=]*(\d+).*$"
+      pattern = "(?:(?:[,(]\\s)|(?:^\\s*))+(\\d+(\\.\\d+)?)"
       captureGroup = 1
     }
-    message = "Numbers should always have their named param attached, or be defined as a val."
+    message = "Numbers ({$1} in this instance) should always have a named parameter attached, or be assigned to a val."
   }
   "Await\\.result"
 ]
@@ -60,18 +60,12 @@ case object DisableSyntaxBase {
     def -(other: String): String = s"$value - $other"
   }
 
-  implicit class RichString(value: String) { // assert: DisableSyntax.classist
-    def -(other: String): String = s"$value - $other"
-  }
-
   5 // assert: DisableSyntax.magicNumbers
 
   val fortyTwo = 42
   val someDays = 75.days
   // actually 7.5 million years
   Await.result(Future(fortyTwo), someDays) // assert: DisableSyntax.Await\.result
-
-  "foo" // assert: DisableSyntax.bad-indentation
 
   override def finalize(): Unit = println("exit") // assert: DisableSyntax.noFinalize
 

--- a/scalafix-tests/input/src/main/scala/test/disableSyntax/DisableSyntaxBase.scala
+++ b/scalafix-tests/input/src/main/scala/test/disableSyntax/DisableSyntaxBase.scala
@@ -12,8 +12,16 @@ DisableSyntax.noFinalize = true
 DisableSyntax.regex = [
   {
     id = offensive
-    pattern = "[P|p]imp"
+    pattern = "[Pp]imp"
     message = "Please consider a less offensive word such as Extension"
+  }
+  {
+    id = magicNumbers
+    regex = {
+      pattern = "[^=]*(\d+).*$"
+      captureGroup = 1
+    }
+    message = "Numbers should always have their named param attached, or be defined as a val."
   }
   "Await\\.result"
 ]
@@ -52,8 +60,18 @@ case object DisableSyntaxBase {
     def -(other: String): String = s"$value - $other"
   }
 
+  implicit class RichString(value: String) { // assert: DisableSyntax.classist
+    def -(other: String): String = s"$value - $other"
+  }
+
+  5 // assert: DisableSyntax.magicNumbers
+
+  val fortyTwo = 42
+  val someDays = 75.days
   // actually 7.5 million years
-  Await.result(Future(42), 75.days) // assert: DisableSyntax.Await\.result
+  Await.result(Future(fortyTwo), someDays) // assert: DisableSyntax.Await\.result
+
+  "foo" // assert: DisableSyntax.bad-indentation
 
   override def finalize(): Unit = println("exit") // assert: DisableSyntax.noFinalize
 


### PR DESCRIPTION
I think the best way to see what I've changed is to look at the [updated docs](https://github.com/scalacenter/scalafix/blob/64e39aaa13120504dfb4ea927901ef5f4c528358/docs/rules/DisableSyntax.md).  To summarize:

1. Now error messages will underline the whole area of matched regex
2. The relevant capture group can be specified, in case you have complicated regex's which may match on parts which aren't helpful in the error message
3. scalafix errors which came from a regex match have access to the capture groups for substitution in the error messages.

I'm not dead set on any of the naming or formatting I've chosen.  Feel free to have me change them