### PR TITLE
RemoveUnused: add example for patternvars & add reference to scala 2.13

### DIFF
--- a/docs/rules/RemoveUnused.md
+++ b/docs/rules/RemoveUnused.md
@@ -64,6 +64,26 @@ object Main {
 }
 ```
 
+Remove unused pattern match variables (Scala 2.12 & 2.13 only):
+
+```scala
+case class AB(a: Int, b: String)
+// before
+object Main {
+  val example = AB(42, "lol")
+  example match {
+    case AB(a, b) => println("Not used")
+  }
+}
+// after
+object Main {
+  val example = AB(42, "lol")
+  example match {
+    case AB(_, _) => println("Not used")
+  }
+}
+```
+
 ## Formatting
 
 > This rule does a best-effort at preserving original formatting. In some cases,
@@ -98,7 +118,7 @@ println(scalafix.website.rule("RemoveUnused", RemoveUnusedConfig.default))
 Consult `scala -Y` in the command-line for more information about using
 `-Ywarn-unused`.
 
-For Scala @SCALA212@
+For Scala @SCALA212@ & @SCALA213@
 
 ```
 $ scala -Ywarn-unused:help

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnusedConfig.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnusedConfig.scala
@@ -13,7 +13,7 @@ case class RemoveUnusedConfig(
     @Description("Remove unused local definitions")
     locals: Boolean = true,
     @Description(
-      "Remove unused pattern match variables (compatible with Scala 2.12 and 2.13"
+      "Remove unused pattern match variables (compatible with Scala 2.12 and 2.13)"
     )
     patternvars: Boolean = true
 )


### PR DESCRIPTION
Follows https://github.com/scalacenter/scalafix/pull/1318