### PR TITLE
Fix "Using external rules" not shown in sidebar

### DIFF
--- a/docs/rules/external-rules.md
+++ b/docs/rules/external-rules.md
@@ -1,5 +1,5 @@
 ---
-id: external-rule
+id: external-rules
 sidebar_label: Using external rules
 title: Using external rules
 ---

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -43,6 +43,10 @@
       "rules/DisableSyntax": {
         "title": "DisableSyntax"
       },
+      "rules/external-rules": {
+        "title": "Using external rules",
+        "sidebar_label": "Using external rules"
+      },
       "rules/LeakingImplicitClassVal": {
         "title": "LeakingImplicitClassVal"
       },
@@ -54,7 +58,7 @@
       },
       "rules/overview": {
         "title": "Built-in Rules",
-        "sidebar_label": "All rules"
+        "sidebar_label": "Built-in rules"
       },
       "rules/ProcedureSyntax": {
         "title": "ProcedureSyntax"


### PR DESCRIPTION
Follow-up #974 
Sorry, I have forgoten to confirm sidebar in the previous PR.

![image](https://user-images.githubusercontent.com/127635/62429770-cf4ff780-b74d-11e9-89ef-a7ae46407d85.png)
