### PR TITLE
Enable to access to uri from outside of scalafix package

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/v1/SemanticDocument.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/SemanticDocument.scala
@@ -20,6 +20,8 @@ final class SemanticDocument private[scalafix] (
     tree.tokens
   def input: Input =
     internal.doc.internal.input
+  def uri: String =
+    internal.textDocument.uri
 
   def matchingParens: MatchingParens =
     internal.doc.internal.matchingParens.value


### PR DESCRIPTION
This PR enable us to access to `SemanticDocument#internal.textDocument.uri` from outside of `scalafix` package. I consider that this will be useful for developing custom scalafix rules :)

Since `SemanticDocument#internal` has modifier `private[scalafix]`, currently we have to [do some workarounds](https://github.com/tanishiking/scalafix-check-scaladoc/blob/bc3f7fc274030de4efa91589d6525b7ec52ef460/scalafix/rules/src/main/scala/scalafix/checkscaladoc/ScalafixAccess.scala#L8) to access `SemanticDocument#internal.textDocument.uri` when we develop third-party scalafix custom rule.

Should we still prohibit us from accessing `uri`, or enable us to access `textDocument` instead of `uri` ?