### PR TITLE
Don't produce each time a RichCompilationUnit

### DIFF
--- a/scalafix-rules/src/main/scala/scala/meta/internal/proxy/GlobalProxy.scala
+++ b/scalafix-rules/src/main/scala/scala/meta/internal/proxy/GlobalProxy.scala
@@ -6,9 +6,6 @@ import scala.meta.internal.pc.ScalafixGlobal
 
 object GlobalProxy {
   def typedTreeAt(g: ScalafixGlobal, pos: Position): g.Tree = {
-    // NOTE(olafur) clearing `unitOfFile` fixes a bug where `typedTreeAt` would
-    // produce symbols with erroneous `.info` signatures.
-    g.unitOfFile.clear()
     g.typedTreeAt(pos)
   }
 }


### PR DESCRIPTION
The bug doesn't seem to exist anymore.
This call was increasing the memory usage of ExpicitResultType