### PR TITLE
Fix Patch.replaceSymbols bug that affects ScalaTest rule.

### DIFF
--- a/scalafix-tests/input/src/main/scala/org/scalatest_autofix/Matchers.scala
+++ b/scalafix-tests/input/src/main/scala/org/scalatest_autofix/Matchers.scala
@@ -1,0 +1,9 @@
+/*
+ignore = true
+*/
+package org.scalatest_autofix
+
+object Matchers extends Matchers
+class Matchers {
+  def shouldBe(n: Int): Unit = ???
+}

--- a/scalafix-tests/input/src/main/scala/tests/scalatest_autofix/ScalatestAutofixRule.scala
+++ b/scalafix-tests/input/src/main/scala/tests/scalatest_autofix/ScalatestAutofixRule.scala
@@ -1,0 +1,10 @@
+/*
+rule = ScalatestAutofixRule
+*/
+package tests.scalatest_autofix
+
+import org.scalatest_autofix.Matchers._
+
+object ScalatestAutofixRule {
+  def foo(): Unit = shouldBe(1)
+}

--- a/scalafix-tests/input/src/main/scala/tests/scalatest_autofix/ScalatestAutofixRule2.scala
+++ b/scalafix-tests/input/src/main/scala/tests/scalatest_autofix/ScalatestAutofixRule2.scala
@@ -1,0 +1,22 @@
+/*
+rule = ScalatestAutofixRule
+*/
+package tests.scalatest_autofix
+
+import scala.collection.mutable
+
+object ScalatestAutofixRule2 {
+  object WithRename {
+    import org.scalatest_autofix.{Matchers => ScalaTestMatchers}
+
+    class UsesRename extends ScalaTestMatchers
+    class UsesOriginal extends org.scalatest_autofix.Matchers {
+      val x = mutable.ListBuffer.empty[Int]
+    }
+  }
+  object WithoutRename {
+    import org.scalatest_autofix.Matchers
+    class UsesRename extends Matchers
+    class UsesOriginal extends org.scalatest_autofix.Matchers
+  }
+}

--- a/scalafix-tests/output/src/main/scala/org/scalatest_autofix/matchers/should/Matchers.scala
+++ b/scalafix-tests/output/src/main/scala/org/scalatest_autofix/matchers/should/Matchers.scala
@@ -1,0 +1,6 @@
+package org.scalatest_autofix.matchers.should
+
+object Matchers extends Matchers
+class Matchers {
+  def shouldBe(n: Int): Unit = ???
+}

--- a/scalafix-tests/output/src/main/scala/tests/scalatest_autofix/ScalatestAutofixRule.scala
+++ b/scalafix-tests/output/src/main/scala/tests/scalatest_autofix/ScalatestAutofixRule.scala
@@ -1,0 +1,7 @@
+package tests.scalatest_autofix
+
+import org.scalatest_autofix.matchers.should.Matchers._
+
+object ScalatestAutofixRule {
+  def foo(): Unit = shouldBe(1)
+}

--- a/scalafix-tests/output/src/main/scala/tests/scalatest_autofix/ScalatestAutofixRule2.scala
+++ b/scalafix-tests/output/src/main/scala/tests/scalatest_autofix/ScalatestAutofixRule2.scala
@@ -1,0 +1,20 @@
+package tests.scalatest_autofix
+
+import scala.collection.mutable
+import org.scalatest_autofix.matchers
+import org.scalatest_autofix.matchers.should.Matchers
+
+object ScalatestAutofixRule2 {
+  object WithRename {
+    import org.scalatest_autofix.matchers.should.{Matchers => ScalaTestMatchers}
+
+    class UsesRename extends ScalaTestMatchers
+    class UsesOriginal extends matchers.should.Matchers {
+      val x = mutable.ListBuffer.empty[Int]
+    }
+  }
+  object WithoutRename {
+    class UsesRename extends Matchers
+    class UsesOriginal extends matchers.should.Matchers
+  }
+}

--- a/scalafix-tests/unit/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/scalafix-tests/unit/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -2,6 +2,7 @@ banana.rule.SemanticRuleV1
 banana.rule.SyntacticRuleV1
 banana.rule.CommentFileNonAtomic
 banana.rule.CommentFileAtomic
+scalafix.test.ScalatestAutofixRule
 scalafix.test.ExplicitSynthetic
 scalafix.tests.cli.CrashingRule
 scalafix.tests.cli.NoOpRule

--- a/scalafix-tests/unit/src/main/scala/scalafix/test/ScalatestAutofixRule.scala
+++ b/scalafix-tests/unit/src/main/scala/scalafix/test/ScalatestAutofixRule.scala
@@ -1,0 +1,12 @@
+package scalafix.test
+
+import scalafix.v1.SemanticRule
+import scalafix.v1._
+
+class ScalatestAutofixRule extends SemanticRule("ScalatestAutofixRule") {
+  override def fix(implicit doc: SemanticDocument): Patch = {
+    Patch.replaceSymbols(
+      "org.scalatest_autofix.Matchers" -> "org.scalatest_autofix.matchers.should.Matchers"
+    )
+  }
+}


### PR DESCRIPTION
Previously, the ScalaTest autofix rule didn't properly handle cases with
renamed imports due to a bug in Scalafix. This commit fixes that bug so
that the ScalaTest rule works correctly as expected.