### PR TITLE
Fix issues handling source files with spaces in their path.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 /* scalafmt: { maxColumn = 120 }*/
 
 object Dependencies {
-  val scalametaV = "4.1.9"
+  val scalametaV = "4.2.1"
   val metaconfigV = "0.9.1"
   def dotty = "0.9.0-RC1"
   def scala210 = "2.10.6"

--- a/scalafix-core/src/main/scala/scalafix/internal/v1/package.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/v1/package.scala
@@ -13,16 +13,6 @@ import scala.meta.io.RelativePath
 
 package object v1 {
 
-  implicit class XtensionRelativePathScalafix(path: RelativePath) {
-    // TODO: replace with RelativePath.toURI once https://github.com/scalameta/scalameta/issues/1523 is fixed
-    def toRelativeURI: URI = {
-      val reluri = path.toNIO.asScala.iterator.map { path =>
-        new URI(null, null, path.getFileName.toString, null).toString
-      }
-      URI.create(reluri.mkString("/"))
-    }
-  }
-
   implicit class XtensionTextDocumentFix(sdoc: s.TextDocument) {
     def abspath(sourceroot: URI): AbsolutePath = {
       val absuri = sourceroot.resolve(URI.create(sdoc.uri))

--- a/scalafix-core/src/main/scala/scalafix/v1/SemanticDocument.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/SemanticDocument.scala
@@ -54,20 +54,20 @@ object SemanticDocument {
       classLoader: ClassLoader,
       symtab: SymbolTable
   ): SemanticDocument = {
-    val semanticdbReluri = s"META-INF/semanticdb/$path.semanticdb"
-    Option(classLoader.getResourceAsStream(semanticdbReluri)) match {
+    val semanticdbRelPath = s"META-INF/semanticdb/$path.semanticdb"
+    Option(classLoader.getResourceAsStream(semanticdbRelPath)) match {
       case Some(inputStream) =>
         val sdocs =
           try s.TextDocuments.parseFrom(inputStream).documents
           finally inputStream.close()
-        val reluri = path.toRelativeURI.toString
+        val reluri = path.toURI(isDirectory = false).toString
         val sdoc = sdocs.find(_.uri == reluri).getOrElse {
           throw Error.MissingTextDocument(reluri)
         }
         val impl = new InternalSemanticDoc(doc, sdoc, symtab)
         new SemanticDocument(impl)
       case None =>
-        throw Error.MissingSemanticdb(semanticdbReluri)
+        throw Error.MissingSemanticdb(semanticdbRelPath)
     }
   }
 }

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/TestkitPath.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/TestkitPath.scala
@@ -30,7 +30,7 @@ final class TestkitPath(
     )
     pprint.PPrinter.BlackWhite.tokenize(map).mkString
   }
-  def testName: String = testPath.toRelativeURI.toString
+  def testName: String = testPath.toURI(isDirectory = false).toString
   def toInput: Input =
     Input.VirtualFile(testName, FileIO.slurp(input, StandardCharsets.UTF_8))
   def resolveOutput(props: TestkitProperties): Either[String, AbsolutePath] = {

--- a/scalafix-tests/input/src/main/scala/test/Filename With Spaces.scala
+++ b/scalafix-tests/input/src/main/scala/test/Filename With Spaces.scala
@@ -1,0 +1,8 @@
+/*
+rules = []
+ */
+package test
+
+object Object {
+  val x = 1
+}

--- a/scalafix-tests/output/src/main/scala/test/Filename With Spaces.scala
+++ b/scalafix-tests/output/src/main/scala/test/Filename With Spaces.scala
@@ -1,0 +1,6 @@
+
+package test
+
+object Object {
+  val x = 1
+}


### PR DESCRIPTION
Upgrades to scalameta 4.2.1 to ensure proper semanticdb files are generated for such files.

Fixes #972.