### PR TITLE
check the whole caret position in the testkit

### DIFF
--- a/scalafix-testkit/src/main/scala/scalafix/internal/testkit/AssertDelta.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/internal/testkit/AssertDelta.scala
@@ -25,9 +25,7 @@ case class AssertDelta(
     sameKey(assert.key) &&
       (assert.caretPosition match {
         case Some(carPos) =>
-          (carPos.start == lintDiagnostic.position.start) &&
-            (carPos.end == lintDiagnostic.position.end ||
-              (carPos.start == (carPos.end - 1) && lintDiagnostic.position.start == lintDiagnostic.position.end)) &&
+          carPos.lineCaret == lintDiagnostic.position.lineCaret &&
             assert.expectedMessage.forall(_.trim == lintDiagnostic.message.trim)
         case None =>
           sameLine(assert.anchorPosition)

--- a/scalafix-testkit/src/main/scala/scalafix/internal/testkit/AssertDelta.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/internal/testkit/AssertDelta.scala
@@ -26,6 +26,8 @@ case class AssertDelta(
       (assert.caretPosition match {
         case Some(carPos) =>
           (carPos.start == lintDiagnostic.position.start) &&
+            (carPos.end == lintDiagnostic.position.end ||
+              (carPos.start == (carPos.end - 1) && lintDiagnostic.position.start == lintDiagnostic.position.end)) &&
             assert.expectedMessage.forall(_.trim == lintDiagnostic.message.trim)
         case None =>
           sameLine(assert.anchorPosition)

--- a/scalafix-testkit/src/main/scala/scalafix/internal/testkit/CommentAssertion.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/internal/testkit/CommentAssertion.scala
@@ -97,19 +97,21 @@ object MultiLineAssertExtractor {
               )
           }
 
-        val caretOffset = lines(1).indexOf('^')
-        if (caretOffset == -1)
+        val caretOffsetStart = lines(1).indexOf('^')
+        if (caretOffsetStart == -1)
           throw new Exception("^ should be on the second line of the assert")
-        val offset = caretOffset - token.pos.startColumn
-        val caretStart = token.pos.start + offset
+        val caretOffsetEnd = lines(1).lastIndexOf('^')
+        val offsetStart = caretOffsetStart - token.pos.startColumn
+        val offsetEnd = caretOffsetEnd - token.pos.startColumn + 1
+        val caretStart = token.pos.start + offsetStart
+        val caretEnd = token.pos.start + offsetEnd
         val message = lines.drop(2).mkString("\n")
-
         Some(
           CommentAssertion(
             anchorPosition = token.pos,
             key = key,
             caretPosition = Some(
-              Position.Range(token.pos.input, caretStart, caretStart)
+              Position.Range(token.pos.input, caretStart, caretEnd)
             ),
             expectedMessage = Some(message)
           )

--- a/scalafix-testkit/src/main/scala/scalafix/internal/testkit/CommentAssertion.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/internal/testkit/CommentAssertion.scala
@@ -12,7 +12,9 @@ import scalafix.internal.util.PositionSyntax._
 // For example:
 //
 // ```scala
-// Option(1).get // assert: Disable.get
+// class Foo {
+//   def bar(x: Int = 42) = 1 // assert: DisableSyntax.defaultArgs
+// }
 // ```
 //
 // You can also use the multiline variant. This isuseful two visually
@@ -22,14 +24,13 @@ import scalafix.internal.util.PositionSyntax._
 // For example:
 //
 // ```scala
-// Option(1).get /* assert: Disable.get
-//           ^
-// Option.get is the root of all evilz
-//
-// If you must Option.get, wrap the code block with
-// // scalafix:off Option.get
-// ...
-// // scalafix:on Option.get
+// class Foo {
+//   def bar(x: Int = 42) = 1 /* assert: DisableSyntax.defaultArgs
+//                    ^^
+// Default args makes it hard to use methods as functions.
+// */
+// }
+// ```
 // */
 case class CommentAssertion(
     anchorPosition: Position,

--- a/scalafix-tests/input/src/main/scala/test/DisableSyntaxMoreRules.scala
+++ b/scalafix-tests/input/src/main/scala/test/DisableSyntaxMoreRules.scala
@@ -24,7 +24,7 @@ object DisableSyntaxMoreRules {
 
   class Foo {
     def bar(x: Int = 42) = 1 /* assert: DisableSyntax.defaultArgs
-                     ^
+                     ^^
 Default args makes it hard to use methods as functions.
 */
   }
@@ -58,11 +58,11 @@ Default args makes it hard to use methods as functions.
 
   class Bar { type Foo = Int; def foo = 42 }
   def foo(a: { type Foo = Int; def foo: Foo } = new Bar): Int = a.foo /* assert: DisableSyntax.defaultArgs
-                                                ^
+                                                ^^^^^^^
 Default args makes it hard to use methods as functions.
 */
   def foo2(a: { type Foo = Int; def foo: Foo } = {val a = new Bar; a}): Int = a.foo /* assert: DisableSyntax.defaultArgs
-                                                 ^
+                                                 ^^^^^^^^^^^^^^^^^^^^
 Default args makes it hard to use methods as functions.
 */
 

--- a/scalafix-tests/input/src/main/scala/test/NoFinalize.scala
+++ b/scalafix-tests/input/src/main/scala/test/NoFinalize.scala
@@ -25,7 +25,7 @@ case object NoFinalize {
 
   class Example {
     override protected def finalize() = () /* assert: DisableSyntax.noFinalize
-                           ^
+                           ^^^^^^^^
     finalize should not be used
     */
   }

--- a/scalafix-tests/input/src/main/scala/test/disableSyntax/DisableSyntaxBase.scala
+++ b/scalafix-tests/input/src/main/scala/test/disableSyntax/DisableSyntaxBase.scala
@@ -36,7 +36,7 @@ case object DisableSyntaxBase {
 
 
   null /* assert: DisableSyntax.null
-  ^
+  ^^^^
   null should be avoided, consider using Option instead
   */
 

--- a/scalafix-tests/input/src/main/scala/test/disableSyntax/DisableSyntaxNoValPatterns.scala
+++ b/scalafix-tests/input/src/main/scala/test/disableSyntax/DisableSyntaxNoValPatterns.scala
@@ -14,9 +14,9 @@ case object DisableSyntaxNoValPatterns {
   val (works6, _) = (1, Left(42))
   case class TestClass(a: Int, b: Int)
   val TestClass(a, b) = TestClass(1, 1) /* assert: DisableSyntax.noValPatterns
-      ^
+      ^^^^^^^^^^^^^^^
   Pattern matching in val assignment can result in match error, use "_ match { ... }" with a fallback case instead.*/
   val TestClass(c, _) = TestClass(1, 1) /* assert: DisableSyntax.noValPatterns
-      ^
+      ^^^^^^^^^^^^^^^
   Pattern matching in val assignment can result in match error, use "_ match { ... }" with a fallback case instead.*/
 }


### PR DESCRIPTION
This pull request ensures that the testkit checks the whole caret (`^^^^`) position range. Before only the range start was tested.