### PR TITLE
adapt to scala/scala#9292 (ArrayCharSequence)

### DIFF
--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
@@ -43,11 +43,20 @@ final class DisableSyntax(config: DisableSyntaxConfig)
     val regexDiagnostics = Seq.newBuilder[Diagnostic]
     config.regex.foreach { regex =>
       val (matcher, pattern, groupIndex) = regex.value match {
-        case Right(pat) => (pat.matcher(doc.input.chars), pat.pattern, 0)
+        case Right(pat) =>
+          (
+            pat.matcher(java.nio.CharBuffer.wrap(doc.input.chars)),
+            pat.pattern,
+            0
+          )
         case Left(reg) =>
           val pattern = reg.pattern
           val groupIndex = reg.captureGroup.getOrElse(0)
-          (pattern.matcher(doc.input.chars), pattern.pattern, groupIndex)
+          (
+            pattern.matcher(java.nio.CharBuffer.wrap(doc.input.chars)),
+            pattern.pattern,
+            groupIndex
+          )
       }
 
       val message = regex.message.getOrElse(s"$pattern is disabled")

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ArgsSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ArgsSuite.scala
@@ -2,9 +2,9 @@ package scalafix.tests.config
 
 import metaconfig.Conf
 import metaconfig.internal.ConfGet
-import scalafix.internal.v1.Args
 import metaconfig.typesafeconfig.typesafeConfigMetaconfigParser
 import scalafix.internal.config.ScalafixConfig
+import scalafix.internal.v1.Args
 
 class ArgsSuite extends munit.FunSuite {
 


### PR DESCRIPTION
this will future-proof you against scala/scala#9292, which will
be included in Scala 2.13.4.

ArrayCharSequence only existed to plug a whole in the Java standard
library which, as of Java 8, is now plugged. we are likely to
deprecate ArrayCharSequence, so this is actually code improvement
and not an ugly workaround