### PR TITLE
Add universal inequality cases and tests

### DIFF
--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
@@ -225,10 +225,17 @@ final class DisableSyntax(config: DisableSyntaxConfig)
           }
       case Term.ApplyInfix(_, t @ Term.Name("=="), _, _)
           if config.noUniversalEquality =>
-        Seq(noUniversalEqualityDiagnostic(t))
+        Seq(noUniversalEqualityDiagnostic("==", t))
       case Term.Apply(Term.Select(_, t @ Term.Name("==")), _)
           if config.noUniversalEquality =>
-        Seq(noUniversalEqualityDiagnostic(t))
+        Seq(noUniversalEqualityDiagnostic("==", t))
+
+      case Term.ApplyInfix(_, t @ Term.Name("!="), _, _)
+          if config.noUniversalEquality =>
+        Seq(noUniversalEqualityDiagnostic("!=", t))
+      case Term.Apply(Term.Select(_, t @ Term.Name("!=")), _)
+          if config.noUniversalEquality =>
+        Seq(noUniversalEqualityDiagnostic("!=", t))
     }
     val FinalizeMatcher = DisableSyntax.FinalizeMatcher("noFinalize")
     doc.tree.collect(DefaultMatcher.orElse(FinalizeMatcher)).flatten
@@ -251,8 +258,8 @@ final class DisableSyntax(config: DisableSyntaxConfig)
       explain = "Pattern matching in val assignment can result in match error, " +
         "use \"_ match { ... }\" with a fallback case instead.")
 
-  private def noUniversalEqualityDiagnostic(t: Term.Name): Diagnostic =
-    Diagnostic("==", config.noUniversalEqualityMessage, t.pos)
+  private def noUniversalEqualityDiagnostic(symbol: String, t: Term.Name): Diagnostic =
+    Diagnostic(symbol, config.noUniversalEqualityMessage, t.pos)
 
 }
 

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
@@ -229,7 +229,6 @@ final class DisableSyntax(config: DisableSyntaxConfig)
       case Term.Apply(Term.Select(_, t @ Term.Name("==")), _)
           if config.noUniversalEquality =>
         Seq(noUniversalEqualityDiagnostic("==", t))
-
       case Term.ApplyInfix(_, t @ Term.Name("!="), _, _)
           if config.noUniversalEquality =>
         Seq(noUniversalEqualityDiagnostic("!=", t))
@@ -258,7 +257,9 @@ final class DisableSyntax(config: DisableSyntaxConfig)
       explain = "Pattern matching in val assignment can result in match error, " +
         "use \"_ match { ... }\" with a fallback case instead.")
 
-  private def noUniversalEqualityDiagnostic(symbol: String, t: Term.Name): Diagnostic =
+  private def noUniversalEqualityDiagnostic(
+      symbol: String,
+      t: Term.Name): Diagnostic =
     Diagnostic(symbol, config.noUniversalEqualityMessage, t.pos)
 
 }

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntaxConfig.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntaxConfig.scala
@@ -77,7 +77,7 @@ case class DisableSyntaxConfig(
     )
     @ExampleValue("\"use === instead of ==\"")
     noUniversalEqualityMessage: String =
-      "== is unsafe since it allows comparing two unrelated types",
+      "== and != are unsafe since they allow comparing two unrelated types",
     @Description(
       "Report error if the text contents of a source file matches a given regex.")
     @ExampleValue(

--- a/scalafix-tests/input/src/main/scala/test/DisableSyntaxMoreRules.scala
+++ b/scalafix-tests/input/src/main/scala/test/DisableSyntaxMoreRules.scala
@@ -8,7 +8,7 @@ DisableSyntax.noImplicitObject = true
 DisableSyntax.noImplicitConversion = true
 DisableSyntax.noUniversalEquality = true
 DisableSyntax.noUniversalEqualityMessage =
-  "== is not typesafe, use === from cats.Eq instead"
+  "== and != are not typesafe, use === and =!= from cats.Eq instead"
 */
 package test
 
@@ -91,12 +91,23 @@ Default args makes it hard to use methods as functions.
 
   1 == 2 /* assert: DisableSyntax.==
     ^^
-    == is not typesafe, use === from cats.Eq instead
+    == and != are not typesafe, use === and =!= from cats.Eq instead
   */
 
   1.==(2) /* assert: DisableSyntax.==
     ^^
-    == is not typesafe, use === from cats.Eq instead
+    == and != are not typesafe, use === and =!= from cats.Eq instead
   */
+
+ 1 != 2 /* assert: DisableSyntax.!=
+   ^^
+    == and != are not typesafe, use === and =!= from cats.Eq instead
+  */
+
+  1.!=(2) /* assert: DisableSyntax.!=
+    ^^
+    == and != are not typesafe, use === and =!= from cats.Eq instead
+  */
+
 
 }


### PR DESCRIPTION
Currently, the rule for disabling universal equality still allows for universal inequality.  This PR addresses that.