### PR TITLE
Close global after compute ondemand semanticdb files

### DIFF
--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
@@ -383,7 +383,7 @@ case class Args(
         settings.YpresentationAnyThread.value = true
         settings.classpath.value = validatedClasspath.syntax
         val reporter = new StoreReporter()
-        new Global(settings, reporter)
+        new Global(settings, reporter, "Scalafix")
       })
     }
 


### PR DESCRIPTION
The state before the fix. It possible to reproduce by running multiple time the test on-demand with scalacOptions
The presentation compiler is never closed.

![image](https://user-images.githubusercontent.com/7843237/109968921-94c88b00-7cf3-11eb-8d68-e69f12b4a970.png)
