### PR TITLE
clarify syntax of --tool-classpath

### DIFF
--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
@@ -149,7 +149,7 @@ case class Args(
     )
     exclude: List[PathMatcher] = Nil,
     @Description(
-      "Additional classpath for compiling and classloading custom rules."
+      "Additional classpath for compiling and classloading custom rules, as a set of filesystem paths, separated by ':' on Unix or ';' on Windows."
     )
     toolClasspath: URLClassLoader = ClasspathOps.thisClassLoader,
     @Description("The encoding to use for reading/writing files")


### PR DESCRIPTION
* I naively assumed a `URLClassLoader` would require URL(s), and it did work for a while (the `file:` prefix is supported in `java.nio.file.Paths.get()`), until my path contained '%' which was not supposed to be escaped
* Seeing that repeating the argument did not work, I had to look up the source code to figure out the usage of a single, `java.ioFile.pathSeparator`-separated argument value