### PR TITLE
Fix snapshot version string in the Installation page

### DIFF
--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -459,11 +459,11 @@ If using the sbt plugin
  // project/plugins.sbt
  addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "@VERSION@")
 +resolvers += Resolver.sonatypeRepo("snapshots")
-+dependencyOverrides += "ch.epfl.scala" % "scalafix-interfaces" % "@NIGHTLY_VERSION@-SNAPSHOT"
++dependencyOverrides += "ch.epfl.scala" % "scalafix-interfaces" % "@NIGHTLY_VERSION@"
 ```
 
 If using the command-line interface
 
 ```sh
-cs launch ch.epfl.scala:scalafix-cli_@SCALA212@:@NIGHTLY_VERSION@-SNAPSHOT -r sonatype:snapshots --main scalafix.cli.Cli -- --help
+cs launch ch.epfl.scala:scalafix-cli_@SCALA212@:@NIGHTLY_VERSION@ -r sonatype:snapshots --main scalafix.cli.Cli -- --help
 ```


### PR DESCRIPTION
For snapshot releases, the `@NIGHTLY_VERSION@` string already contains the `-SNAPSHOT` suffix. The current version produces wrong outputs like the following:

```diff
 // project/plugins.sbt
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.27")
+resolvers += Resolver.sonatypeRepo("snapshots")
+dependencyOverrides += "ch.epfl.scala" % "scalafix-interfaces" % "0.9.27+13-5a94c83f-SNAPSHOT-SNAPSHOT"
```

This PR removes the redundant `-SNAPSHOT` suffix.