### PR TITLE
Fix string representation of `Input.VirtualFile` in exception message

### DIFF
--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
@@ -135,7 +135,7 @@ object SemanticRuleSuite {
         x.is[Token.Comment] && x.syntax.startsWith("/*")
       }
       .getOrElse {
-        val input = tokens.headOption.fold("the file")(_.input.toString)
+        val input = tokens.headOption.fold("the file")(_.input.path)
         throw new IllegalArgumentException(
           s"Missing /* */ comment at the top of $input"
         )

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
@@ -135,7 +135,7 @@ object SemanticRuleSuite {
         x.is[Token.Comment] && x.syntax.startsWith("/*")
       }
       .getOrElse {
-        val input = tokens.headOption.fold("the file")(_.input.path)
+        val input = tokens.headOption.fold("the file")(_.input.syntax)
         throw new IllegalArgumentException(
           s"Missing /* */ comment at the top of $input"
         )


### PR DESCRIPTION
Current behaviour:

```
 java.lang.IllegalArgumentException: Missing /* */ comment at the top of Input.VirtualFile("scalafix-rules/src/main/scala/fix/Foo.scala", "package fix
```

Would be nicer to just use [`Input.VirtualFile.path`](https://github.com/scalameta/trees/blob/master/scalameta/inputs/shared/src/main/scala/scala/meta/inputs/Input.scala#L74) in the message.