### PR TITLE
Clarify ExplicitResultTypesConfigSuite config error message

### DIFF
--- a/scalafix-docs/src/main/scala/scalafix/docs/PatchDocs.scala
+++ b/scalafix-docs/src/main/scala/scalafix/docs/PatchDocs.scala
@@ -103,10 +103,7 @@ object PatchDocs {
     "-Ywarn-unused",
     "-P:semanticdb:synthetics:on"
   )
-  lazy val classpath = ClasspathOps
-    .getURLs(this.getClass().getClassLoader())
-    .map(p => Paths.get(p.toURI()))
-    .mkString(File.pathSeparator)
+  lazy val classpath = ClasspathOps.getCurrentClasspath
   lazy val compiler =
     InteractiveSemanticdb.newCompiler(classpath, scalacOptions)
   lazy val symtab =

--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ClasspathOps.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ClasspathOps.scala
@@ -38,16 +38,14 @@ object ClasspathOps {
 
   def thisClasspath: Classpath = {
     Classpath(
-      thisClassLoader.getURLs.iterator
+      getURLs(this.getClass().getClassLoader())
         .map(url => AbsolutePath(Paths.get(url.toURI)))
         .toList
     )
   }
 
   def getCurrentClasspath: String = {
-    this.getClass.getClassLoader
-      .asInstanceOf[URLClassLoader]
-      .getURLs
+    getURLs(this.getClass.getClassLoader)
       .map(_.getFile)
       .mkString(File.pathSeparator)
   }

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/ExplicitResultTypes.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/ExplicitResultTypes.scala
@@ -59,11 +59,11 @@ final class ExplicitResultTypes(
         }
       }
     if (config.scalacClasspath.nonEmpty && config.scalaVersion != supportedScalaVersion) {
-      Configured.typeMismatch(
-        s"scalaVersion=${Properties.versionNumberString}",
-        Conf.Obj("scalaVersion" -> Conf.Str(config.scalaVersion))
+      Configured.error(
+        s"The ExplicitResultTypes rule only supports the Scala version '$supportedScalaVersion'. " +
+          s"To fix this problem, either remove `ExplicitResultTypes` from .scalafix.conf or change the Scala version " +
+          s"in your build to match exactly '$supportedScalaVersion'."
       )
-
     } else {
       config.conf // Support deprecated explicitReturnTypes config
         .getOrElse("explicitReturnTypes", "ExplicitResultTypes")(

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ExplicitResultTypesConfigSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ExplicitResultTypesConfigSuite.scala
@@ -1,0 +1,19 @@
+package scalafix.tests.config
+
+import org.scalatest.FunSuite
+import scalafix.internal.rule._
+import scalafix.v1.Configuration
+import scalafix.internal.reflect.ClasspathOps
+
+class ExplicitResultTypesConfigSuite extends FunSuite {
+  test("Unsupported Scala version") {
+    val scalaVersion = "2.12.0"
+    val classpath = ClasspathOps.thisClasspath.entries
+    val config = new ExplicitResultTypes().withConfiguration(
+      Configuration()
+        .withScalaVersion(scalaVersion)
+        .withScalacClasspath(classpath)
+    )
+    assert(config.isNotOk)
+  }
+}


### PR DESCRIPTION
We have had several reported issues about Scalafix not working due to
the 2.12.11 requirement of the ExplicitResultTypes rule. This commit
updates the error message to explain the problem and include
instructions on how to fix this problem.