### PR TITLE
Welcome Brice Jaglin to the team!

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Head over here: https://scalacenter.github.io/scalafix/
 
 The current maintainers (people who can merge pull requests) are:
 
+- Brice Jaglin - [`@bjaglin`](https://github.com/bjaglin)
 - Gabriele Petronella - [`@gabro`](https://github.com/gabro)
 - Guillaume Massé - [`@MasseGuillaume`](https://github.com/MasseGuillaume)
 - Ólafur Páll Geirsson - [`@olafurpg`](https://github.com/olafurpg)
@@ -23,6 +24,4 @@ The current maintainers (people who can merge pull requests) are:
 
 ## Contributing
 
-Contributions are welcome!
-See [CONTRIBUTING.md](CONTRIBUTING.md).
-
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -232,6 +232,12 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
     organization := "ch.epfl.scala",
     developers ++= List(
       Developer(
+        "bjaglin",
+        "Brice Jaglin",
+        "bjaglin@teads.tv",
+        url("https://github.com/bjaglin")
+      ),
+      Developer(
         "xeno-by",
         "Eugene Burmako",
         "eugene.burmako@gmail.com",


### PR DESCRIPTION
Brice has made a lot of fantastic contributions lately improving the
experience of using scalafix for both end users and rule authors.
I'm really happy to welcome him as a scalafix maintainer!