### PR TITLE
respect -Xlint or -Xlint:unused scalac options in RemoveUnused rule

### DIFF
--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
@@ -27,15 +27,17 @@ class RemoveUnused(config: RemoveUnusedConfig)
   override def isRewrite: Boolean = true
 
   private def warnUnusedPrefix = List("-Wunused", "-Ywarn-unused")
+  private def warnUnusedString = List("-Xlint", "-Xlint:unused")
   override def withConfiguration(config: Configuration): Configured[Rule] = {
     val hasWarnUnused = config.scalacOptions.exists(option =>
-      warnUnusedPrefix.exists(prefix => option.startsWith(prefix))
+      warnUnusedPrefix.exists(prefix => option.startsWith(prefix)) ||
+        warnUnusedString.contains(option)
     )
     if (!hasWarnUnused) {
       Configured.error(
         s"""|The Scala compiler option "-Ywarn-unused" is required to use RemoveUnused.
             |To fix this problem, update your build to use at least one Scala compiler
-            |option that starts with -Ywarn-unused or -Wunused (2.13 only)""".stripMargin
+            |option like -Ywarn-unused, -Xlint:unused, or -Wunused (2.13 only).""".stripMargin
       )
     } else {
       config.conf

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
@@ -37,7 +37,7 @@ class RemoveUnused(config: RemoveUnusedConfig)
       Configured.error(
         s"""|The Scala compiler option "-Ywarn-unused" is required to use RemoveUnused.
             |To fix this problem, update your build to use at least one Scala compiler
-            |option like -Ywarn-unused, -Xlint:unused, or -Wunused (2.13 only).""".stripMargin
+            |option like -Ywarn-unused, -Xlint:unused (2.12.2 or above), or -Wunused (2.13 only)""".stripMargin
       )
     } else {
       config.conf


### PR DESCRIPTION
This PullRequests suppress RemoveUnused configuration error if scalac options contain `-Xlint` or `-Xlint:unused`, both of which generate and add unused diagnostics message string into SemanticDB.

Note: There might be discussions at the following point.

## -Xlint linting options notation
Currently this PullRequest supports no explicit linting option (just `-Xlint`) or only a linting option per a line (`-Xlint:unused`) for implementation simplicity. IMHO this covers majority of `-Xlint` usage, as long as I check with "-Xlint" GitHub search.

This PR does NOT support multiple linting options together like `-Xlint:unused,constant`, wildcard like `-Xlint:_`, nor unary operator like `-Xlint:-constant,_`.

If we want to support multiple linting options notation or else above, it may need to introduce a simple scalac option parser (or just check in a naive way, like 
 `option.startsWith("-Xlint:") && (option.contains("_") || option.contains("unused")) && !option.contains("-unused")` ?).