### PR TITLE
allow building on JDK 15

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -3,5 +3,4 @@
 -Xmx2G
 -XX:ReservedCodeCacheSize=1024m
 -XX:+TieredCompilation
--XX:+CMSClassUnloadingEnabled
 -Dfile.encoding=UTF-8


### PR DESCRIPTION
I don't know anything about this flag, but JDK 15 doesn't accept it.

A possible alternate approach here would be to add `-XX:+IgnoreUnrecognizedVMOptions`.