### PR TITLE
scalafix-interfaces: advise against using classloader overloads

### DIFF
--- a/scalafix-interfaces/src/main/java/scalafix/interfaces/Scalafix.java
+++ b/scalafix-interfaces/src/main/java/scalafix/interfaces/Scalafix.java
@@ -148,6 +148,9 @@ public interface Scalafix {
      * classload external rules must have the provided classloader as ancestor to share a common loaded instance
      * of `scalafix-core`, and therefore must have been compiled against the same Scala binary version as
      * the one in the classLoader provided here.
+     * <p>
+     * Unless you have an advanced use-case, prefer the high-level overloads that cannot cause runtime errors
+     * due to an invalid classloader hierarchy.
      *
      * @param classLoader Classloader containing the full Scalafix classpath, including the scalafix-cli module. To be
      *                    able to run advanced semantic rules using the Scala Presentation Compiler such as

--- a/scalafix-interfaces/src/main/java/scalafix/interfaces/ScalafixArguments.java
+++ b/scalafix-interfaces/src/main/java/scalafix/interfaces/ScalafixArguments.java
@@ -67,9 +67,11 @@ public interface ScalafixArguments {
     /**
      * @param toolClasspath Custom classpath for classloading and compiling external rules.
      *                      Must be a URLClassLoader (not regular ClassLoader) to support
-     *                      compiling sources. This classloader should have as ancestor the
+     *                      compiling sources. This classloader must have as ancestor the
      *                      classloader of the {@link Scalafix} instance that returned this
-     *                      {@link ScalafixArguments} instance.
+     *                      {@link ScalafixArguments} instance. Unless you have an advanced
+     *                      use-case, prefer the high-level overloads that cannot cause
+     *                      runtime errors due to an invalid classloader hierarchy.
      */
     ScalafixArguments withToolClasspath(URLClassLoader toolClasspath);
 


### PR DESCRIPTION
https://github.com/joan38/mill-scalafix/pull/3#discussion_r440642136

As mentioned there, I think it's still interesting to keep these overloads for power-users.