### PR TITLE
ExplicitResultTypes path-dependent types import bugfix & tweaks

### DIFF
--- a/scalafix-rules/src/main/scala/scala/meta/internal/pc/ScalafixGlobal.scala
+++ b/scalafix-rules/src/main/scala/scala/meta/internal/pc/ScalafixGlobal.scala
@@ -238,7 +238,21 @@ class ScalafixGlobal(
             // "scala.Seq[T]" even when it's needed.
             loop(ThisType(sym.owner), name)
           } else if (sym.hasPackageFlag || sym.isPackageObjectOrClass) {
-            if (history.tryShortenName(name)) NoPrefix
+            val dotSyntaxFriendlyName = name.map { name0 =>
+              if (name0.symbol.isStatic) name0
+              else {
+                // Use the prefix rather than the real owner to maximize the
+                // chances of shortening the reference: when `name` is directly
+                // nested in a non-statically addressable type (class or trait),
+                // its original owner is that type (requiring a type projection
+                // to reference it) while the prefix is its concrete owner value
+                // (for which the dot syntax works).
+                // https://docs.scala-lang.org/tour/inner-classes.html
+                // https://danielwestheide.com/blog/the-neophytes-guide-to-scala-part-13-path-dependent-types/
+                ShortName(name0.symbol.cloneSymbol(sym))
+              }
+            }
+            if (history.tryShortenName(dotSyntaxFriendlyName)) NoPrefix
             else tpe
           } else {
             if (history.isSymbolInScope(sym, pre)) SingleType(NoPrefix, sym)

--- a/scalafix-tests/input/src/main/scala/test/explicitResultTypes/ExplicitResultTypesPathDependent.scala
+++ b/scalafix-tests/input/src/main/scala/test/explicitResultTypes/ExplicitResultTypesPathDependent.scala
@@ -20,7 +20,12 @@ class Clazz {
 package object PackageObject extends Trait
 
 package pkg {
-  object Obj extends Clazz
+  abstract class AbstractClazz {
+    trait T4
+  }
+  object Obj extends Clazz {
+    object NestedObj extends AbstractClazz
+  }
 }
 
 object ExplicitResultTypesPathDependent {
@@ -46,4 +51,7 @@ object ExplicitResultTypesPathDependent {
 
   def t3: pkg.Obj.T3 = ???
   val t3Ref = t3
+
+  def t4: pkg.Obj.NestedObj.T4 = ???
+  val t4Ref = t4
 }

--- a/scalafix-tests/input/src/main/scala/test/explicitResultTypes/ExplicitResultTypesPathDependent.scala
+++ b/scalafix-tests/input/src/main/scala/test/explicitResultTypes/ExplicitResultTypesPathDependent.scala
@@ -1,7 +1,27 @@
 /*
 rules = ExplicitResultTypes
+ExplicitResultTypes.skipSimpleDefinitions = ["Lit"]
  */
 package test.explicitResultTypes
+
+// like https://github.com/tpolecat/doobie/blob/c2e044/modules/core/src/main/scala/doobie/free/Aliases.scala#L10
+trait Trait {
+  type T1 // like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/free/Aliases.scala#L14
+  object Nested {
+    type T2
+  }
+}
+
+class Clazz {
+  type T3
+}
+
+// like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/hi/package.scala#L25
+package object PackageObject extends Trait
+
+package pkg {
+  object Obj extends Clazz
+}
 
 object ExplicitResultTypesPathDependent {
   class Path {
@@ -16,4 +36,14 @@ object ExplicitResultTypesPathDependent {
     def bar: Self
   }
   implicit def foo[T] = null.asInstanceOf[Foo[T]].bar
+
+  // like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/util/query.scala#L163
+  def t1: PackageObject.T1 = ???
+  val t1Ref = t1
+
+  def t2: PackageObject.Nested.T2 = ???
+  val t2Ref = t2
+
+  def t3: pkg.Obj.T3 = ???
+  val t3Ref = t3
 }

--- a/scalafix-tests/input/src/main/scala/tests/ExplicitResultTypesImports.scala
+++ b/scalafix-tests/input/src/main/scala/tests/ExplicitResultTypesImports.scala
@@ -16,7 +16,6 @@ object ExplicitResultTypesImports {
 
   val timezone = null.asInstanceOf[java.util.TimeZone]
 
-  // TODO: Is this desirable behavior?
   val inner = null.asInstanceOf[scala.collection.Searching.SearchResult]
 
   final val javaEnum = java.util.Locale.Category.DISPLAY

--- a/scalafix-tests/output/src/main/scala/test/explicitResultTypes/ExplicitResultTypesPathDependent.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitResultTypes/ExplicitResultTypesPathDependent.scala
@@ -1,6 +1,7 @@
 
 package test.explicitResultTypes
 
+import test.explicitResultTypes.PackageObject.{ Nested, T1 }
 import test.explicitResultTypes.pkg.Obj
 // like https://github.com/tpolecat/doobie/blob/c2e044/modules/core/src/main/scala/doobie/free/Aliases.scala#L10
 trait Trait {
@@ -18,7 +19,12 @@ class Clazz {
 package object PackageObject extends Trait
 
 package pkg {
-  object Obj extends Clazz
+  abstract class AbstractClazz {
+    trait T4
+  }
+  object Obj extends Clazz {
+    object NestedObj extends AbstractClazz
+  }
 }
 
 object ExplicitResultTypesPathDependent {
@@ -37,11 +43,14 @@ object ExplicitResultTypesPathDependent {
 
   // like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/util/query.scala#L163
   def t1: PackageObject.T1 = ???
-  val t1Ref: test.explicitResultTypes.PackageObject.T1 = t1
+  val t1Ref: T1 = t1
 
   def t2: PackageObject.Nested.T2 = ???
-  val t2Ref: test.explicitResultTypes.PackageObject.Nested.T2 = t2
+  val t2Ref: Nested.T2 = t2
 
   def t3: pkg.Obj.T3 = ???
   val t3Ref: Obj.T3 = t3
+
+  def t4: pkg.Obj.NestedObj.T4 = ???
+  val t4Ref: Obj.NestedObj.T4 = t4
 }

--- a/scalafix-tests/output/src/main/scala/test/explicitResultTypes/ExplicitResultTypesPathDependent.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitResultTypes/ExplicitResultTypesPathDependent.scala
@@ -1,6 +1,26 @@
 
 package test.explicitResultTypes
 
+import test.explicitResultTypes.pkg.Obj
+// like https://github.com/tpolecat/doobie/blob/c2e044/modules/core/src/main/scala/doobie/free/Aliases.scala#L10
+trait Trait {
+  type T1 // like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/free/Aliases.scala#L14
+  object Nested {
+    type T2
+  }
+}
+
+class Clazz {
+  type T3
+}
+
+// like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/hi/package.scala#L25
+package object PackageObject extends Trait
+
+package pkg {
+  object Obj extends Clazz
+}
+
 object ExplicitResultTypesPathDependent {
   class Path {
     class B { class C }
@@ -14,4 +34,14 @@ object ExplicitResultTypesPathDependent {
     def bar: Self
   }
   implicit def foo[T]: Foo[T]#Self = null.asInstanceOf[Foo[T]].bar
+
+  // like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/util/query.scala#L163
+  def t1: PackageObject.T1 = ???
+  val t1Ref: test.explicitResultTypes.PackageObject.T1 = t1
+
+  def t2: PackageObject.Nested.T2 = ???
+  val t2Ref: test.explicitResultTypes.PackageObject.Nested.T2 = t2
+
+  def t3: pkg.Obj.T3 = ???
+  val t3Ref: Obj.T3 = t3
 }

--- a/scalafix-tests/output/src/main/scala/tests/ExplicitResultTypesImports.scala
+++ b/scalafix-tests/output/src/main/scala/tests/ExplicitResultTypesImports.scala
@@ -18,7 +18,6 @@ object ExplicitResultTypesImports {
 
   val timezone: ju.TimeZone = null.asInstanceOf[java.util.TimeZone]
 
-  // TODO: Is this desirable behavior?
   val inner: Searching.SearchResult = null.asInstanceOf[scala.collection.Searching.SearchResult]
 
   final val javaEnum: Category = java.util.Locale.Category.DISPLAY


### PR DESCRIPTION
Best reviewed by commits (as each of them should be green test-wise): the first one prevents compilation error when running the rule against a codebase using https://github.com/tpolecat/doobie (see commit message and comments in test), while the second improve reference shortening for path-dependent types.