### PR TITLE
Fix travis failing jdk installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 jdk:
-- oraclejdk8
+- openjdk8
 stages:
   - name: test
   - name: release


### PR DESCRIPTION
Travis failed to install `oraclejdk8` in recent PR https://travis-ci.org/scalacenter/scalafix/jobs/567473636#L167

`openjdk8` is chosen, since `openjdk11` fails to download `sbt-unidoc` on `TEST="2.11"` job
https://travis-ci.org/scalacenter/scalafix/jobs/567475070#L2403

