### PR TITLE
delay doc publishing until a release is tagged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,10 @@ jobs:
       - run: sbt ci-213-windows
         shell: bash
   checks:
-    name: Scalafmt
+    name: Scalafmt & docs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v7
       - run: ./scalafmt --test
+      - run: sbt docs/mdoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 jdk:
 - openjdk8
 stages:
-  - name: test
   - name: release
-    if: (branch = master AND type = push) OR (tag IS present)
+    if: tag IS present
 before_install:
   - if [ "$TRAVIS_BUILD_STAGE_NAME" = 'Release'  ]; then
       curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.9.4;


### PR DESCRIPTION
New features/deprecations should not be publicly documented until a corresponding release is cut. `mdoc` is now run as part of the CI workflow to limit the risk of `docs/docusaurusPublishGhpages` failing at release time (would a doc change breaking mdoc be visible only on master now?).

This came up as I realized I should hold https://github.com/scalacenter/scalafix/pull/1155 & https://github.com/scalacenter/scalafix/pull/1160 (granted, it's not a big deal if I don't) after seeing the `SNAPSHOT` version in https://scalacenter.github.io/scalafix/docs/users/installation.html#help. Holding documentation PRs is hard to manage - we would need GitHub milestones to handle them properly?.

Once https://github.com/scalacenter/scalafix/issues/1146 is done, the concept of release will be local, so another strategy will need to be found.