### PR TITLE
improve RemoveUnused rule

### DIFF
--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
@@ -67,6 +67,9 @@ class RemoveUnused(config: RemoveUnusedConfig)
       Patch.empty
     } else {
       doc.tree.collect {
+        case Importer(_, importees)
+            if importees.forall(_.is[Importee.Unimport]) =>
+          importees.map(Patch.removeImportee).asPatch
         case Importer(_, importees) =>
           val hasUsedWildcard = importees.exists {
             case i: Importee.Wildcard => !isUnusedImport(importPosition(i))

--- a/scalafix-tests/input/src/main/scala/test/RemoveUnusedImports.scala
+++ b/scalafix-tests/input/src/main/scala/test/RemoveUnusedImports.scala
@@ -8,6 +8,8 @@ import scala.concurrent.Future
 import scala.util.{Properties, Try}
 import scala.math.{ max, min }
 import scala.util.{Success => Successful}
+import scala.util.{ Random => _ }
+import scala.util.{ Random => _, Left => _, Right => _}
 import scala.concurrent.ExecutionContext
 import scala.runtime.{RichBoolean}
 import scala.concurrent.// formatting caveat


### PR DESCRIPTION
I think `importees` can be remove if `forall(_.is[Importee.Unimport])`