### PR TITLE
Fix AnchorPatches test

### DIFF
--- a/scalafix-tests/input/src/main/scala/test/AnchorPatches.scala
+++ b/scalafix-tests/input/src/main/scala/test/AnchorPatches.scala
@@ -5,7 +5,7 @@ ExplicitResultTypes.memberVisibility = [Public]
 unsafeShortenNames = true
 ExplicitResultTypes.unsafeShortenNames = true
  */
-package test.escapeHatch
+package test
 
 import scala.collection.mutable
 import scala.collection.immutable // scalafix:ok RemoveUnusedImports

--- a/scalafix-tests/output/src/main/scala/test/AnchorPatches.scala
+++ b/scalafix-tests/output/src/main/scala/test/AnchorPatches.scala
@@ -1,4 +1,4 @@
-package test.escapeHatch
+package test
 
 import scala.collection.immutable // scalafix:ok RemoveUnusedImports
 


### PR DESCRIPTION
Trying to re-enable this test for all scala versions. Right now it fails for 2.13. This test uses RemoveUnused Rule and specifically here will remove imports. This test requires `-Wunused:imports` in 2.13.

After debugging in 2.13, I can see that `scalacOptions` that is set in `TestkitProperties.scala` file is equal to `List(-target:jvm-1.8, -Wunused:imports, -encoding, UTF-8, -feature, -unchecked)`. So it's supposed to work, but it's not. In fact, there are no diagnostic in SemanticDocument of this file, so the rule is not able to remove unused imports. 

* Weirdly removing `scalacOptions += "-Ywarn-unused" ` from `build.sbt` makes the test run, but many other tests will fail like RemoveUnusedStatements (still in 2.13)

I am not able to understand why changing `build.sbt` makes the test passes... I am not sure which scalaOptions are used to compile and get SemanticDocument for this test.


