### PR TITLE
expose scalafix 2.13 patch version in scalafix-interfaces

### DIFF
--- a/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixImpl.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixImpl.scala
@@ -27,5 +27,7 @@ final class ScalafixImpl extends Scalafix {
     Versions.scala211
   override def scala212(): String =
     Versions.scala212
+  override def scala213(): String =
+    Versions.scala213
 
 }

--- a/scalafix-interfaces/src/main/java/scalafix/interfaces/Scalafix.java
+++ b/scalafix-interfaces/src/main/java/scalafix/interfaces/Scalafix.java
@@ -53,6 +53,11 @@ public interface Scalafix {
      */
     String scala212();
 
+    /**
+     * The most recent Scala 2.13 version in {@link #supportedScalaVersions()}
+     */
+    String scala213();
+
 
 
     /**


### PR DESCRIPTION
Follow-up of https://github.com/scalacenter/scalafix/pull/1118