### PR TITLE
align behavior with semanticdb-scalac: last arg wins

### DIFF
--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
@@ -336,7 +336,8 @@ case class Args(
   def semanticdbOption(name: String): Option[String] = {
     val flag = s"-P:semanticdb:$name:"
     scalacOptions
-      .find(_.startsWith(flag))
+      .filter(_.startsWith(flag))
+      .lastOption
       .map(_.stripPrefix(flag))
   }
 

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSemanticSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSemanticSuite.scala
@@ -173,6 +173,8 @@ class CliSemanticSuite extends BaseCliSuite {
         props.inputClasspath.entries.partition(_.isDirectory)
       Array(
         s"--scalacOptions",
+        s"-P:semanticdb:targetroot:shouldBeIgnored",
+        s"--scalacOptions",
         s"-P:semanticdb:targetroot:${targetroot.toString()}",
         "--classpath",
         Classpath(jars).syntax


### PR DESCRIPTION
Should fix https://github.com/scalacenter/scalafix/issues/1110, as failure to look up the target root triggers the presentation compiler, with a version that might not match the bytecode injected (see https://github.com/scalacenter/scalafix/issues/998).

The `SemanticDBPlugin` from sbt 1.3.x duplicates the `targetroot` option on `Test` (or any configuration that extends one where scalafix is enabled) via parent configuration delegation.: https://github.com/sbt/sbt/blob/a1b54d027a87654cbc782270872afc1b4c5a8852/main/src/main/scala/sbt/plugins/SemanticdbPlugin.scala#L42-L45.

In that case, `semanticdb-scalac` picks the last: https://github.com/scalameta/scalameta/blob/de206a796c7558f0ceb8bf3a557f3296f0ac34de/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ConfigOps.scala#L105-L106, while scalafix was picking the first.