### PR TITLE
Upgrade sbt to 1.2.7

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.7


### PR DESCRIPTION
Here are release notes and there is no significant breakage.

https://developer.lightbend.com/blog/2018-07-02-sbt-1-2-0/index.html
https://developer.lightbend.com/blog/2018-08-07-sbt-1-2-1/index.html
https://developer.lightbend.com/blog/2018-09-14-sbt-1-2-3/index.html
https://developer.lightbend.com/blog/2018-10-08-sbt-1-2-4-and-nightly-builds/index.html
https://developer.lightbend.com/blog/2018-10-17-sbt-1-2-6/index.html
https://developer.lightbend.com/blog/2018-11-30-sbt-1-2-7-and-sbt-0-13-18/index.html

sbt 1.2 has many zinc optimizations :)

---

As a release note for 1.2.4 said, it is necessary to run `clean` after updated sbt

> Please run clean after updating since sbt 1.2.4 includes a fix in the incremental compiler.