### PR TITLE
Upgrade Scalameta to 4.4.12

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import scala.util.{Properties, Try}
 /* scalafmt: { maxColumn = 120 }*/
 
 object Dependencies {
-  val scalametaV = "4.4.10"
+  val scalametaV = "4.4.12"
   val metaconfigV = "0.9.10"
   def scala210 = "2.10.7"
   def scala211 = "2.11.12"


### PR DESCRIPTION
Issue #1337 is caused by a regression introduced in scalameta/scalameta#2239, and got fixed by scalameta/scalameta#2260, which is included in Scalameta 4.4.11. This PR upgrades Scalameta to 4.4.12 to include the fix, so that issue #1337 can be resolved.
