### PR TITLE
Update tutorial's ivy resolver docs.

### DIFF
--- a/docs/developers/tutorial.md
+++ b/docs/developers/tutorial.md
@@ -754,9 +754,15 @@ custom repository like Bintray or a private Nexus.
 scalafixResolvers.in(ThisBuild) ++= List(
   coursierapi.MavenRepository.of("https://dl.bintray.com/scalacenter/releases"),
   coursierapi.MavenRepository.of("https://oss.sonatype.org/content/repositories/snapshots"),
-  coursierapi.IvyRepository.of("https://dl.bintray.com/sbt/sbt-plugin-releases")
+  coursierapi.IvyRepository.of("https://dl.bintray.com/sbt/sbt-plugin-releases/[defaultPattern]"),
+  coursierapi.IvyRepository.of("https://foo.com/a/b/c/[defaultPattern]")
 )
 ```
+
+Notice for Ivy resolvers, `coursierapi.IvyRepository.of` is interpolated as a pattern. Appending `[defaultPattern]`
+uses this [convenience method](https://github.com/coursier/coursier/blob/a92e4f263f494199078adfb1c5db67ba0b076674/modules/core/shared/src/main/scala/coursier/ivy/Pattern.scala#L107)
+to substitute in [this default pattern](https://github.com/coursier/coursier/blob/a92e4f263f494199078adfb1c5db67ba0b076674/modules/core/shared/src/main/scala/coursier/ivy/Pattern.scala#L236-L245).
+Tests showing a working example can found [here](https://github.com/coursier/coursier/blob/master/modules/tests/jvm/src/test/scala/coursier/test/IvyTests.scala).
 
 ### Conclusion
 


### PR DESCRIPTION
I followed the Contributing docs for [Documentation](https://github.com/scalacenter/scalafix/blob/master/CONTRIBUTING.md#documentation), and the documentation website looks as expected on my local.

<img width="2098" alt="Screen Shot 2020-08-15 at 3 49 40 PM" src="https://user-images.githubusercontent.com/3627116/90321442-4e563f00-df0f-11ea-8b48-715922e397e3.png">

I believe following this documentation update solves both of these issues: [1077](https://github.com/scalacenter/scalafix/issues/1077) and [1074](https://github.com/scalacenter/scalafix/issues/1074).

Documentation around `[defaultPattern]` usage can also be found in Ammonite [docs](https://ammonite.io/) and [tests](https://github.com/lihaoyi/Ammonite/blob/master/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala#L69-L79).

I have verified using `[defaultPatten]` works for resolving custom ScalaFix rules I've published to an internal / private company artifactory registry.