### PR TITLE
convert empty values to None or Nil in ExplicitResultType rule

### DIFF
--- a/scalafix-tests/input/src/main/scala-2.12/test/explicitResultTypes/ExplicitResultTypesShort.scala
+++ b/scalafix-tests/input/src/main/scala-2.12/test/explicitResultTypes/ExplicitResultTypesShort.scala
@@ -19,4 +19,8 @@ object ExplicitResultTypesShort {
   implicit def tparam[T](e: T) = e
   implicit val opt = Option.empty[Int]
   implicit val seq = Seq.empty[List[Int]]
+  object Shadow {
+    val Option = scala.collection.mutable.ListBuffer
+    implicit val shadow = Option.empty[List[Int]]
+  }
 }

--- a/scalafix-tests/input/src/main/scala-2.12/test/explicitResultTypes/ExplicitResultTypesShort.scala
+++ b/scalafix-tests/input/src/main/scala-2.12/test/explicitResultTypes/ExplicitResultTypesShort.scala
@@ -17,4 +17,6 @@ object ExplicitResultTypesShort {
   implicit var zz = scala.collection.immutable.ListSet.empty[String]
   implicit val FALSE = (x: Any) => false
   implicit def tparam[T](e: T) = e
+  implicit val opt = Option.empty[Int]
+  implicit val seq = Seq.empty[List[Int]]
 }

--- a/scalafix-tests/output/src/main/scala-2.12/test/explicitResultTypes/ExplicitResultTypesShort.scala
+++ b/scalafix-tests/output/src/main/scala-2.12/test/explicitResultTypes/ExplicitResultTypesShort.scala
@@ -17,4 +17,8 @@ object ExplicitResultTypesShort {
   implicit def tparam[T](e: T): T = e
   implicit val opt: Option[Int] = None
   implicit val seq: Seq[List[Int]] = Nil
+  object Shadow {
+    val Option = scala.collection.mutable.ListBuffer
+    implicit val shadow: ListBuffer[List[Int]] = Option.empty[List[Int]]
+  }
 }

--- a/scalafix-tests/output/src/main/scala-2.12/test/explicitResultTypes/ExplicitResultTypesShort.scala
+++ b/scalafix-tests/output/src/main/scala-2.12/test/explicitResultTypes/ExplicitResultTypesShort.scala
@@ -9,10 +9,12 @@ import scala.util.Success
 import scala.collection.immutable.ListSet
 
 object ExplicitResultTypesShort {
-  implicit val x: List[Map[Int,Set[String]]] = List.empty[Map[Int, Set[String]]]
+  implicit val x: List[Map[Int,Set[String]]] = Nil
   implicit val y: HashMap[String,Success[ListBuffer[Int]]] = HashMap.empty[String, Success[ListBuffer[Int]]]
-  implicit def z(x: Int): List[String] = List.empty[String]
+  implicit def z(x: Int): List[String] = Nil
   implicit var zz: ListSet[String] = scala.collection.immutable.ListSet.empty[String]
   implicit val FALSE: Any => Boolean = (x: Any) => false
   implicit def tparam[T](e: T): T = e
+  implicit val opt: Option[Int] = None
+  implicit val seq: Seq[List[Int]] = Nil
 }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSemanticSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSemanticSuite.scala
@@ -248,7 +248,7 @@ class CliSemanticSuite extends BaseCliSuite {
       """
         |package a
         |object NoSemanticdb {
-        |  def foo: Option[Int] = Option.empty[Int]
+        |  def foo: Option[Int] = None
         |}
         |""".stripMargin
     )


### PR DESCRIPTION
Fixes #990

Thank you all for your hard work to make our migrations / linting easier!

This includes the following value conversion in ExplicitResultType rule:

- from Option.empty[T] to None
- from List.empty[T] to Nil
- from Seq.empty[T] to Nil

While I haven't come up with any problem if Seq.empty[T] value is converted to Nil as long as its type is annotated as Seq[T], please let me know if there is any.