### PR TITLE
re-enable MiMa against latest stable version for published modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v7
       - run: ./scalafmt --test
+  mima:
+    name: MiMa
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: olafurpg/setup-scala@v7
+      - run: git fetch --unshallow
+      - run: sbt +mimaReportBinaryIssues

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,6 @@ def inferJavaHome() = {
 lazy val interfaces = project
   .in(file("scalafix-interfaces"))
   .settings(
-    noMima,
     resourceGenerators.in(Compile) += Def.task {
       val props = new java.util.Properties()
       props.put("scalafixVersion", version.value)
@@ -156,7 +155,6 @@ lazy val testsOutput = project
 lazy val testkit = project
   .in(file("scalafix-testkit"))
   .settings(
-    noMima,
     moduleName := "scalafix-testkit",
     isFullCrossVersion,
     libraryDependencies ++= Seq(

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -4,71 +4,10 @@ import com.typesafe.tools.mima.core._
 object Mima {
   val ignoredABIProblems: Seq[ProblemFilter] = {
     // To learn more about mima, see:
-    // See https://github.com/typesafehub/migration-manager/wiki/sbt-plugin#basic-usage
+    // See https://github.com/lightbend/mima
     Seq(
-      // removed semanticdb-sbt
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.Versions.semanticdbSbt"),
-      // @deprecated
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.package.Mirror"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.package.Rewrite"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.package.ScalafixConfig"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.package.RewriteCtx"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.syntax.package#XtensionSymbolSemanticdbIndex.denotOpt"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.syntax.package#XtensionRefSymbolOpt.symbolOpt"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.rule.SemanticRule.sctx"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.rule.SemanticRule.semanticCtx"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.rule.SemanticRule.mirror"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.rule.RuleName.withOldName"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.rule.RuleName.generate"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.rule.RuleCtx.matching"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.rule.Rule.andThen"),
-      ProblemFilters.exclude[MissingClassProblem]("scalafix.rewrite.SemanticRewrite"),
-      ProblemFilters.exclude[MissingClassProblem]("scalafix.rewrite.package$"),
-      ProblemFilters.exclude[MissingClassProblem]("scalafix.rewrite.Rewrite"),
-      ProblemFilters.exclude[MissingClassProblem]("scalafix.rewrite.package"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.lint.LintCategory.key"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.lint.LintMessage.format"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.patch.PatchOps.rename"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.package.Mirror"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.package.Rewrite"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.package.ScalafixConfig"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.package.RewriteCtx"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.syntax.package#XtensionSymbolSemanticdbIndex.denotOpt"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.syntax.package#XtensionRefSymbolOpt.symbolOpt"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.rule.SemanticRule.sctx"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.rule.SemanticRule.semanticCtx"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.rule.SemanticRule.mirror"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.rule.RuleName.withOldName"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.rule.RuleName.generate"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.rule.RuleCtx.matching"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.rule.Rule.andThen"),
-      ProblemFilters.exclude[MissingClassProblem]("scalafix.rewrite.SemanticRewrite"),
-      ProblemFilters.exclude[MissingClassProblem]("scalafix.rewrite.package$"),
-      ProblemFilters.exclude[MissingClassProblem]("scalafix.rewrite.Rewrite"),
-      ProblemFilters.exclude[MissingClassProblem]("scalafix.rewrite.package"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.lint.LintCategory.key"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.lint.LintMessage.format"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.patch.PatchOps.rename"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.testkit.SemanticRuleSuite.LintAssertion"),
-      ProblemFilters.exclude[MissingClassProblem]("scalafix.testkit.package$"),
-      ProblemFilters.exclude[MissingClassProblem]("scalafix.testkit.package"),
       ProblemFilters.exclude[MissingTypesProblem]("scalafix.testkit.DiffAssertions"),
       ProblemFilters.exclude[MissingTypesProblem]("scalafix.testkit.SemanticRuleSuite"),
-      // marked private[scalafix]
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("scalafix.rule.RuleCtx.printLintMessage"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("scalafix.rule.RuleCtx.filter"),
-      ProblemFilters.exclude[IncompatibleMethTypeProblem]("scalafix.patch.Patch.apply"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.patch.Patch.reportLintMessages"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.patch.Patch.lintMessages"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.rule.RuleCtx.printLintMessage"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("scalafix.rule.RuleCtx.filterLintMessage"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.cli.CliRunner.this"),
-      ProblemFilters.exclude[FinalClassProblem]("scalafix.util.TokenList"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("scalafix.util.TokenList.leadingSpaces"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("scalafix.util.TokenList.trailingSpaces"),
-      // Other
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("scalafix.patch.PatchOps.replaceSymbols"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("scalafix.patch.PatchOps.removeTokens"),
       ProblemFilters.exclude[Problem]("scalafix.internal.*")
     )
   }


### PR DESCRIPTION
Useful for https://github.com/scalacenter/scalafix/pull/1176 and to prepare for 1.0

* scalafix-cli
* scalafix-core
* scalafix-interfaces
* scalafix-reflect
* scalafix-rules
* scalafix-testkit