### PR TITLE
fix pretty print for backquoted symbols

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/internal/util/Pretty.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/util/Pretty.scala
@@ -23,7 +23,7 @@ object Pretty {
   }
 
   def pretty(sym: Symbol): Doc =
-    Doc.text(sym.displayName)
+    Doc.text(scala.meta.Name(sym.displayName).toString())
 
   def pretty(tpe: SemanticType): Doc = {
     def prefix(tpe: SemanticType): Doc = {

--- a/scalafix-core/src/main/scala/scalafix/v1/Symbol.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/Symbol.scala
@@ -16,7 +16,7 @@ final class Symbol private (val value: String) {
   def isGlobal: Boolean = value.isGlobal
   def isLocal: Boolean = value.isLocal
   def owner: Symbol = Symbol(value.owner)
-  def displayName: String = value.desc.name.value
+  def displayName: String = encode(value.desc.name.value)
   def info(implicit doc: Symtab): Option[SymbolInformation] =
     doc.info(this)
   def normalized: Symbol = SymbolOps.normalize(this)
@@ -38,6 +38,18 @@ final class Symbol private (val value: String) {
       case _ => false
     })
   override def hashCode(): Int = value.##
+
+  private def encode(value: String): String = {
+    if (value == "") {
+      "``"
+    } else {
+      val (start, parts) = (value.head, value.tail)
+      val isStartOk = Character.isJavaIdentifierStart(start)
+      val isPartsOk = parts.forall(Character.isJavaIdentifierPart)
+      if (isStartOk && isPartsOk) value
+      else "`" + value + "`"
+    }
+  }
 }
 
 object Symbol {

--- a/scalafix-core/src/main/scala/scalafix/v1/Symbol.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/Symbol.scala
@@ -16,7 +16,7 @@ final class Symbol private (val value: String) {
   def isGlobal: Boolean = value.isGlobal
   def isLocal: Boolean = value.isLocal
   def owner: Symbol = Symbol(value.owner)
-  def displayName: String = encode(value.desc.name.value)
+  def displayName: String = value.desc.name.value
   def info(implicit doc: Symtab): Option[SymbolInformation] =
     doc.info(this)
   def normalized: Symbol = SymbolOps.normalize(this)
@@ -38,18 +38,6 @@ final class Symbol private (val value: String) {
       case _ => false
     })
   override def hashCode(): Int = value.##
-
-  private def encode(value: String): String = {
-    if (value == "") {
-      "``"
-    } else {
-      val (start, parts) = (value.head, value.tail)
-      val isStartOk = Character.isJavaIdentifierStart(start)
-      val isPartsOk = parts.forall(Character.isJavaIdentifierPart)
-      if (isStartOk && isPartsOk) value
-      else "`" + value + "`"
-    }
-  }
 }
 
 object Symbol {

--- a/scalafix-tests/shared/src/main/scala/test/PrettyTest.scala
+++ b/scalafix-tests/shared/src/main/scala/test/PrettyTest.scala
@@ -144,4 +144,11 @@ object Test {
     final val javaEnum = java.nio.file.LinkOption.NOFOLLOW_LINKS
     final val clazzOf = classOf[Option[Int]]
   }
+
+  object EscapedName {
+    implicit val `test-test`: Int = 5
+    val x = implicitly[Int]
+    implicit val test: String = "string"
+    val y = implicitly[String]
+  }
 }

--- a/scalafix-tests/unit/src/main/resources/expect/Pretty.expect
+++ b/scalafix-tests/unit/src/main/resources/expect/Pretty.expect
@@ -57,7 +57,7 @@
 [53:9..53:10]:    test/T#X# => class X extends AnyRef { +1 decls }
 [53:10..53:10]:   test/T#X#`<init>`(). => primary ctor <init>()
 [54:7..54:8]:     test/T#x. => val method x: X
-[57:8..57:12]:    test/Test. => final object Test extends AnyRef { +4 decls }
+[57:8..57:12]:    test/Test. => final object Test extends AnyRef { +5 decls }
 [58:9..58:10]:    test/Test.M# => class M extends AnyRef { +2 decls }
 [58:11..58:11]:   test/Test.M#`<init>`(). => primary ctor <init>()
 [59:9..59:10]:    test/Test.M#m(). => method m: Int
@@ -138,3 +138,10 @@
 [143:15..143:19]: test/Test.Literal.unit. => final val method unit: Unit
 [144:15..144:23]: test/Test.Literal.javaEnum. => final val method javaEnum: NOFOLLOW_LINKS.type
 [145:15..145:22]: test/Test.Literal.clazzOf. => final val method clazzOf: Class[Option[Int]]
+[148:10..148:21]: test/Test.EscapedName. => final object EscapedName extends AnyRef { +4 decls }
+[149:18..149:29]: test/Test.EscapedName.`test-test`. => implicit val method test-test: Int
+[150:9..150:10]:  test/Test.EscapedName.x. => val method x: Int
+[150:13..150:28]: *(`test-test`)
+[151:18..151:22]: test/Test.EscapedName.test. => implicit val method test: String
+[152:9..152:10]:  test/Test.EscapedName.y. => val method y: String
+[152:13..152:31]: *(test)


### PR DESCRIPTION
Example:
```
  implicit val `b-b`: Int = 12
  val crazy1 = implicitly[Int]
```
the synthetics of this piece of code is `List(*(b-b))`, and I would expect ```List(*(`b-b`))```

Maybe there is another way to get correctly the toString, and this is just a proposition to get more feedback.
Thanks
