### PR TITLE
Add Mega-Linter in list of integrating tools

### DIFF
--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -446,6 +446,7 @@ Scalafix is supported in other build tools via externally maintained plugins:
 - Mill: [mill-scalafix](https://github.com/joan38/mill-scalafix)
 - Gradle: [gradle-scalafix](https://github.com/cosmicsilence/gradle-scalafix)
 - Maven: [scalafix-maven-plugin](https://github.com/evis/scalafix-maven-plugin)
+- [Mega-Linter](https://nvuillam.github.io/mega-linter/): More than 70 linters ready to use for GitHub Actions, other CI tools and locally, including [scalafix](https://nvuillam.github.io/mega-linter/descriptors/scala_scalafix/) activated by default
 
 ## SNAPSHOT
 

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -446,7 +446,7 @@ Scalafix is supported in other build tools via externally maintained plugins:
 - Mill: [mill-scalafix](https://github.com/joan38/mill-scalafix)
 - Gradle: [gradle-scalafix](https://github.com/cosmicsilence/gradle-scalafix)
 - Maven: [scalafix-maven-plugin](https://github.com/evis/scalafix-maven-plugin)
-- [Mega-Linter](https://nvuillam.github.io/mega-linter/): More than 70 linters ready to use for GitHub Actions, other CI tools and locally, including [scalafix](https://nvuillam.github.io/mega-linter/descriptors/scala_scalafix/) activated by default (limited to [built-in syntactic rules](https://scalacenter.github.io/scalafix/docs/rules/overview.html), as there is no prior compilation)
+- [Mega-Linter](https://nvuillam.github.io/mega-linter/descriptors/scala_scalafix) (only built-in syntactic rules are supported)
 
 ## SNAPSHOT
 

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -446,7 +446,7 @@ Scalafix is supported in other build tools via externally maintained plugins:
 - Mill: [mill-scalafix](https://github.com/joan38/mill-scalafix)
 - Gradle: [gradle-scalafix](https://github.com/cosmicsilence/gradle-scalafix)
 - Maven: [scalafix-maven-plugin](https://github.com/evis/scalafix-maven-plugin)
-- [Mega-Linter](https://nvuillam.github.io/mega-linter/): More than 70 linters ready to use for GitHub Actions, other CI tools and locally, including [scalafix](https://nvuillam.github.io/mega-linter/descriptors/scala_scalafix/) activated by default (limited to [built-in syntactic rules](https://scalacenter.github.io/scalafix/docs/rules/overview.html), as there is no priori compilation)
+- [Mega-Linter](https://nvuillam.github.io/mega-linter/): More than 70 linters ready to use for GitHub Actions, other CI tools and locally, including [scalafix](https://nvuillam.github.io/mega-linter/descriptors/scala_scalafix/) activated by default (limited to [built-in syntactic rules](https://scalacenter.github.io/scalafix/docs/rules/overview.html), as there is no prior compilation)
 
 ## SNAPSHOT
 

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -446,7 +446,7 @@ Scalafix is supported in other build tools via externally maintained plugins:
 - Mill: [mill-scalafix](https://github.com/joan38/mill-scalafix)
 - Gradle: [gradle-scalafix](https://github.com/cosmicsilence/gradle-scalafix)
 - Maven: [scalafix-maven-plugin](https://github.com/evis/scalafix-maven-plugin)
-- [Mega-Linter](https://nvuillam.github.io/mega-linter/): More than 70 linters ready to use for GitHub Actions, other CI tools and locally, including [scalafix](https://nvuillam.github.io/mega-linter/descriptors/scala_scalafix/) activated by default
+- [Mega-Linter](https://nvuillam.github.io/mega-linter/): More than 70 linters ready to use for GitHub Actions, other CI tools and locally, including [scalafix](https://nvuillam.github.io/mega-linter/descriptors/scala_scalafix/) activated by default (limited to [built-in syntactic rules](https://scalacenter.github.io/scalafix/docs/rules/overview.html), as there is no priori compilation)
 
 ## SNAPSHOT
 


### PR DESCRIPTION
Hi, thanks for your linter :) 

I integrated it in Mega-Linter, can I put a link here ? :)

Internal documentation is https://nvuillam.github.io/mega-linter/descriptors/scala_scalafix/, do you have remarks ?

Best regards :)