### PR TITLE
#992 allow 'DisableSyntax.noValPattern' for wildcard patterns

### DIFF
--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
@@ -166,6 +166,7 @@ final class DisableSyntax(config: DisableSyntaxConfig)
       def isProhibited(v: Pat): Boolean = v match {
         case _: Pat.Tuple => false
         case _: Pat.Var => false
+        case _: Pat.Wildcard => false
         case _ => true
       }
     }

--- a/scalafix-tests/input/src/main/scala/test/disableSyntax/DisableSyntaxNoValPatterns.scala
+++ b/scalafix-tests/input/src/main/scala/test/disableSyntax/DisableSyntaxNoValPatterns.scala
@@ -7,11 +7,16 @@ package test.disableSyntax
 case object DisableSyntaxNoValPatterns {
   val Right(notFound) = 1.asInstanceOf[Either[String, String]] // assert: DisableSyntax.noValPatterns
   var Right(shame) = 1.asInstanceOf[Either[String, String]]  // assert: DisableSyntax.noValPatterns
+  val _ = Right("it works")
   val itWorks = Left("42")
   val (works, works2) = (1, 1)
   val ((works3, works4), works5) = ((1, 1), 1)
+  val (works6, _) = (1, Left(42))
   case class TestClass(a: Int, b: Int)
   val TestClass(a, b) = TestClass(1, 1) /* assert: DisableSyntax.noValPatterns
+      ^
+  Pattern matching in val assignment can result in match error, use "_ match { ... }" with a fallback case instead.*/
+  val TestClass(c, _) = TestClass(1, 1) /* assert: DisableSyntax.noValPatterns
       ^
   Pattern matching in val assignment can result in match error, use "_ match { ... }" with a fallback case instead.*/
 }


### PR DESCRIPTION
Fixes #992. Next cases should be allowed:
1. total wildcard: `val _ = "Something"`;
2. tuple element wildcard: `val (first, _) = ("Foo", "Bar")`.

Wildcards in non-total cases such as case classes or sequences still won't be allowed.