### PR TITLE
Configure correctly semanticdb targetroot depending on the dialect

### DIFF
--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -34,7 +34,8 @@ object Mima {
       ProblemFilters.exclude[Problem]("scalafix.testkit.SemanticRuleSuite"),
       ProblemFilters.exclude[Problem]("scalafix.testkit.SemanticRuleSuite.*"),
       ProblemFilters.exclude[MissingClassProblem]("scalafix.testkit.SyntacticRuleSuite$"),
-      ProblemFilters.exclude[Problem]("scalafix.testkit.SyntacticRuleSuite")
+      ProblemFilters.exclude[Problem]("scalafix.testkit.SyntacticRuleSuite"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("scalafix.interfaces.ScalafixArguments.withSemanticdbTargetroot")
     )
   }
 }

--- a/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixArgumentsImpl.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixArgumentsImpl.scala
@@ -166,6 +166,10 @@ final case class ScalafixArgumentsImpl(args: Args = Args.default)
     copy(args = args.copy(sourceroot = Some(AbsolutePath(path)(args.cwd))))
   }
 
+  override def withTargetroot(path: Path): ScalafixArguments = {
+    copy(args = args.copy(targetroot = Some(AbsolutePath(path)(args.cwd))))
+  }
+
   override def withMainCallback(
       callback: ScalafixMainCallback
   ): ScalafixArguments =

--- a/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixArgumentsImpl.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixArgumentsImpl.scala
@@ -166,8 +166,10 @@ final case class ScalafixArgumentsImpl(args: Args = Args.default)
     copy(args = args.copy(sourceroot = Some(AbsolutePath(path)(args.cwd))))
   }
 
