### PR TITLE
Fix #1180 - ExplicitResultTypes for implicit members of local traits

### DIFF
--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/CompilerTypePrinter.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/CompilerTypePrinter.scala
@@ -45,11 +45,13 @@ class CompilerTypePrinter(g: ScalafixGlobal, config: ExplicitResultTypesConfig)(
       space: String
   ): Option[v1.Patch] = {
     val gpos = unit.position(pos.start)
-    GlobalProxy.typedTreeAt(g, gpos)
-    val inverseSemanticdbSymbol = g
-      .inverseSemanticdbSymbols(sym.value)
-      .find(s => g.semanticdbSymbol(s) == sym.value)
-      .getOrElse(g.NoSymbol)
+    val tpe = GlobalProxy.typedTreeAt(g, gpos)
+    val inverseSemanticdbSymbol =
+      if (sym.isLocal) tpe.symbol
+      else
+        g.inverseSemanticdbSymbols(sym.value)
+          .find(s => g.semanticdbSymbol(s) == sym.value)
+          .getOrElse(g.NoSymbol)
     val hasNothing = inverseSemanticdbSymbol.info.exists {
       case g.definitions.NothingTpe => true
       case _ => false

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/ExplicitResultTypes.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/ExplicitResultTypes.scala
@@ -138,12 +138,12 @@ final class ExplicitResultTypes(
     case _: Defn.Var => MemberKind.Var
   }
 
-  def isRuleCandidate[D <: Defn](
-      defn: D,
+  def isRuleCandidate(
+      defn: Defn,
       nm: Name,
       mods: Iterable[Mod],
       body: Term
-  )(implicit ev: Extract[D, Mod], ctx: SemanticDocument): Boolean = {
+  )(implicit ctx: SemanticDocument): Boolean = {
     import config._
 
     def matchesMemberVisibility(): Boolean =
@@ -161,7 +161,7 @@ final class ExplicitResultTypes(
       config.skipSimpleDefinitions.isSimpleDefinition(body)
 
     def isImplicit: Boolean =
-      defn.hasMod(mod"implicit") && !isImplicitly(body)
+      mods.exists(_.is[Mod.Implicit]) && !isImplicitly(body)
 
     def hasParentWihTemplate: Boolean =
       defn.parent.exists(_.is[Template])
@@ -172,7 +172,7 @@ final class ExplicitResultTypes(
 
     isImplicit && !isFinalLiteralVal && !isLocal || {
       hasParentWihTemplate &&
-      !defn.hasMod(mod"implicit") &&
+      !mods.exists(_.is[Mod.Implicit]) &&
       !matchesSimpleDefinition() &&
       matchesMemberKind() &&
       matchesMemberVisibility()

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/ExplicitResultTypes.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/ExplicitResultTypes.scala
@@ -167,7 +167,7 @@ final class ExplicitResultTypes(
       defn.parent.exists(_.is[Template])
 
     def isLocal: Boolean =
-      if (config.skipLocalImplicits) nm.symbol.isLocal
+      if (config.skipLocalImplicits) nm.symbol.isLocal && !hasParentWihTemplate
       else false
 
     isImplicit && !isFinalLiteralVal && !isLocal || {

--- a/scalafix-tests/input/src/main/scala/test/explicitResultTypes/LocalImplicits.scala
+++ b/scalafix-tests/input/src/main/scala/test/explicitResultTypes/LocalImplicits.scala
@@ -1,0 +1,20 @@
+/*
+rule = ExplicitResultTypes
+ExplicitResultTypes.skipLocalImplicits = false
+*/
+package test.explicitResultTypes
+
+class LocalImplicits {
+  trait T
+  def f(): T = new T {
+    implicit val i = 1
+  }
+  def g(): Unit = {
+    class C {
+      implicit val i = 2
+    }
+  }
+  def h(): Unit = {
+    implicit val i = 3
+  }
+}

--- a/scalafix-tests/input/src/main/scala/test/explicitResultTypes/SkipLocalImplicits.scala
+++ b/scalafix-tests/input/src/main/scala/test/explicitResultTypes/SkipLocalImplicits.scala
@@ -1,0 +1,19 @@
+/*
+rule = ExplicitResultTypes
+*/
+package test.explicitResultTypes
+
+class SkipLocalImplicits {
+  trait T
+  def f(): T = new T {
+    implicit val i = 1
+  }
+  def g(): Unit = {
+    class C {
+      implicit val i = 2
+    }
+  }
+  def h(): Unit = {
+    implicit val i = 3
+  }
+}

--- a/scalafix-tests/output/src/main/scala/test/explicitResultTypes/LocalImplicits.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitResultTypes/LocalImplicits.scala
@@ -1,0 +1,16 @@
+package test.explicitResultTypes
+
+class LocalImplicits {
+  trait T
+  def f(): T = new T {
+    implicit val i: Int = 1
+  }
+  def g(): Unit = {
+    class C {
+      implicit val i: Int = 2
+    }
+  }
+  def h(): Unit = {
+    implicit val i: Int = 3
+  }
+}

--- a/scalafix-tests/output/src/main/scala/test/explicitResultTypes/SkipLocalImplicits.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitResultTypes/SkipLocalImplicits.scala
@@ -1,0 +1,16 @@
+package test.explicitResultTypes
+
+class SkipLocalImplicits {
+  trait T
+  def f(): T = new T {
+    implicit val i: Int = 1
+  }
+  def g(): Unit = {
+    class C {
+      implicit val i: Int = 2
+    }
+  }
+  def h(): Unit = {
+    implicit val i = 3
+  }
+}

--- a/scalafix-tests/output/src/main/scala/tests/ExplicitResultTypesRefinement.scala
+++ b/scalafix-tests/output/src/main/scala/tests/ExplicitResultTypesRefinement.scala
@@ -51,7 +51,7 @@ object ExplicitResultTypesRefinement {
   }
   trait Chars { def chars: CharSequence }
   val chars: Chars = new Chars {
-    val chars = 42.toString()
+    val chars: String = 42.toString()
   }
   def app(): Unit = {
     println(field.results)

--- a/scalafix-tests/output/src/main/scala/tests/RscCompat.scala
+++ b/scalafix-tests/output/src/main/scala/tests/RscCompat.scala
@@ -179,7 +179,7 @@ object RscCompat_Test {
     val more2: more2 = new more2
     class more2 extends { def foo(implicit x: Int, y: Int) = 42 }
     val more3: more3 = new more3
-    class more3 extends { implicit def bar = 42 }
+    class more3 extends { implicit def bar: Int = 42 }
 
     implicit val crazy1 = implicitly[Int]
     implicit val crazy2: Bijection[In,Out1] = Bijection.connect[In, Out1]


### PR DESCRIPTION
Fix #1180 
Also fix: `ExplicitResultTypes.skipLocalImplicits = false` has no effect.