### PR TITLE
Include filename for unexpected errors.

### DIFF
--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/FileException.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/FileException.scala
@@ -1,0 +1,8 @@
+package scalafix.internal.v1
+
+import scala.meta.io.AbsolutePath
+import scala.util.control.NoStackTrace
+
+case class FileException(file: AbsolutePath, cause: Throwable)
+    extends Exception(s"unexpected error processing file $file", cause)
+    with NoStackTrace

--- a/scalafix-core/src/main/scala/scalafix/internal/v1/Rules.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/v1/Rules.scala
@@ -37,7 +37,8 @@ case class Rules(rules: List[Rule] = Nil) {
       tokens: Tokens,
       messages: List[Diagnostic],
       patch: Patch,
-      suppress: Boolean): Patch = {
+      suppress: Boolean
+  ): Patch = {
     if (suppress) {
       patch + SuppressOps.addComments(tokens, messages.map(_.position))
     } else {
@@ -47,8 +48,9 @@ case class Rules(rules: List[Rule] = Nil) {
 
   def semanticPatch(
       sdoc: SemanticDocument,
-      suppress: Boolean): (String, List[RuleDiagnostic]) = {
-    val fixes = rules.iterator.map {
+      suppress: Boolean
+  ): (String, List[RuleDiagnostic]) = {
+    val fixes = rules.map {
       case rule: SemanticRule =>
         rule.name -> rule.fix(sdoc)
       case rule: SyntacticRule =>
@@ -59,9 +61,10 @@ case class Rules(rules: List[Rule] = Nil) {
 
   def syntacticPatch(
       doc: SyntacticDocument,
-      suppress: Boolean): (String, List[RuleDiagnostic]) = {
+      suppress: Boolean
+  ): (String, List[RuleDiagnostic]) = {
     require(!isSemantic, semanticRules.map(_.name).mkString("+"))
-    val fixes = syntacticRules.iterator.map { rule =>
+    val fixes = syntacticRules.map { rule =>
       rule.name -> rule.fix(doc)
     }.toMap
     PatchInternals.syntactic(fixes, doc, suppress)

--- a/scalafix-tests/unit/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/scalafix-tests/unit/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,6 +1,7 @@
 banana.rule.SemanticRuleV1
 banana.rule.SyntacticRuleV1
 scalafix.test.ExplicitSynthetic
+scalafix.tests.cli.CrashingRule
 scalafix.tests.cli.NoOpRule
 scalafix.tests.cli.DeprecatedName
 scalafix.tests.cli.Scala2_9


### PR DESCRIPTION
Previously, the stack trace from unexpected errors didn't include
the file path being processed. Now the error includes what file is
being processed and the stack trace is truncated to only include
relevant parts.

Supersedes #908