### PR TITLE
make it possible to use testkit with ScalaTest 3.2.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,1 +1,5 @@
 pullRequests.frequency = "0 0 1,15 * ?"
+updates.pin = [
+  # don't bump, to avoid forcing breaking changes on clients via eviction
+  { groupId = "org.scalatest", artifactId = "scalatest", version = "3.0.8" },
+]

--- a/build.sbt
+++ b/build.sbt
@@ -182,7 +182,7 @@ lazy val unit = project
     libraryDependencies ++= List(
       jgit,
       semanticdbPluginLibrary,
-      scalatest,
+      scalatest.withRevision("3.2.0"), // make sure testkit clients can use recent 3.x versions
       "org.scalameta" %% "testkit" % scalametaV
     ),
     compileInputs.in(Compile, compile) := {

--- a/docs/developers/setup.md
+++ b/docs/developers/setup.md
@@ -118,11 +118,14 @@ artifact
 cs fetch ch.epfl.scala:scalafix-testkit_@SCALA212@:@VERSION@
 ```
 
-Next, create a test suite that extends the class `SemanticRuleSuite`
+Next, create a test suite that extends `AbstractSemanticRuleSuite`
 
 ```scala
 package myproject
-class MyTests extends scalafix.testkit.SemanticRuleSuite {
+class MyTests
+    extends scalafix.testkit.AbstractSemanticRuleSuite
+    with org.scalatest.funsuite.AnyFunSuiteLike {
+
   runAllTests()
 }
 ```

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,8 @@ object Dependencies {
   def metacp = "org.scalameta" %% "metacp" % scalametaV
   def semanticdbPluginLibrary = "org.scalameta" % "semanticdb-scalac-core" % scalametaV cross CrossVersion.full
   def scalameta = "org.scalameta" %% "scalameta" % scalametaV
-  def scalatest = "org.scalatest" %% "scalatest" % "3.0.8"
+  def scalatest =
+    "org.scalatest" %% "scalatest" % "3.0.8" // don't bump, to avoid forcing breaking changes on clients via eviction
   def bijectionCore = "com.twitter" %% "bijection-core" % "0.9.7"
   def scalacheck = "org.scalacheck" %% "scalacheck" % "1.14.3"
   def collectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.6"

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -52,6 +52,8 @@ object Mima {
       ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.testkit.SemanticRuleSuite.LintAssertion"),
       ProblemFilters.exclude[MissingClassProblem]("scalafix.testkit.package$"),
       ProblemFilters.exclude[MissingClassProblem]("scalafix.testkit.package"),
+      ProblemFilters.exclude[MissingTypesProblem]("scalafix.testkit.DiffAssertions"),
+      ProblemFilters.exclude[MissingTypesProblem]("scalafix.testkit.SemanticRuleSuite"),
       // marked private[scalafix]
       ProblemFilters.exclude[ReversedMissingMethodProblem]("scalafix.rule.RuleCtx.printLintMessage"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("scalafix.rule.RuleCtx.filter"),

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/AbstractSemanticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/AbstractSemanticRuleSuite.scala
@@ -1,0 +1,101 @@
+package scalafix.testkit
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+import org.scalatest.exceptions.TestFailedException
+import org.scalatest.{BeforeAndAfterAll, Suite, TestRegistration}
+import scalafix.internal.reflect.ClasspathOps
+import scalafix.internal.testkit.{AssertDiff, CommentAssertion}
+
+import scala.meta._
+import scala.meta.internal.io.FileIO
+
+/** Construct a test suite for running semantic Scalafix rules.
+ * <p>
+ * Mix-in FunSuiteLike (ScalaTest 3.0), AnyFunSuiteLike (ScalaTest 3.1+) or
+ * the testing style of your choice if you add your own tests.
+ */
+abstract class AbstractSemanticRuleSuite(
+    val props: TestkitProperties,
+    val isSaveExpect: Boolean
+) extends Suite
+    with TestRegistration
+    with DiffAssertions
+    with BeforeAndAfterAll { self =>
+
+  def this(props: TestkitProperties) = this(props, isSaveExpect = false)
+  def this() = this(TestkitProperties.loadFromResources())
+
+  private def scalaVersion: String = scala.util.Properties.versionNumberString
+  private def scalaVersionDirectory: Option[String] =
+    if (scalaVersion.startsWith("2.11")) Some("scala-2.11")
+    else if (scalaVersion.startsWith("2.12")) Some("scala-2.12")
+    else if (scalaVersion.startsWith("2.13")) Some("scala-2.13")
+    else None
+
+  def evaluateTestBody(diffTest: RuleTest): Unit = {
+    val (rule, sdoc) = diffTest.run.apply()
+    rule.beforeStart()
+    val (fixed, messages) =
+      try rule.semanticPatch(sdoc, suppress = false)
+      finally rule.afterComplete()
+    val tokens = fixed.tokenize.get
+    val obtained = SemanticRuleSuite.stripTestkitComments(tokens)
+    val expected = diffTest.path.resolveOutput(props) match {
+      case Right(file) =>
+        FileIO.slurp(file, StandardCharsets.UTF_8)
+      case Left(err) =>
+        if (fixed == sdoc.input.text) {
+          // rule is a linter, no need for an output file.
+          obtained
+        } else {
+          fail(err)
+        }
+    }
+
+    val expectedLintMessages = CommentAssertion.extract(sdoc.tokens)
+    val diff = AssertDiff(messages, expectedLintMessages)
+
+    if (diff.isFailure) {
+      println("###########> Lint       <###########")
+      println(diff.toString)
+    }
+
+    val result = compareContents(obtained, expected)
+    if (result.nonEmpty) {
+      println("###########> Diff       <###########")
+      println(error2message(obtained, expected))
+    }
+
+    val isTestFailure = result.nonEmpty || diff.isFailure
+    diffTest.path.resolveOutput(props) match {
+      case Right(output) if isTestFailure && isSaveExpect =>
+        println(s"promoted expect test: $output")
+        Files.write(output.toNIO, obtained.getBytes(StandardCharsets.UTF_8))
+      case _ =>
+    }
+
+    if (isTestFailure) {
+      throw new TestFailedException("see above", 0)
+    }
+  }
+
+  def runOn(diffTest: RuleTest): Unit = {
+    registerTest(diffTest.path.testName) {
+      evaluateTestBody(diffTest)
+    }
+  }
+
+  lazy val testsToRun = {
+    val symtab = ClasspathOps.newSymbolTable(props.inputClasspath)
+    val classLoader = ClasspathOps.toClassLoader(props.inputClasspath)
+    val tests = TestkitPath.fromProperties(props)
+    tests.map { test =>
+      RuleTest.fromPath(props, test, classLoader, symtab)
+    }
+  }
+  def runAllTests(): Unit = {
+    testsToRun.foreach(runOn)
+  }
+}

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/AbstractSyntacticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/AbstractSyntacticRuleSuite.scala
@@ -1,0 +1,74 @@
+package scalafix.testkit
+
+import org.scalatest.{Suite, TestRegistration}
+import org.scalatest.Tag
+import scala.meta._
+import scalafix.syntax._
+import scalafix.v0._
+import scalafix.internal.config.ScalafixConfig
+
+/** Utility to unit test syntactic rules.
+ * <p>
+ * Mix-in FunSuiteLike (ScalaTest 3.0), AnyFunSuiteLike (ScalaTest 3.1+) or
+ * the testing style of your choice if you add your own tests.
+ *
+ * @param rule the default rule to use from `check`/`checkDiff`.
+ */
+abstract class AbstractSyntacticRuleSuite(rule: Rule = Rule.empty)
+    extends Suite
+    with TestRegistration
+    with DiffAssertions {
+
+  def check(name: String, original: String, expected: String): Unit = {
+    check(rule, name, original, expected)
+  }
+
+  def check(
+      rule: Rule,
+      name: String,
+      original: String,
+      expected: String
+  ): Unit = {
+    check(rule, name, original, expected, Seq(): _*)
+  }
+
+  def check(
+      rule: Rule,
+      name: String,
+      original: String,
+      expected: String,
+      testTags: Tag*
+  ): Unit = {
+    registerTest(name, testTags: _*) {
+      import scala.meta._
+      val obtained = rule.apply(Input.String(original))
+      assertNoDiff(obtained, expected)
+    }
+  }
+
+  def checkDiff(original: Input, expected: String): Unit = {
+    checkDiff(rule, original, expected, Seq(): _*)
+  }
+
+  def checkDiff(original: Input, expected: String, testTags: Tag*): Unit = {
+    checkDiff(rule, original, expected, testTags: _*)
+  }
+
+  def checkDiff(rule: Rule, original: Input, expected: String): Unit = {
+    checkDiff(rule, original, expected, Seq(): _*)
+  }
+
+  def checkDiff(
+      rule: Rule,
+      original: Input,
+      expected: String,
+      testTags: Tag*
+  ): Unit = {
+    registerTest(original.label, testTags: _*) {
+      val dialect = ScalafixConfig.default.parser.dialectForFile("Source.scala")
+      val ctx = RuleCtx(dialect(original).parse[Source].get)
+      val obtained = rule.diff(ctx)
+      assertNoDiff(obtained, expected)
+    }
+  }
+}

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/DiffAssertions.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/DiffAssertions.scala
@@ -5,7 +5,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.TimeZone
 
-import org.scalatest.FunSuiteLike
+import org.scalatest.Suite
 import org.scalatest.exceptions.TestFailedException
 
 object DiffAssertions {
@@ -36,7 +36,7 @@ object DiffAssertions {
   }
 }
 
-trait DiffAssertions extends FunSuiteLike {
+trait DiffAssertions extends Suite {
 
   def assertEqual[A](a: A, b: A): Unit = {
     assert(a === b)

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
@@ -1,28 +1,23 @@
 package scalafix.testkit
 
-import java.nio.charset.StandardCharsets
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.FunSuite
-import org.scalatest.exceptions.TestFailedException
 import scala.meta._
-import scala.meta.internal.io.FileIO
-import scalafix.internal.reflect.ClasspathOps
+import org.scalatest.FunSpecLike
 import scalafix.internal.reflect.RuleCompiler
-import scalafix.internal.testkit.AssertDiff
-import scalafix.internal.testkit.CommentAssertion
-import scalafix.internal.testkit.EndOfLineAssertExtractor
-import scalafix.internal.testkit.MultiLineAssertExtractor
+import scalafix.internal.testkit.{
+  EndOfLineAssertExtractor,
+  MultiLineAssertExtractor
+}
 import scalafix.v0.SemanticdbIndex
-import java.nio.file.Files
 
-/** Construct a test suite for running semantic Scalafix rules. */
-abstract class SemanticRuleSuite(
-    val props: TestkitProperties,
-    val isSaveExpect: Boolean
-) extends FunSuite
-    with DiffAssertions
-    with BeforeAndAfterAll { self =>
-
+@deprecated(
+  "Use AbstractSemanticRuleSuite with the styling trait of your choice mixed-in (*SpecLike or *SuiteLike)",
+  "0.9.18"
+)
+class SemanticRuleSuite(
+    override val props: TestkitProperties,
+    override val isSaveExpect: Boolean
+) extends AbstractSemanticRuleSuite
+    with FunSpecLike {
   def this(props: TestkitProperties) = this(props, isSaveExpect = false)
   def this() = this(TestkitProperties.loadFromResources())
 
@@ -35,78 +30,6 @@ abstract class SemanticRuleSuite(
       inputSourceroot: AbsolutePath,
       expectedOutputSourceroot: Seq[AbsolutePath]
   ) = this()
-
-  private def scalaVersion: String = scala.util.Properties.versionNumberString
-  private def scalaVersionDirectory: Option[String] =
-    if (scalaVersion.startsWith("2.11")) Some("scala-2.11")
-    else if (scalaVersion.startsWith("2.12")) Some("scala-2.12")
-    else if (scalaVersion.startsWith("2.13")) Some("scala-2.13")
-    else None
-
-  def evaluateTestBody(diffTest: RuleTest): Unit = {
-    val (rule, sdoc) = diffTest.run.apply()
-    rule.beforeStart()
-    val (fixed, messages) =
-      try rule.semanticPatch(sdoc, suppress = false)
-      finally rule.afterComplete()
-    val tokens = fixed.tokenize.get
-    val obtained = SemanticRuleSuite.stripTestkitComments(tokens)
-    val expected = diffTest.path.resolveOutput(props) match {
-      case Right(file) =>
-        FileIO.slurp(file, StandardCharsets.UTF_8)
-      case Left(err) =>
-        if (fixed == sdoc.input.text) {
-          // rule is a linter, no need for an output file.
-          obtained
-        } else {
-          fail(err)
-        }
-    }
-
-    val expectedLintMessages = CommentAssertion.extract(sdoc.tokens)
-    val diff = AssertDiff(messages, expectedLintMessages)
-
-    if (diff.isFailure) {
-      println("###########> Lint       <###########")
-      println(diff.toString)
-    }
-
-    val result = compareContents(obtained, expected)
-    if (result.nonEmpty) {
-      println("###########> Diff       <###########")
-      println(error2message(obtained, expected))
-    }
-
-    val isTestFailure = result.nonEmpty || diff.isFailure
-    diffTest.path.resolveOutput(props) match {
-      case Right(output) if isTestFailure && isSaveExpect =>
-        println(s"promoted expect test: $output")
-        Files.write(output.toNIO, obtained.getBytes(StandardCharsets.UTF_8))
-      case _ =>
-    }
-
-    if (isTestFailure) {
-      throw new TestFailedException("see above", 0)
-    }
-  }
-
-  def runOn(diffTest: RuleTest): Unit = {
-    test(diffTest.path.testName) {
-      evaluateTestBody(diffTest)
-    }
-  }
-
-  lazy val testsToRun = {
-    val symtab = ClasspathOps.newSymbolTable(props.inputClasspath)
-    val classLoader = ClasspathOps.toClassLoader(props.inputClasspath)
-    val tests = TestkitPath.fromProperties(props)
-    tests.map { test =>
-      RuleTest.fromPath(props, test, classLoader, symtab)
-    }
-  }
-  def runAllTests(): Unit = {
-    testsToRun.foreach(runOn)
-  }
 }
 
 object SemanticRuleSuite {

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SyntacticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SyntacticRuleSuite.scala
@@ -1,70 +1,12 @@
 package scalafix.testkit
 
 import org.scalatest.FunSuiteLike
-import org.scalatest.Tag
-import scala.meta._
-import scalafix.syntax._
-import scalafix.v0._
-import scalafix.internal.config.ScalafixConfig
+import scalafix.v0.Rule
 
-/** Utility to unit test syntactic rules
- *
- * @param rule the default rule to use from `check`/`checkDiff`.
- */
+@deprecated(
+  "Use AbstractSyntacticRuleSuite with the styling trait of your choice mixed-in (*SpecLike or *SuiteLike)",
+  "0.9.18"
+)
 class SyntacticRuleSuite(rule: Rule = Rule.empty)
-    extends FunSuiteLike
-    with DiffAssertions {
-
-  def check(name: String, original: String, expected: String): Unit = {
-    check(rule, name, original, expected)
-  }
-
-  def check(
-      rule: Rule,
-      name: String,
-      original: String,
-      expected: String
-  ): Unit = {
-    check(rule, name, original, expected, Seq(): _*)
-  }
-
-  def check(
-      rule: Rule,
-      name: String,
-      original: String,
-      expected: String,
-      testTags: Tag*
-  ): Unit = {
-    test(name, testTags: _*) {
-      import scala.meta._
-      val obtained = rule.apply(Input.String(original))
-      assertNoDiff(obtained, expected)
-    }
-  }
-
-  def checkDiff(original: Input, expected: String): Unit = {
-    checkDiff(rule, original, expected, Seq(): _*)
-  }
-
-  def checkDiff(original: Input, expected: String, testTags: Tag*): Unit = {
-    checkDiff(rule, original, expected, testTags: _*)
-  }
-
-  def checkDiff(rule: Rule, original: Input, expected: String): Unit = {
-    checkDiff(rule, original, expected, Seq(): _*)
-  }
-
-  def checkDiff(
-      rule: Rule,
-      original: Input,
-      expected: String,
-      testTags: Tag*
-  ): Unit = {
-    test(original.label, testTags: _*) {
-      val dialect = ScalafixConfig.default.parser.dialectForFile("Source.scala")
-      val ctx = RuleCtx(dialect(original).parse[Source].get)
-      val obtained = rule.diff(ctx)
-      assertNoDiff(obtained, expected)
-    }
-  }
-}
+    extends AbstractSyntacticRuleSuite(rule)
+    with FunSuiteLike

--- a/scalafix-tests/unit/src/test/scala-2.12/scalafix/tests/cli/InterfacesPropertiesSuite.scala
+++ b/scalafix-tests/unit/src/test/scala-2.12/scalafix/tests/cli/InterfacesPropertiesSuite.scala
@@ -1,9 +1,9 @@
 package scalafix.tests.cli
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scalafix.Versions
 
-class InterfacesPropertiesSuite extends FunSuite with BeforeAndAfterAll {
+class InterfacesPropertiesSuite extends AnyFunSuite with BeforeAndAfterAll {
   val props = new java.util.Properties()
   override def beforeAll(): Unit = {
     val path = "scalafix-interfaces.properties"

--- a/scalafix-tests/unit/src/test/scala-2.12/scalafix/tests/cli/ScalafixImplSuite.scala
+++ b/scalafix-tests/unit/src/test/scala-2.12/scalafix/tests/cli/ScalafixImplSuite.scala
@@ -10,7 +10,7 @@ import java.nio.file.Paths
 import java.util.Collections
 import java.util.Optional
 import coursier._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scala.collection.JavaConverters._
 import scala.meta.io.AbsolutePath
 import scala.meta.io.Classpath
@@ -26,7 +26,7 @@ import scalafix.testkit.DiffAssertions
 import scalafix.{interfaces => i}
 import scala.util.Properties
 
-class ScalafixImplSuite extends FunSuite with DiffAssertions {
+class ScalafixImplSuite extends AnyFunSuite with DiffAssertions {
   def semanticdbPluginPath(): String = {
     val semanticdbscalac = ClasspathOps.thisClassLoader.getURLs.collectFirst {
       case url if url.toString.contains("semanticdb-scalac_") =>

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/AutoClasspathSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/AutoClasspathSuite.scala
@@ -3,10 +3,10 @@ package scalafix.tests.cli
 import java.io.File
 import scala.meta.io.AbsolutePath
 import scala.meta.io.Classpath
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scalafix.internal.reflect.ClasspathOps
 
-class AutoClasspathSuite extends FunSuite {
+class AutoClasspathSuite extends AnyFunSuite {
   test("--classpath=auto") {
     val tmp = File.createTempFile("foo", "bar")
     assert(tmp.delete())

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/BaseCliSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/BaseCliSuite.scala
@@ -18,13 +18,13 @@ import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.BasicFileAttributes
 import scala.meta.io.AbsolutePath
 import scala.meta.io.RelativePath
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scalafix.testkit.TestkitProperties
 import scalafix.tests.util.ScalaVersions
 import scalafix.v1.Main
 
 // extend this class to run custom cli tests.
-trait BaseCliSuite extends FunSuite with DiffAssertions {
+trait BaseCliSuite extends AnyFunSuite with DiffAssertions {
 
   val original: String =
     """|object Main {

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliGitDiffSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliGitDiffSuite.scala
@@ -5,13 +5,13 @@ import java.io.PrintStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 import org.scalatest._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scalafix.cli.ExitStatus
 import scalafix.testkit.DiffAssertions
 import scalafix.internal.tests.utils.{Fs, Git}
 import scalafix.internal.tests.utils.SkipWindows
 
-class CliGitDiffSuite extends FunSuite with DiffAssertions {
+class CliGitDiffSuite extends AnyFunSuite with DiffAssertions {
   gitTest("addition", SkipWindows) { (fs, git, cli) =>
     val oldCode = "old.scala"
     val newCode = "new.scala"

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/config/DisableSyntaxConfigSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/config/DisableSyntaxConfigSuite.scala
@@ -1,13 +1,13 @@
 package scalafix.tests.config
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import metaconfig.Configured
 import metaconfig.Configured.NotOk
 import metaconfig.ConfError
 import metaconfig.typesafeconfig._
 import scalafix.internal.rule._
 
-class DisableSyntaxConfigSuite extends FunSuite {
+class DisableSyntaxConfigSuite extends AnyFunSuite {
   test("Warn about invalid keywords") {
     val rawConfig =
       """|keywords = [

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ExplicitResultTypesConfigSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ExplicitResultTypesConfigSuite.scala
@@ -1,11 +1,11 @@
 package scalafix.tests.config
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scalafix.internal.rule._
 import scalafix.v1.Configuration
 import scalafix.internal.reflect.ClasspathOps
 
-class ExplicitResultTypesConfigSuite extends FunSuite {
+class ExplicitResultTypesConfigSuite extends AnyFunSuite {
   test("Unsupported Scala version") {
     val scalaVersion = "2.12.0"
     val classpath = ClasspathOps.thisClasspath.entries

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/config/GitHubUrlRuleSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/config/GitHubUrlRuleSuite.scala
@@ -3,11 +3,11 @@ package scalafix.tests.config
 import metaconfig.Conf
 import metaconfig.Configured.NotOk
 import metaconfig.Configured.Ok
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scalafix.internal.reflect.GitHubUrlRule
 import scalafix.testkit.DiffAssertions
 
-class GitHubUrlRuleSuite extends FunSuite with DiffAssertions {
+class GitHubUrlRuleSuite extends AnyFunSuite with DiffAssertions {
   def check(original: String, expected: String, ok: Boolean = true): Unit = {
     test((if (ok) "" else "FAIL ") + original) {
       Conf.Str(original) match {

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/BaseSemanticSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/BaseSemanticSuite.scala
@@ -1,7 +1,7 @@
 package scalafix.tests.core
 
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scala.meta._
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.symtab.SymbolTable
@@ -36,7 +36,7 @@ object BaseSemanticSuite {
 }
 
 abstract class BaseSemanticSuite(filename: String)
-    extends FunSuite
+    extends AnyFunSuite
     with BeforeAndAfterAll
     with DiffAssertions {
   var _db: LegacyInMemorySemanticdbIndex = _

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/DialectSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/DialectSuite.scala
@@ -1,11 +1,13 @@
 package scalafix.tests.core
 
+import org.scalatest.funsuite.AnyFunSuiteLike
+
 import scala.meta._
 import scalafix.v0.Rule
-import scalafix.testkit.SyntacticRuleSuite
+import scalafix.testkit.AbstractSyntacticRuleSuite
 import scalafix.internal.tests.utils.SkipWindows
 
-class DialectSuite extends SyntacticRuleSuite {
+class DialectSuite extends AbstractSyntacticRuleSuite with AnyFunSuiteLike {
 
   val original: String =
     """|object LiteralType {

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/EscapeHatchSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/EscapeHatchSuite.scala
@@ -2,7 +2,7 @@ package scalafix.tests.core
 
 import java.nio.file.Paths
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scalafix.internal.config.ScalafixConfig
 import scalafix.internal.diff.{DiffDisable, EmptyDiff, NewFile}
 import scalafix.internal.patch.EscapeHatch
@@ -17,7 +17,7 @@ import scala.meta.{Source, Tree}
 import scala.meta.contrib.AssociatedComments
 import scala.meta.inputs.Input
 
-class EscapeHatchSuite extends FunSuite {
+class EscapeHatchSuite extends AnyFunSuite {
 
   private val noEscapes = Input.String(
     """object Foo"""

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/PatchSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/PatchSuite.scala
@@ -3,14 +3,17 @@ package scalafix.tests.core
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
+
+import org.scalatest.funsuite.AnyFunSuiteLike
+
 import scala.meta._
 import scala.meta.tokens.Token.Ident
 import scalafix.v0.Rule
-import scalafix.testkit.SyntacticRuleSuite
+import scalafix.testkit.AbstractSyntacticRuleSuite
 import scalafix.internal.tests.utils.SkipWindows
 import scalafix.patch.Patch
 
-class PatchSuite extends SyntacticRuleSuite {
+class PatchSuite extends AbstractSyntacticRuleSuite with AnyFunSuiteLike {
 
   val original: String =
     """// Foobar

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/PositionSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/PositionSuite.scala
@@ -1,12 +1,12 @@
 package scalafix.tests.core
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scala.meta.inputs.Input
 import scala.meta.inputs.Position
 import scalafix.testkit.DiffAssertions
 import scalafix.internal.util.PositionSyntax._
 
-class PositionSuite extends FunSuite with DiffAssertions {
+class PositionSuite extends AnyFunSuite with DiffAssertions {
 
   val startMarker = '→'
   val stopMarker = '←'

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/util/TokenListSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/util/TokenListSuite.scala
@@ -1,12 +1,12 @@
 package scalafix.tests.core.util
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.meta._
 import scala.meta.dialects.Scala211
 import scalafix.util.TokenList
 
-class TokenListSuite extends FunSuite {
+class TokenListSuite extends AnyFunSuite {
 
   val tokens =
     """package foo

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/interfaces/ScalafixSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/interfaces/ScalafixSuite.scala
@@ -4,7 +4,7 @@ import java.net.URL
 import java.nio.file.{Files, Path}
 
 import coursierapi.Repository
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scalafix.interfaces.{Scalafix, ScalafixDiagnostic, ScalafixMainCallback}
 import scalafix.internal.tests.utils.SkipWindows
 
@@ -15,7 +15,7 @@ import scala.jdk.CollectionConverters._
  * That is done automatically as part of `sbt unit/test`, but if you run this from any other way, running
  * `sbt cli/crossPublishLocalBinTransitive` is a prerequisite.
  */
-class ScalafixSuite extends FunSuite {
+class ScalafixSuite extends AnyFunSuite {
 
   def tmpFile(prefix: String, suffix: String)(content: String): Path = {
     val path = Files.createTempFile(prefix, suffix)

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/reflect/RuleDecoderSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/reflect/RuleDecoderSuite.scala
@@ -7,10 +7,10 @@ import metaconfig.Conf
 import metaconfig.ConfDecoder
 import scala.meta.io.AbsolutePath
 import scala.meta.io.RelativePath
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scalafix.v1.RuleDecoder
 
-class RuleDecoderSuite extends FunSuite {
+class RuleDecoderSuite extends AnyFunSuite {
   val cwd: AbsolutePath = AbsolutePath(BuildInfo.baseDirectory)
     .resolve("scalafix-tests")
     .resolve("unit")

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/reflect/RuleInstrumentationSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/reflect/RuleInstrumentationSuite.scala
@@ -1,11 +1,11 @@
 package scalafix.tests.reflect
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scalafix.internal.reflect.RuleInstrumentation
 import metaconfig.Configured
 import scala.meta.inputs.Input
 
-class RuleInstrumentationSuite extends FunSuite {
+class RuleInstrumentationSuite extends AnyFunSuite {
   def check(name: String, original: String, expected: List[String]): Unit = {
     test(name) {
       val Configured.Ok(obtained) =

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/reflect/ToolClasspathSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/reflect/ToolClasspathSuite.scala
@@ -9,11 +9,11 @@ import coursier._
 import metaconfig.Conf
 import scala.meta.io.AbsolutePath
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scalafix.tests.util.ScalaVersions
 import scalafix.v1.RuleDecoder
 
-class ToolClasspathSuite extends FunSuite with BeforeAndAfterAll {
+class ToolClasspathSuite extends AnyFunSuite with BeforeAndAfterAll {
   var scalafmtClasspath: List[AbsolutePath] = _
   override def beforeAll(): Unit = {
     val jars =

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/rule/MavenFuzzSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/rule/MavenFuzzSuite.scala
@@ -2,7 +2,7 @@ package scalafix.tests.rule
 
 import coursier._
 import scala.collection.JavaConverters._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scalafix.testkit.DiffAssertions
 import scalafix.interfaces.Scalafix
 import java.nio.file.Files
@@ -20,7 +20,7 @@ import java.nio.file.Paths
 import org.scalatest.Ignore
 
 @Ignore // Ignored because this test is very slow.
-class MavenFuzzSuite extends FunSuite with DiffAssertions {
+class MavenFuzzSuite extends AnyFunSuite with DiffAssertions {
   private def getCompilingSources(
       g: ScalafixGlobal,
       classfiles: Seq[Path],

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/rule/RuleSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/rule/RuleSuite.scala
@@ -3,14 +3,15 @@ package scalafix.tests.rule
 import scalafix.testkit._
 import scala.util.control.NonFatal
 import org.scalatest.exceptions.TestFailedException
+import org.scalatest.funsuite.AnyFunSuiteLike
 
 object RuleSuite {
   def main(args: Array[String]): Unit = {
     if (Array("--save-expect").sameElements(args)) {
-      val suite = new SemanticRuleSuite(
+      val suite = new AbstractSemanticRuleSuite(
         TestkitProperties.loadFromResources(),
         isSaveExpect = true
-      ) {
+      ) with AnyFunSuiteLike {
         testsToRun.foreach { t =>
           try evaluateTestBody(t)
           catch {
@@ -28,6 +29,6 @@ object RuleSuite {
     }
   }
 }
-class RuleSuite extends SemanticRuleSuite {
+class RuleSuite extends AbstractSemanticRuleSuite with AnyFunSuiteLike {
   runAllTests()
 }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/testkit/AssertDeltaSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/testkit/AssertDeltaSuite.scala
@@ -1,6 +1,6 @@
 package scalafix.tests.testkit
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scala.meta.Position
 import scala.meta.dialects.Scala212
 import scala.meta.inputs.Input
@@ -17,7 +17,7 @@ import scalafix.testkit.DiffAssertions
 import scalafix.internal.util.LintSyntax._
 import scalafix.v0.LintMessage
 
-class AssertDeltaSuite() extends FunSuite with DiffAssertions {
+class AssertDeltaSuite() extends AnyFunSuite with DiffAssertions {
   test("associate assert and reported message", SkipWindows) {
     val input = Input.VirtualFile(
       path = "foo/bar/Disable.scala",

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/util/ExpectSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/util/ExpectSuite.scala
@@ -1,6 +1,6 @@
 package scalafix.tests.util
 import java.nio.charset.StandardCharsets
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scala.meta.internal.io.FileIO
 import scala.meta.io.AbsolutePath
 import scalafix.testkit.DiffAssertions
@@ -8,7 +8,7 @@ import scalafix.tests.BuildInfo
 import scalafix.tests.core.BaseSemanticSuite
 import scalafix.v1.SemanticDocument
 
-trait ExpectSuite extends FunSuite with DiffAssertions {
+trait ExpectSuite extends AnyFunSuite with DiffAssertions {
   def filename: String
   def obtained(): String
 

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/util/IntervalSetSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/util/IntervalSetSuite.scala
@@ -1,11 +1,11 @@
 package scalafix.tests.util
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalactic.source.Position
 
 import scalafix.internal.util.IntervalSet
 
-class IntervalSetSuite extends FunSuite {
+class IntervalSetSuite extends AnyFunSuite {
   test("contains") {
     val set = IntervalSet(Seq((1, 2), (4, 5)))
     assert(!set.contains(0))

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/util/ScalametaStructureSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/util/ScalametaStructureSuite.scala
@@ -1,11 +1,11 @@
 package scalafix.tests.util
 
 import scala.meta._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scalafix.testkit.DiffAssertions
 import scalafix.v1._
 
-class ScalametaStructureSuite extends FunSuite with DiffAssertions {
+class ScalametaStructureSuite extends AnyFunSuite with DiffAssertions {
   test("pretty(t)") {
     val obtained = q"a.b.c.d".structureWidth(1)
     val expected =

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/v1/LazyValueSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/v1/LazyValueSuite.scala
@@ -1,8 +1,8 @@
 package scalafix.tests.v1
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scalafix.internal.v1.LazyValue
 
-class LazyValueSuite extends FunSuite {
+class LazyValueSuite extends AnyFunSuite {
   test("now") {
     var i = 0
     val now = LazyValue.now {

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/v1/SymbolInformationSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/v1/SymbolInformationSuite.scala
@@ -1,11 +1,11 @@
 package scalafix.tests.v1
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scala.meta.internal.symtab.GlobalSymbolTable
 import scalafix.internal.reflect.ClasspathOps
 import scalafix.testkit.DiffAssertions
 import scalafix.v1._
 
-class SymbolInformationSuite extends FunSuite with DiffAssertions {
+class SymbolInformationSuite extends AnyFunSuite with DiffAssertions {
   private val classpath = ClasspathOps.thisClasspath
 
   private val symtab = GlobalSymbolTable(classpath, includeJdk = true)

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/v1/SymbolMatcherSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/v1/SymbolMatcherSuite.scala
@@ -1,11 +1,11 @@
 package scalafix.tests.v1
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scalafix.tests.core.BaseSemanticSuite
 import scalafix.v1._
 import scala.meta._
 
-class SymbolMatcherSuite extends FunSuite {
+class SymbolMatcherSuite extends AnyFunSuite {
   implicit val doc = BaseSemanticSuite.loadDoc("SymbolMatcherTest.scala")
 
   test("exact") {


### PR DESCRIPTION
Fix https://github.com/scalacenter/scalafix/issues/1172.

I ran MiMa locally against 0.9.17 and ~[will open a separate PR to re-introduce it](https://gitter.im/scalacenter/scalafix?at=5ef22c8e6c06cd1bf44d5c9d)~ https://github.com/scalacenter/scalafix/pull/1177.

* Deprecate existing `*RuleSuite` as they cause runtime failure when used in a classpath where ScalaTest 3.0.x gets evicted by 3.2.x
* testkit clients must now mix-in themselves an implementation of `TestRegistration` (as this trait moved between 3.0.x & 3.2.x) like `[Any]FunSuiteLike`
* Run https://github.com/scalatest/autofix/tree/master/3.1.x on `unit`