### PR TITLE
fix MiMA after 0.9.18 release with a new Scala patch version

### DIFF
--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -283,7 +283,8 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
   )
 
   private val PreviousScalaVersion = Map(
-    "2.13.3" -> "2.13.2"
+    "2.12.12" -> "2.12.11",
+    "2.13.4" -> "2.13.3"
   )
 
   override def projectSettings: Seq[Def.Setting[_]] = List(


### PR DESCRIPTION
```
2020-07-04T00:13:45.0599582Z [warn] 	module not found: ch.epfl.scala#scalafix-reflect_2.13.2;0.9.18
2020-07-04T00:13:45.0600207Z [warn] ==== local: tried
2020-07-04T00:13:45.0600786Z [warn]   /home/runner/.ivy2/local/ch.epfl.scala/scalafix-reflect_2.13.2/0.9.18/ivys/ivy.xml
2020-07-04T00:13:45.0601153Z [warn] ==== public: tried
2020-07-04T00:13:45.0601779Z [warn]   https://repo1.maven.org/maven2/ch/epfl/scala/scalafix-reflect_2.13.2/0.9.18/scalafix-reflect_2.13.2-0.9.18.pom
2020-07-04T00:13:45.0602312Z [warn] ==== local-preloaded-ivy: tried
2020-07-04T00:13:45.0602855Z [warn]   /home/runner/.sbt/preloaded/ch.epfl.scala/scalafix-reflect_2.13.2/0.9.18/ivys/ivy.xml
2020-07-04T00:13:45.0603330Z [warn] ==== local-preloaded: tried
2020-07-04T00:13:45.0603920Z [warn]   file:////home/runner/.sbt/preloaded/ch/epfl/scala/scalafix-reflect_2.13.2/0.9.18/scalafix-reflect_2.13.2-0.9.18.pom
2020-07-04T00:13:45.0604415Z [warn] ==== sonatype-snapshots: tried
2020-07-04T00:13:45.0605033Z [warn]   https://oss.sonatype.org/content/repositories/snapshots/ch/epfl/scala/scalafix-reflect_2.13.2/0.9.18/scalafix-reflect_2.13.2-0.9.18.pom
2020-07-04T00:13:45.0605547Z [warn] ==== sonatype-public: tried
2020-07-04T00:13:45.0606166Z [warn]   https://oss.sonatype.org/content/repositories/public/ch/epfl/scala/scalafix-reflect_2.13.2/0.9.18/scalafix-reflect_2.13.2-0.9.18.pom
2020-07-04T00:13:45.0606536Z [warn] ==== Maven2 Local: tried
2020-07-04T00:13:45.0607091Z [warn]   file:/home/runner/.m2/repository/ch/epfl/scala/scalafix-reflect_2.13.2/0.9.18/scalafix-reflect_2.13.2-0.9.18.pom
2020-07-04T00:13:45.0713193Z [warn] 	::::::::::::::::::::::::::::::::::::::::::::::
2020-07-04T00:13:45.0714263Z [warn] 	::          UNRESOLVED DEPENDENCIES         ::
2020-07-04T00:13:45.0714933Z [warn] 	::::::::::::::::::::::::::::::::::::::::::::::
2020-07-04T00:13:45.0716728Z [warn] 	:: ch.epfl.scala#scalafix-reflect_2.13.2;0.9.18: not found
```
Now that we have a stable 2.13.3 artifact, `PreviousScalaVersion` should not have it as a key. Instead of removing that only mapping, I prepared for the next patch releases so that nothing needs to be done until a release is cut, like this time.