### PR TITLE
Handle secondary constructor in Procedure syntax

### DIFF
--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/ProcedureSyntax.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/ProcedureSyntax.scala
@@ -1,6 +1,9 @@
 package scalafix.internal.rule
 
 import scala.meta._
+import scala.meta.tokens.Token
+import scala.meta.tokens.Token.Equals
+import scala.meta.tokens.Token.RightParen
 
 import scalafix.util.Trivia
 import scalafix.v1._
@@ -9,6 +12,7 @@ class ProcedureSyntax extends SyntacticRule("ProcedureSyntax") {
 
   override def description: String =
     "Replaces deprecated procedure syntax with explicit ': Unit ='"
+
   override def isRewrite: Boolean = true
 
   override def fix(implicit doc: SyntacticDocument): Patch = {
@@ -23,6 +27,21 @@ class ProcedureSyntax extends SyntacticRule("ProcedureSyntax") {
           toAdd <- doc.tokenList.leading(bodyStart).find(!_.is[Trivia])
         } yield Patch.addRight(toAdd, s": Unit =").atomic
         fixed.getOrElse(Patch.empty)
+
+      /** @see [[https://github.com/ohze/scala-rewrites/blob/dotty/rewrites/src/main/scala/fix/scala213/ConstructorProcedureSyntax.scala ConstructorProcedureSyntax.scala]] */
+      case t: Ctor.Secondary =>
+        val tokens = t.tokens
+        val beforeInitIdx = tokens.indexOf(t.init.tokens.head) - 1
+        // last RightParen before init
+        val lastRightParenIdx =
+          tokens.lastIndexWhere(_.is[RightParen], beforeInitIdx)
+        // if slicedTokens don't have Equals token => need patching
+        val slicedTokens = tokens.slice(lastRightParenIdx, beforeInitIdx)
+        slicedTokens.find(_.is[Equals]) match {
+          case Some(_) => Patch.empty
+          case None => Patch.addRight(tokens(lastRightParenIdx), " =")
+        }
+
     }.asPatch
   }
 }

--- a/scalafix-tests/input/src/main/scala/test/ConstructorProcedureSyntax.scala
+++ b/scalafix-tests/input/src/main/scala/test/ConstructorProcedureSyntax.scala
@@ -1,0 +1,45 @@
+/*
+rules = ProcedureSyntax
+ */
+package test
+
+class ConstructorProcedureSyntax(i: Long) {
+  def this(a: Int) { this(0L + 1) }
+  def this(a: Int, b: Int) {
+    this(0L)
+  }
+  def f/**/{
+    println("f")
+    class X{
+      def this(a:Int)    { this() }
+      def this (j: String)= this(j.toInt)
+    }
+  }
+  def this(){this(1L)
+    println("hi")
+    class X{
+      def this (j: String) // comment }
+      {
+        this()
+      }
+      def this (j: Int) { // comment {
+        this()
+      }
+    }
+    println(".")
+  }
+  def this(i: Float) /**/
+  //
+  /***/
+  {
+    this(i.toLong)
+  }
+
+  def this(i: String) = this(i.toLong)
+
+  class Bar(a: String) {
+    def this() {
+      this("bar")
+    }
+  }
+}

--- a/scalafix-tests/output/src/main/scala/test/ConstructorProcedureSyntax.scala
+++ b/scalafix-tests/output/src/main/scala/test/ConstructorProcedureSyntax.scala
@@ -1,0 +1,42 @@
+package test
+
+class ConstructorProcedureSyntax(i: Long) {
+  def this(a: Int) = { this(0L + 1) }
+  def this(a: Int, b: Int) = {
+    this(0L)
+  }
+  def f: Unit =/**/{
+    println("f")
+    class X{
+      def this(a:Int) =    { this() }
+      def this (j: String)= this(j.toInt)
+    }
+  }
+  def this() ={this(1L)
+    println("hi")
+    class X{
+      def this (j: String) = // comment }
+      {
+        this()
+      }
+      def this (j: Int) = { // comment {
+        this()
+      }
+    }
+    println(".")
+  }
+  def this(i: Float) = /**/
+  //
+  /***/
+  {
+    this(i.toLong)
+  }
+
+  def this(i: String) = this(i.toLong)
+
+  class Bar(a: String) {
+    def this() = {
+      this("bar")
+    }
+  }
+}


### PR DESCRIPTION
* code inspired from [ConstructorProcedureSyntax](https://github.com/ohze/scala-rewrites/blob/dotty/rewrites/src/main/scala/fix/scala213/ConstructorProcedureSyntax.scala)
* We don't remove braces in case of 1 statement

fixes #1235