### PR TITLE
add triggered config description to docs

### DIFF
--- a/docs/users/configuration.md
+++ b/docs/users/configuration.md
@@ -34,8 +34,15 @@ DisableSyntax.noFinalize = true
 
 ## Triggered configuration
 
-Overlay rules and rule specific configuration for scalafix on compilation, which is enabled by `scalafixOnCompile := true`.
-Every configuration can be overlaid by `triggered` prefix. With the following configuration, explicit scalafix invocation will run with `[ DisableSyntax, RemoveUnused ]` rules, while scalafix on compilation will run with `[ DisableSyntax ]` rule.
+When Scalafix is triggered automatically (`scalafixOnCompile := true`), the
+values for keys prefixed with `triggered` takes precedence over the default
+configuration - both for rules and rule-specific configuration. You can think
+of `triggered` as a optional overlay, on top of the default configuration.
+  
+For example, with the following configuration, explicit scalafix invocation
+will run `DisableSyntax` & `RemoveUnused`, while triggered invocations
+will only run `DisableSyntax`. In both cases, the `noFinalize` configuration
+is enabled.
 
 ```scala
 // .scalafix.conf

--- a/docs/users/configuration.md
+++ b/docs/users/configuration.md
@@ -31,3 +31,22 @@ rules = [
 ]
 DisableSyntax.noFinalize = true
 ```
+
+## Triggered configuration
+
+Overlay rules and rule specific configuration for scalafix on compilation, which is enabled by `scalafixOnCompile := true`.
+Every configuration can be overlaid by `triggered` prefix. With the following configuration, explicit scalafix invocation will run with `[ DisableSyntax, RemoveUnused ]` rules, while scalafix on compilation will run with `[ DisableSyntax ]` rule.
+
+```scala
+// .scalafix.conf
+rules = [
+  DisableSyntax,
+  RemoveUnused
+]
+DisableSyntax.noFinalize = true
+
+// `rules` on compilation
+triggered.rules = [
+  DisableSyntax
+]
+```

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -231,7 +231,9 @@ feature with care as it has several shortcomings, for example:
    is the first task executed, without any other concurrently.
 1. Some rules such as `RemoveUnused` can be counter-productive if applied too
    often/early, as the work-in-progress code that was just added might disappear
-   after a simple `test`.
+   after a simple `test`. 
+   `triggered` prefix in `.scalafix.conf` will help you to run scalafix on compile
+   with different configuration than explicit invocation.
 1. If you run many semantic rules by default, the last one(s) to run might see
    stale information and fail the invocation, which needs to be re-run manually.
    This is [not specific to `scalafixOnCompile`](https://github.com/scalacenter/scalafix/issues/1204),
@@ -243,7 +245,7 @@ feature with care as it has several shortcomings, for example:
 1. Non-idempotent rewrite rules might get you in an infinite loop where sources
    never converge - not specific to `scalafixOnCompile` either, but rather
    confusing when triggered automatically.
-1. Bugs in rule implementations can prevent you from getting a successul
+1. Bugs in rule implementations can prevent you from getting a successful
    `compile`, blocking testing or publishing for example
 
 ### Run custom rules

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -239,7 +239,7 @@ feature with care as it has several shortcomings, for example:
    stale information and fail the invocation, which needs to be re-run manually.
    This is [not specific to `scalafixOnCompile`](https://github.com/scalacenter/scalafix/issues/1204),
    but the problem becomes much more visible with it.
-1. To keep the overhad minimal, `scalafixCaching` is automatically enabled when
+1. To keep the overhead minimal, `scalafixCaching` is automatically enabled when
    `scalafixOnCompile` is, which can cause unexpected behaviors if you run into
    false positive cache hits. `scalafixCaching` can explicitly be set to
    `false` in that case.

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -232,8 +232,9 @@ feature with care as it has several shortcomings, for example:
 1. Some rules such as `RemoveUnused` can be counter-productive if applied too
    often/early, as the work-in-progress code that was just added might disappear
    after a simple `test`. 
-   `triggered` prefix in `.scalafix.conf` will help you to run scalafix on compile
-   with different configuration than explicit invocation.
+   To make such invocations less intrusive, you can change the rules and rules
+   configuration used in that case by defining in `.scalafix.conf`
+   [custom values for them](configuration.md#triggered-configuration).
 1. If you run many semantic rules by default, the last one(s) to run might see
    stale information and fail the invocation, which needs to be re-run manually.
    This is [not specific to `scalafixOnCompile`](https://github.com/scalacenter/scalafix/issues/1204),


### PR DESCRIPTION
ref: https://github.com/scalacenter/scalafix/pull/1217 https://github.com/scalacenter/sbt-scalafix/pull/169

This is a follow up PR to introduce `--triggered` args and `triggered` configuration prefix to run scalafix on compilation with different config.