### PR TITLE
Support literal types

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/internal/config/ParserConfig.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/config/ParserConfig.scala
@@ -6,11 +6,13 @@ import metaconfig._
 import scala.meta.Dialect
 
 case class ParserConfig(
+    literalTypes: Boolean = true,
     trailingCommas: Boolean = true,
     inlineKeyword: Boolean = false
 ) {
 
-  private val dialect = scala.meta.dialects.Scala212.copy(
+  private val dialect = scala.meta.dialects.Scala213.copy(
+    allowLiteralTypes = literalTypes,
     allowTrailingCommas = trailingCommas,
     allowInlineMods = inlineKeyword,
     allowInlineIdents = !inlineKeyword

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/DiffAssertions.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/DiffAssertions.scala
@@ -10,9 +10,11 @@ import org.scalatest.exceptions.TestFailedException
 
 object DiffAssertions {
   def compareContents(original: String, revised: String): String = {
-    "".lines
     def splitLines(s: String) =
-      s.trim.replaceAllLiterally("\r\n", "\n").split("\n")
+      s.trim
+        .replaceAllLiterally("\r\n", "\n")
+        .replace(" +$", "")
+        .split("\n")
     compareContents(splitLines(original), splitLines(revised))
   }
 

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
@@ -40,6 +40,7 @@ abstract class SemanticRuleSuite(
   private def scalaVersionDirectory: Option[String] =
     if (scalaVersion.startsWith("2.11")) Some("scala-2.11")
     else if (scalaVersion.startsWith("2.12")) Some("scala-2.12")
+    else if (scalaVersion.startsWith("2.13")) Some("scala-2.13")
     else None
 
   def evaluateTestBody(diffTest: RuleTest): Unit = {

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SyntacticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SyntacticRuleSuite.scala
@@ -5,6 +5,7 @@ import org.scalatest.Tag
 import scala.meta._
 import scalafix.syntax._
 import scalafix.v0._
+import scalafix.internal.config.ScalafixConfig
 
 /** Utility to unit test syntactic rules
  *
@@ -60,9 +61,10 @@ class SyntacticRuleSuite(rule: Rule = Rule.empty)
       testTags: Tag*
   ): Unit = {
     test(original.label, testTags: _*) {
-      val ctx = RuleCtx(original.parse[Source].get)
+      val dialect = ScalafixConfig.default.parser.dialectForFile("Source.scala")
+      val ctx = RuleCtx(dialect(original).parse[Source].get)
       val obtained = rule.diff(ctx)
-      assert(obtained == expected)
+      assertNoDiff(obtained, expected)
     }
   }
 }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/DialectSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/DialectSuite.scala
@@ -1,0 +1,38 @@
+package scalafix.tests.core
+
+import scala.meta._
+import scalafix.v0.Rule
+import scalafix.testkit.SyntacticRuleSuite
+import scalafix.internal.tests.utils.SkipWindows
+
+class DialectSuite extends SyntacticRuleSuite {
+
+  val original: String =
+    """|object LiteralType {
+       |  val x: 41 = 41
+       |}
+       |""".stripMargin
+
+  val LiteralType: Rule = Rule.syntactic("LiteralType") { ctx =>
+    ctx.tree.collect {
+      case lit @ Lit.Int(n) =>
+        ctx.replaceTree(lit, (n + 1).toString)
+    }.asPatch
+  }
+
+  checkDiff(
+    LiteralType,
+    Input.String(original),
+    """
+      |--- Input.String('<object Lit...>')
+      |+++ Input.String('<object Lit...>')
+      |@@ -1,3 +1,3 @@
+      | object LiteralType {
+      |-  val x: 41 = 41
+      |+  val x: 42 = 42
+      | }
+      |""".stripMargin,
+    SkipWindows
+  )
+
+}


### PR DESCRIPTION
Previously, Scalafix failed to parse sources that used literal types,
which got introduced in 2.13.  Now, Scalafix uses the correct parser
dialect so that literal types are understood correctly. Fixes #1045