### PR TITLE
support for Scala 2.12.12

### DIFF
--- a/bin/test-release.sh
+++ b/bin/test-release.sh
@@ -9,12 +9,12 @@ cs resolve \
   ch.epfl.scala:scalafix-core_2.12:$version  \
   ch.epfl.scala:scalafix-core_2.13:$version  \
   ch.epfl.scala:scalafix-reflect_2.11.12:$version  \
-  ch.epfl.scala:scalafix-reflect_2.12.11:$version  \
+  ch.epfl.scala:scalafix-reflect_2.12.12:$version  \
   ch.epfl.scala:scalafix-reflect_2.13.3:$version  \
   ch.epfl.scala:scalafix-cli_2.11.12:$version  \
-  ch.epfl.scala:scalafix-cli_2.12.11:$version  \
+  ch.epfl.scala:scalafix-cli_2.12.12:$version  \
   ch.epfl.scala:scalafix-cli_2.13.3:$version  \
   ch.epfl.scala:scalafix-testkit_2.11.12:$version  \
-  ch.epfl.scala:scalafix-testkit_2.12.11:$version \
+  ch.epfl.scala:scalafix-testkit_2.12.12:$version \
   ch.epfl.scala:scalafix-testkit_2.13.3:$version \
   -r sonatype:public

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,11 +4,11 @@ import scala.util.{Properties, Try}
 /* scalafmt: { maxColumn = 120 }*/
 
 object Dependencies {
-  val scalametaV = "4.3.18"
+  val scalametaV = "4.3.20"
   val metaconfigV = "0.9.10"
   def scala210 = "2.10.7"
   def scala211 = "2.11.12"
-  def scala212 = "2.12.11"
+  def scala212 = "2.12.12"
   def scala213 = "2.13.3"
   def coursierV = "2.0.0-RC5-6"
   def coursierInterfaceV = "0.0.22"


### PR DESCRIPTION
https://github.com/scala/scala/releases/tag/v2.12.12
https://github.com/scalameta/scalameta/releases/tag/v4.3.20
https://github.com/scalameta/scalameta/releases/tag/v4.3.19