### PR TITLE
include semanticEnabled settings in installation

### DIFF
--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -82,7 +82,7 @@ following settings to `build.sbt`.
  )
 ```
 
-- sbt 1.2 or less
+- all sbt versions
 
 ```diff
  // build.sbt

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -63,10 +63,9 @@ is not enabled for this project. The second error says `RemoveUnused` requires
 the Scala compiler option `-Ywarn-unused`. To fix both problems, add the
 following settings to `build.sbt`. 
 
-- sbt 1.3.x or above
 
 ```diff
- // build.sbt
+ // build.sbt, for sbt 1.3x and newer
  inThisBuild(
    List(
      scalaVersion := "@SCALA212@", // @SCALA211@, or @SCALA213@

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -66,7 +66,7 @@ following settings to `build.sbt`
 ```diff
  // build.sbt
  lazy val myproject = project.settings(
-   scalaVersion := "@SCALA212@", // or @SCALA211@
+   scalaVersion := "@SCALA212@", // @SCALA211@, or @SCALA213@
 +  addCompilerPlugin(scalafixSemanticdb), // enable SemanticDB
    scalacOptions ++= List(
 +    "-Yrangepos",          // required by SemanticDB compiler plugin
@@ -74,6 +74,22 @@ following settings to `build.sbt`
    )
  )
 ```
+
+> To enable SemanticDB related settings for all projects in your build.sbt, 
+> use the following setting which is available from Scalafix 0.9.14 and sbt 1.3.x . 
+> 
+> ```diff
+>  // build.sbt
+> inThisBuild(
+>  List(
+>    scalaVersion := "@SCALA212@", // @SCALA211@, or @SCALA213@
+> +  semanticdbEnabled := true,
+> +  semanticdbIncludeInJar := true,
+> +  semanticdbVersion := scalafixSemanticdb.revision
+>   )
+> )
+> ```
+
 
 For `project/*.scala` files, add
 `import scalafix.sbt.ScalafixPlugin.autoImport._` to the top of the file to

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -65,7 +65,10 @@ following settings to `build.sbt`.
 
 
 ```diff
- // build.sbt, for sbt 1.3x and newer
+ /*
+  * build.sbt, for sbt 1.3x and newer
+  * SemanticDB is enabled for all sub-projects via ThisBuild scope.
+  */
  inThisBuild(
    List(
      scalaVersion := "@SCALA212@", // @SCALA211@, or @SCALA213@
@@ -75,16 +78,25 @@ following settings to `build.sbt`.
  )
 
  lazy val myproject = project.settings(
-   scalacOptions ++= List(
-+    "-Ywarn-unused-import" // required by `RemoveUnused` rule
-   )
+   scalacOptions += "-Ywarn-unused-import" // required by `RemoveUnused` rule
  )
 ```
 
-- all sbt versions
+```diff
+ /*
+  * build.sbt, for sbt 1.3x and newer
+  * SemanticDB is enabled only for a sub-project.
+  */
+ lazy val myproject = project.settings(
+   scalaVersion := "@SCALA212@", // @SCALA211@, or @SCALA213@
++  semanticdbEnabled := true, // enable SemanticDB
++  semanticdbVersion := scalafixSemanticdb.revision, // use Scalafix compatible version
++  scalacOptions += "-Ywarn-unused-import" // required by `RemoveUnused` rule
+ )
+```
 
 ```diff
- // build.sbt
+ // build.sbt, for sbt 1.2.x and older
  lazy val myproject = project.settings(
    scalaVersion := "@SCALA212@", // @SCALA211@, or @SCALA213@
 +  addCompilerPlugin(scalafixSemanticdb), // enable SemanticDB

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -61,7 +61,28 @@ The first error message means the
 [SemanticDB](https://scalameta.org/docs/semanticdb/guide.html) compiler plugin
 is not enabled for this project. The second error says `RemoveUnused` requires
 the Scala compiler option `-Ywarn-unused`. To fix both problems, add the
-following settings to `build.sbt`
+following settings to `build.sbt`. 
+
+- sbt 1.3.x or above
+
+```diff
+ // build.sbt
+ inThisBuild(
+   List(
+     scalaVersion := "@SCALA212@", // @SCALA211@, or @SCALA213@
++    semanticdbEnabled := true, // enable SemanticDB
++    semanticdbVersion := scalafixSemanticdb.revision // use Scalafix compatible version
+   )
+ )
+
+ lazy val myproject = project.settings(
+   scalacOptions ++= List(
++    "-Ywarn-unused-import" // required by `RemoveUnused` rule
+   )
+ )
+```
+
+- sbt 1.2 or less
 
 ```diff
  // build.sbt
@@ -74,22 +95,6 @@ following settings to `build.sbt`
    )
  )
 ```
-
-> To enable SemanticDB related settings for all projects in your build.sbt, 
-> use the following setting which is available from Scalafix 0.9.14 and sbt 1.3.x . 
-> 
-> ```diff
->  // build.sbt
-> inThisBuild(
->  List(
->    scalaVersion := "@SCALA212@", // @SCALA211@, or @SCALA213@
-> +  semanticdbEnabled := true,
-> +  semanticdbIncludeInJar := true,
-> +  semanticdbVersion := scalafixSemanticdb.revision
->   )
-> )
-> ```
-
 
 For `project/*.scala` files, add
 `import scalafix.sbt.ScalafixPlugin.autoImport._` to the top of the file to
@@ -125,6 +130,10 @@ Great! You are all set to use Scalafix with sbt :)
 >   -Xms1G
 >   -Xmx8G
 > ```
+> 
+> You can also use project scoped settings if you don't want to mix 
+> SemanticDB settings with your sub-projects which don't use it, 
+> rather than using ThisBuild scoped settings.
 
 ### Settings and tasks
 


### PR DESCRIPTION
Although I might miss 0.9.14 release, please let me send a PullRequest to include this change to be included in an installation guide column.
https://github.com/scalacenter/sbt-scalafix/pull/89

It would be nicer to be documented,  although I would think we needn't to hurry it.