### PR TITLE
Adjust position for first imports to precede comment

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/internal/patch/ImportPatchOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/patch/ImportPatchOps.scala
@@ -38,7 +38,12 @@ object ImportPatchOps {
       case Source((stat: Pkg) :: _) => loop(stat)
       case Source(_) => ctx.toks(tree).head
       case Pkg(_, stat :: _) => loop(stat)
-      case els => ctx.tokenList.prev(ctx.tokenList.prev(ctx.toks(els).head))
+      case els =>
+        ctx.tokenList.prev(ctx.tokenList.prev(ctx.toks(els).head)) match {
+          case comment @ Token.Comment(_) =>
+            ctx.tokenList.prev(ctx.tokenList.prev(comment))
+          case other => other
+        }
     }
     loop(ctx.tree)
   }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/PatchSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/PatchSuite.scala
@@ -97,6 +97,26 @@ class PatchSuite extends SyntacticRuleSuite {
       |""".stripMargin
   )
 
+  check(
+    addGlobalImporter,
+    "addGlobalImporter skip a comment preceding the first statement",
+    """package foo.bar
+      |
+      |/**
+      | * API docs here
+      | */
+      |object A
+      |""".stripMargin,
+    """package foo.bar
+      |
+      |import scala.collection.{ mutable => _ }
+      |/**
+      | * API docs here
+      | */
+      |object A
+      |""".stripMargin
+  )
+
   val tree = Input.String(original).parse[Source].get
 
   test("Patch.empty") {


### PR DESCRIPTION
Right now if you use `addGlobalImport` on a file that doesn't have any imports, it will just drop in the new imports one token ahead of the first statement in the file, which is inconvenient if that statement is preceded by a comment:

```scala
package foo.bar

/**
 * API docs for A here
 */
import whatever
object A
```

This change just checks whether the token one token ahead of the first statement is a comment, and if it is, it moves to the left of that. This could still go wrong, and it wouldn't be too hard to make the logic for picking this position much more robust (I'd be happy to take a stab at that if there's interest).