### PR TITLE
sbt scalafixResolvers: coursiersmall -> coursierapi

### DIFF
--- a/docs/developers/tutorial.md
+++ b/docs/developers/tutorial.md
@@ -747,11 +747,10 @@ custom repository like Bintray or a private Nexus.
 
 ```scala
 // build.sbt
-import coursierapi.{MavenRepository => MavenR, IvyRepository => IvyR}
 scalafixResolvers.in(ThisBuild) ++= List(
-  MavenR.of("https://dl.bintray.com/scalacenter/releases"),
-  MavenR.of("https://oss.sonatype.org/content/repositories/snapshots"),
-  IvyR.of("https://dl.bintray.com/sbt/sbt-plugin-releases")
+  coursierapi.MavenRepository.of("https://dl.bintray.com/scalacenter/releases"),
+  coursierapi.MavenRepository.of("https://oss.sonatype.org/content/repositories/snapshots"),
+  coursierapi.IvyRepository.of("https://dl.bintray.com/sbt/sbt-plugin-releases")
 )
 ```
 

--- a/docs/developers/tutorial.md
+++ b/docs/developers/tutorial.md
@@ -747,13 +747,11 @@ custom repository like Bintray or a private Nexus.
 
 ```scala
 // build.sbt
-import com.geirsson.coursiersmall.{Repository => R}
+import coursierapi.{MavenRepository => MavenR, IvyRepository => IvyR}
 scalafixResolvers.in(ThisBuild) ++= List(
-  R.SonatypeSnapshots,
-  R.bintrayRepo("scalacenter", "releases"),
-  R.bintrayIvyRepo("sbt", "sbt-plugin-releases"),
-  new R.Maven("https://oss.sonatype.org/content/repositories/snapshots/"),
-  new R.Ivy(s"https://dl.bintray.com/sbt/sbt-plugin-releases/")
+  MavenR.of("https://dl.bintray.com/scalacenter/releases"),
+  MavenR.of("https://oss.sonatype.org/content/repositories/snapshots"),
+  IvyR.of("https://dl.bintray.com/sbt/sbt-plugin-releases")
 )
 ```
 


### PR DESCRIPTION
Merge only when https://github.com/scalacenter/sbt-scalafix/pull/123 is released.

The `coursier-interface` facade is pretty poor when it comes to resolver helpers.