-  override def withTargetroot(path: Path): ScalafixArguments = {
-    copy(args = args.copy(targetroot = Some(AbsolutePath(path)(args.cwd))))
+  override def withSemanticdbTargetroot(path: Path): ScalafixArguments = {
+    copy(args =
+      args.copy(semanticdbTargetroot = Some(AbsolutePath(path)(args.cwd)))
+    )
   }
 
   override def withMainCallback(

--- a/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixArgumentsImpl.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixArgumentsImpl.scala
@@ -129,7 +129,7 @@ final case class ScalafixArgumentsImpl(args: Args = Args.default)
       case ScalafixDialect.Scala2 =>
         copy(args = args.copy(dialect = ScalafixConfig.Scala2))
       case ScalafixDialect.Scala3 =>
-        copy(args = args.copy(dialect = scala.meta.dialects.Scala3))
+        copy(args = args.copy(dialect = ScalafixConfig.Scala3))
     }
 
   override def withParsedArguments(

--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
@@ -111,6 +111,11 @@ case class Args(
     )
     sourceroot: Option[AbsolutePath] = None,
     @Description(
+      "Absolute path passed to semanticdb with -P:semanticdb:targetroot:<path>. " +
+        "Used to locate semanticdb files. Default, Scalafix will try to locate semanticdb files under the classpath"
+    )
+    targetroot: Option[AbsolutePath] = None,
+    @Description(
       "If set, automatically infer the --classpath flag by scanning for directories with META-INF/semanticdb"
     )
     autoClasspath: Boolean = false,
@@ -342,7 +347,9 @@ case class Args(
   }
 
   def validatedClasspath: Classpath = {
-    val targetroot = semanticTargetRoot
+    val targetrootClasspath = targetroot
+      .map(_.toString())
+      .orElse(semanticTargetRoot())
       .map(option => Classpath(option))
       .getOrElse(Classpath(Nil))
     val baseClasspath =
@@ -354,7 +361,7 @@ case class Args(
       } else {
         classpath
       }
-    targetroot ++ baseClasspath
+    targetrootClasspath ++ baseClasspath
   }
 
   def classLoader: ClassLoader =

--- a/scalafix-core/src/main/scala/scalafix/internal/config/ScalafixConfig.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/config/ScalafixConfig.scala
@@ -37,5 +37,6 @@ object ScalafixConfig {
     decoder(default)
 
   val Scala2: Dialect = scala.meta.dialects.Scala213
+  val Scala3: Dialect = scala.meta.dialects.Scala3
   val DefaultSbtDialect: Dialect = scala.meta.dialects.Sbt1
 }

--- a/scalafix-core/src/main/scala/scalafix/internal/config/ScalafixMetaconfigReaders.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/config/ScalafixMetaconfigReaders.scala
@@ -21,7 +21,6 @@ import metaconfig.ConfError
 import metaconfig.Configured
 import metaconfig.Configured.NotOk
 import metaconfig.Configured.Ok
-import scalafix.internal.config.ScalafixConfig.Scala2
 import scalafix.internal.util.SymbolOps
 import scalafix.patch.Patch.internal._
 import scalafix.v0.Symbol
@@ -36,7 +35,7 @@ trait ScalafixMetaconfigReaders {
     ReaderUtil.oneOf[MetaParser](parseSource, parseStat, parseCase)
   }
   implicit lazy val dialectReader: ConfDecoder[Dialect] = {
-    import scala.meta.dialects._
+    import scalafix.internal.config.ScalafixConfig._
     ReaderUtil.oneOf[Dialect](
       Scala2,
       Scala3

--- a/scalafix-interfaces/src/main/java/scalafix/interfaces/ScalafixArguments.java
+++ b/scalafix-interfaces/src/main/java/scalafix/interfaces/ScalafixArguments.java
@@ -145,6 +145,12 @@ public interface ScalafixArguments {
     ScalafixArguments withSourceroot(Path path);
 
     /**
+     * @param path The SemanticDB targetroot path passed via --targetroot. Must match <code>path</code>
+     *             in <code>-Xplugin:semanticdb:targetroot:{path}</path></code> if used.
+     */
+    ScalafixArguments withTargetroot(Path path);
+
+    /**
      * @param callback Handler for reported linter messages. If not provided, defaults to printing
      *                 linter messages to the Stdout.
      */

--- a/scalafix-interfaces/src/main/java/scalafix/interfaces/ScalafixArguments.java
+++ b/scalafix-interfaces/src/main/java/scalafix/interfaces/ScalafixArguments.java
@@ -148,7 +148,7 @@ public interface ScalafixArguments {
      * @param path The SemanticDB targetroot path passed via --targetroot. Must match <code>path</code>
      *             in <code>-Xplugin:semanticdb:targetroot:{path}</path></code> if used.
      */
-    ScalafixArguments withTargetroot(Path path);
+    ScalafixArguments withSemanticdbTargetroot(Path path);
 
     /**
      * @param callback Handler for reported linter messages. If not provided, defaults to printing

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/RuleTest.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/RuleTest.scala
@@ -66,6 +66,6 @@ object RuleTest {
   }
 
   def getDialectFromScalaV(scalaV: String): Dialect =
-    if (scalaV.startsWith("3")) scala.meta.dialects.Scala3
-    else scala.meta.dialects.Scala213
+    if (scalaV.startsWith("3")) ScalafixConfig.Scala3
+    else ScalafixConfig.Scala2
 }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ArgsSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ArgsSuite.scala
@@ -72,4 +72,15 @@ class ArgsSuite extends munit.FunSuite {
 
     assertEquals(disableSyntaxRule, expected)
   }
+
+  test("targetRoot") {
+    val targetRootPath = "/some-path"
+    val scalacOptions = List("-semanticdb-target", targetRootPath)
+    val args = Args.default.copy(
+      dialect = ScalafixConfig.Scala3,
+      scalacOptions = scalacOptions
+    )
+    val semanticTargetRoot = args.semanticTargetRoot()
+    assert(semanticTargetRoot.contains(targetRootPath))
+  }
 }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ArgsSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ArgsSuite.scala
@@ -1,5 +1,7 @@
 package scalafix.tests.config
 
+import scala.meta.io.AbsolutePath
+
 import metaconfig.Conf
 import metaconfig.internal.ConfGet
 import metaconfig.typesafeconfig.typesafeConfigMetaconfigParser
@@ -76,11 +78,12 @@ class ArgsSuite extends munit.FunSuite {
   test("targetRoot") {
     val targetRootPath = "/some-path"
     val scalacOptions = List("first", "-semanticdb-target", targetRootPath)
-    val args = Args.default.copy(
+    val args: Args = Args.default.copy(
       dialect = ScalafixConfig.Scala3,
-      scalacOptions = scalacOptions
+      scalacOptions = scalacOptions,
+      scalaVersion = "3.0.0-RC3"
     )
-    val semanticTargetRoot = args.targetrootFromScalacOptions()
-    assert(semanticTargetRoot.contains(targetRootPath))
+    val classpath = args.validatedClasspath
+    assert(classpath.entries.contains(AbsolutePath(targetRootPath)))
   }
 }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ArgsSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ArgsSuite.scala
@@ -75,12 +75,12 @@ class ArgsSuite extends munit.FunSuite {
 
   test("targetRoot") {
     val targetRootPath = "/some-path"
-    val scalacOptions = List("-semanticdb-target", targetRootPath)
+    val scalacOptions = List("first", "-semanticdb-target", targetRootPath)
     val args = Args.default.copy(
       dialect = ScalafixConfig.Scala3,
       scalacOptions = scalacOptions
     )
-    val semanticTargetRoot = args.semanticTargetRoot()
+    val semanticTargetRoot = args.targetrootFromScalacOptions()
     assert(semanticTargetRoot.contains(targetRootPath))
   }
 }


### PR DESCRIPTION
it makes me release that sourceroot need also to be configured differently if the dialect Scala3.

There are two commits in this PR. The second is a proposition to make the targetroot configurable through the api