### PR TITLE
Small update to intro docs

### DIFF
--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -11,7 +11,7 @@ pull request is tested on both Linux and Windows.
 **Java 8 or Java 11.**
 
 **Scala 2.11, 2.12 or 2.13**: Scalafix works only with the latest version of Scala
-2.11,  Scala 2.12 and Scala 2.13. 
+2.11,  Scala 2.12 and Scala 2.13.
 
 | Scalafix  | Scala Compiler                       | Scalameta   |
 | --------- | ------------------------------------ | ----------- |
@@ -60,8 +60,8 @@ RemoveUnused ...
 The first error message means the
 [SemanticDB](https://scalameta.org/docs/semanticdb/guide.html) compiler plugin
 is not enabled for this project. The second error says `RemoveUnused` requires
-the Scala compiler option `-Ywarn-unused`. To fix both problems, add the
-following settings to `build.sbt`
+the Scala compiler option `-Ywarn-unused-import` (or `-Wunused:imports` in
+2.13.x). To fix both problems, add the following settings to `build.sbt`
 
 ```diff
  // build.sbt

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -43,6 +43,9 @@
       "rules/DisableSyntax": {
         "title": "DisableSyntax"
       },
+      "rules/ExplicitResultTypes": {
+        "title": "ExplicitResultTypes"
+      },
       "rules/external-rules": {
         "title": "Using external rules",
         "sidebar_label": "Using external rules"

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,6 @@
     "rename-version": "docusaurus-rename-version"
   },
   "devDependencies": {
-    "docusaurus": "^1.4.0"
+    "docusaurus": "1.14.4"
   }
 }


### PR DESCRIPTION
This pr just adds in a small note to remind users that may be new to scalafix that the `-Ywarn-unused` options differs a bit between scala versions (although that info is in the `RemoveUnused` section.

I also updated docusaurus to the latest, built it locally and ensured that things still look good.

closes #1089