### PR TITLE
Revert "Update scalatest to 3.1.0"

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   def metacp = "org.scalameta" %% "metacp" % scalametaV
   def semanticdbPluginLibrary = "org.scalameta" % "semanticdb-scalac-core" % scalametaV cross CrossVersion.full
   def scalameta = "org.scalameta" %% "scalameta" % scalametaV
-  def scalatest = "org.scalatest" %% "scalatest" % "3.1.0"
+  def scalatest = "org.scalatest" %% "scalatest" % "3.0.8"
   def scalacheck = "org.scalacheck" %% "scalacheck" % "1.14.2"
 
   def testsDeps = List(

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/DiffAssertions.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/DiffAssertions.scala
@@ -5,8 +5,8 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.TimeZone
 
+import org.scalatest.FunSuiteLike
 import org.scalatest.exceptions.TestFailedException
-import org.scalatest.funsuite.AnyFunSuiteLike
 
 object DiffAssertions {
   def compareContents(original: String, revised: String): String = {
@@ -34,7 +34,7 @@ object DiffAssertions {
   }
 }
 
-trait DiffAssertions extends AnyFunSuiteLike {
+trait DiffAssertions extends FunSuiteLike {
 
   def assertEqual[A](a: A, b: A): Unit = {
     assert(a === b)

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
@@ -2,6 +2,7 @@ package scalafix.testkit
 
 import java.nio.charset.StandardCharsets
 import org.scalatest.BeforeAndAfterAll
+import org.scalatest.FunSuite
 import org.scalatest.exceptions.TestFailedException
 import scala.meta._
 import scala.meta.internal.io.FileIO
@@ -13,13 +14,12 @@ import scalafix.internal.testkit.EndOfLineAssertExtractor
 import scalafix.internal.testkit.MultiLineAssertExtractor
 import scalafix.v0.SemanticdbIndex
 import java.nio.file.Files
-import org.scalatest.funsuite.AnyFunSuite
 
 /** Construct a test suite for running semantic Scalafix rules. */
 abstract class SemanticRuleSuite(
     val props: TestkitProperties,
     val isSaveExpect: Boolean
-) extends AnyFunSuite
+) extends FunSuite
     with DiffAssertions
     with BeforeAndAfterAll { self =>
 

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SyntacticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SyntacticRuleSuite.scala
@@ -1,17 +1,17 @@
 package scalafix.testkit
 
+import org.scalatest.FunSuiteLike
 import org.scalatest.Tag
 import scala.meta._
 import scalafix.syntax._
 import scalafix.v0._
-import org.scalatest.funsuite.AnyFunSuiteLike
 
 /** Utility to unit test syntactic rules
  *
  * @param rule the default rule to use from `check`/`checkDiff`.
  */
 class SyntacticRuleSuite(rule: Rule = Rule.empty)
-    extends AnyFunSuiteLike
+    extends FunSuiteLike
     with DiffAssertions {
 
   def check(name: String, original: String, expected: String): Unit = {


### PR DESCRIPTION
This reverts commit 78c9d049e2ccd2536519c764135a59e80eebb604.

ScalaTest v3.1 has several breaking changes that makes the latest Scalafix integration fail in Pants. I'm reverting this upgrade for now since the ScalaTest upgrade was done without much thought (it wasn't even mentioned in the release notes). We'll need to find another long-term solution to deal with this situation, either require clients to upgrade to ScalaTest 3.1 (which is a tall order for large codebases) or use another testing framework in Scalafix testkit. 