### PR TITLE
Upgrade to Scalameta v4.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ cache:
     - "$HOME/.sbt"
     - "$HOME/.ivy2/cache"
     - "$HOME/.coursier"
+    - "$HOME/.cache"
   yarn: true
 
 before_cache:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 /* scalafmt: { maxColumn = 120 }*/
 
 object Dependencies {
-  val scalametaV = "4.0.0"
+  val scalametaV = "4.1.0"
   val metaconfigV = "0.8.4"
   def dotty = "0.9.0-RC1"
   def scala210 = "2.10.6"

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.23")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M4")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M8")
 unmanagedSources.in(Compile) += baseDirectory.value / ".." / "Dependencies.scala"

--- a/scalafix-docs/src/main/scala/scalafix/docs/PatchDocs.scala
+++ b/scalafix-docs/src/main/scala/scalafix/docs/PatchDocs.scala
@@ -56,7 +56,8 @@ object PatchDocs {
         PatchInternals.semantic(
           Map(RuleName("patch") -> p),
           doc,
-          suppress = false)
+          suppress = false
+        )
       obtained
     }
     def showDiff(context: Int = 0)(implicit doc: SemanticDocument): Unit = {
@@ -68,7 +69,8 @@ object PatchDocs {
       val (_, diagnostics) = PatchInternals.semantic(
         Map(RuleName("RuleName") -> p.asPatch),
         doc,
-        suppress = false)
+        suppress = false
+      )
       diagnostics.foreach { diag =>
         println(diag.formattedMessage)
       }
@@ -89,7 +91,8 @@ object PatchDocs {
   }
 
   def unifiedDiff(obtained: String, context: Int)(
-      implicit doc: SemanticDocument): String = {
+      implicit doc: SemanticDocument
+  ): String = {
     val in = Input.VirtualFile("before patch", doc.input.text)
     val out = Input.VirtualFile("after  patch", obtained)
     PatchInternals.unifiedDiff(in, out, context)
@@ -99,7 +102,8 @@ object PatchDocs {
     "-P:semanticdb:synthetics:on"
   )
   lazy val compiler = InteractiveSemanticdb.newCompiler(scalacOptions)
-  lazy val symtab = GlobalSymbolTable(ClasspathOps.thisClasspath)
+  lazy val symtab =
+    GlobalSymbolTable(ClasspathOps.thisClasspath, includeJdk = true)
   lazy val scalafixSymtab = new Symtab { self =>
     override def info(symbol: Symbol): Option[SymbolInformation] = {
       symtab.info(symbol.value).map(new SymbolInformation(_)(self))
@@ -130,7 +134,8 @@ object PatchDocs {
     val textDocument = InteractiveSemanticdb.toTextDocument(
       compiler,
       code,
-      scalacOptions.filter(_.startsWith("-P:semanticdb")))
+      scalacOptions.filter(_.startsWith("-P:semanticdb"))
+    )
     if (debug) {
       Predef.println("```")
       Predef.println(Print.document(Format.Compact, textDocument))

--- a/scalafix-reflect/src/main/scala/scalafix/internal/v0/LegacyInMemorySemanticdbIndex.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/v0/LegacyInMemorySemanticdbIndex.scala
@@ -19,8 +19,8 @@ import scalafix.internal.v1._
 
 case class LegacyInMemorySemanticdbIndex(
     index: Map[String, SemanticdbIndex],
-    symtab: SymbolTable)
-    extends CrashingSemanticdbIndex
+    symtab: SymbolTable
+) extends CrashingSemanticdbIndex
     with SymbolTable {
 
   def info(symbol: String): Option[s.SymbolInformation] = symtab.info(symbol)
@@ -78,8 +78,9 @@ object LegacyInMemorySemanticdbIndex {
 
   def load(
       classpath: Classpath,
-      sourceroot: AbsolutePath): LegacyInMemorySemanticdbIndex = {
-    val symtab = ClasspathOps.newSymbolTable(classpath).get
+      sourceroot: AbsolutePath
+  ): LegacyInMemorySemanticdbIndex = {
+    val symtab = ClasspathOps.newSymbolTable(classpath)
     val dialect = dialects.Scala212
     load(classpath, sourceroot, symtab, dialect)
   }

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
@@ -24,7 +24,8 @@ abstract class SemanticRuleSuite(val props: TestkitProperties)
 
   @deprecated(
     "Use empty constructor instead. Arguments are passed as resource 'scalafix-testkit.properties'",
-    "0.6.0")
+    "0.6.0"
+  )
   def this(
       index: SemanticdbIndex,
       inputSourceroot: AbsolutePath,
@@ -77,9 +78,7 @@ abstract class SemanticRuleSuite(val props: TestkitProperties)
   }
 
   lazy val testsToRun = {
-    val symtab = ClasspathOps
-      .newSymbolTable(props.inputClasspath)
-      .getOrElse { sys.error("Failed to load symbol table") }
+    val symtab = ClasspathOps.newSymbolTable(props.inputClasspath)
     val classLoader = ClasspathOps.toClassLoader(props.inputClasspath)
     val tests = TestkitPath.fromProperties(props)
     tests.map { test =>
@@ -94,8 +93,9 @@ abstract class SemanticRuleSuite(val props: TestkitProperties)
 object SemanticRuleSuite {
   def defaultClasspath(classDirectory: AbsolutePath) = Classpath(
     classDirectory ::
-      RuleCompiler.defaultClasspathPaths.filter(path =>
-      path.toNIO.getFileName.toString.contains("scala-library"))
+      RuleCompiler.defaultClasspathPaths.filter(
+      path => path.toNIO.getFileName.toString.contains("scala-library")
+    )
   )
 
   def stripTestkitComments(input: String): String =
@@ -119,7 +119,8 @@ object SemanticRuleSuite {
       .getOrElse {
         val input = tokens.headOption.fold("the file")(_.input.toString)
         throw new IllegalArgumentException(
-          s"Missing /* */ comment at the top of $input")
+          s"Missing /* */ comment at the top of $input"
+        )
       }
   }
 

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/BaseSemanticSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/BaseSemanticSuite.scala
@@ -17,7 +17,7 @@ object BaseSemanticSuite {
   lazy val symtab: SymbolTable = {
     val classpath =
       Classpaths.withDirectory(AbsolutePath(BuildInfo.sharedClasspath))
-    ClasspathOps.newSymbolTable(classpath).get
+    ClasspathOps.newSymbolTable(classpath)
   }
   def loadDoc(filename: String): SemanticDocument = {
     val root = AbsolutePath(BuildInfo.sharedSourceroot).resolve("scala/test")
@@ -29,7 +29,8 @@ object BaseSemanticSuite {
       doc,
       relpath,
       ClasspathOps.thisClassLoader,
-      symtab)
+      symtab
+    )
   }
 }
 

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/Classpaths.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/Classpaths.scala
@@ -2,11 +2,9 @@ package scalafix.tests.core
 
 import scala.meta.io.AbsolutePath
 import scala.meta.io.Classpath
-import scalafix.internal.reflect.ClasspathOps
 import scalafix.internal.reflect.RuleCompiler
 
 object Classpaths {
-  def jdk: Classpath = ClasspathOps.bootClasspath.get
   def scalaLibrary = Classpath(
     RuleCompiler.defaultClasspathPaths.filter { path =>
       path.isFile ||
@@ -14,6 +12,6 @@ object Classpaths {
     }
   )
   def withDirectory(dir: AbsolutePath): Classpath =
-    Classpath(dir :: jdk.entries ::: scalaLibrary.entries)
+    Classpath(dir :: scalaLibrary.entries)
 
 }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/v1/SymbolInformationSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/v1/SymbolInformationSuite.scala
@@ -6,10 +6,9 @@ import scalafix.testkit.DiffAssertions
 import scalafix.v1._
 
 class SymbolInformationSuite extends FunSuite with DiffAssertions {
-  private val classpath =
-    ClasspathOps.bootClasspath.get ++ ClasspathOps.thisClasspath
+  private val classpath = ClasspathOps.thisClasspath
 
-  private val symtab = GlobalSymbolTable(classpath)
+  private val symtab = GlobalSymbolTable(classpath, includeJdk = true)
   private implicit val v1Symtab = new Symtab {
     override def info(symbol: Symbol): Option[SymbolInformation] =
       symtab.info(symbol.value).map(new SymbolInformation(_)(this))


### PR DESCRIPTION
This release has faster tree traversal, supports more Scala versions,
works on Java 11 and is ~8mb smaller than v4.0.0.