### PR TITLE
The idea it to use the new ScalaVersion model instead of a string

### DIFF
--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
@@ -289,7 +289,7 @@ case class Args(
 
     val configuration = Configuration()
       .withConf(targetConf)
-      .withScalaVersion(scalaVersion.value)
+      .withScalaVersion(scalaVersion)
       .withScalacOptions(scalacOptions)
       .withScalacClasspath(validatedClasspath.entries)
     decoder.read(rulesConf).andThen(_.withConfiguration(configuration))

--- a/scalafix-core/src/main/scala/scalafix/internal/config/ScalaVersion.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/config/ScalaVersion.scala
@@ -23,6 +23,12 @@ sealed trait ScalaVersion {
 
   def isScala2: Boolean = major == Major.Scala2
   def isScala3: Boolean = major == Major.Scala3
+  def isScala211: Boolean = isScala2 && minor.contains(11)
+
+  def isFullVersion: Boolean = this match {
+    case _: Patch => true
+    case _ => false
+  }
 
   def value: String = this match {
     case Major(major) => s"${major.value}"
@@ -44,12 +50,22 @@ object ScalaVersion {
       extends ScalaVersion {
     override val minor: Some[Int] = Some(minorVersion)
     override val patch = None
-
   }
+
   case class Patch(major: MajorVersion, minorVersion: Int, patchVersion: Int)
       extends ScalaVersion {
     override val minor: Some[Int] = Some(minorVersion)
     override val patch: Some[Int] = Some(patchVersion)
+
+    def binaryVersion: Minor = Minor(major, minorVersion)
+  }
+  object Patch {
+    def from(s: String): Try[Patch] = {
+      ScalaVersion.from(s) match {
+        case Success(patch: Patch) => Success(patch)
+        case _ => Failure(new Exception(s"$s is not a valid full version."))
+      }
+    }
   }
 
   sealed trait MajorVersion {

--- a/scalafix-core/src/main/scala/scalafix/v1/Configuration.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/Configuration.scala
@@ -2,15 +2,16 @@ package scalafix.v1
 import scala.meta.io.AbsolutePath
 
 import metaconfig.Conf
+import scalafix.internal.config.ScalaVersion
 
 final class Configuration private (
-    val scalaVersion: String,
+    val scalaVersion: ScalaVersion,
     val scalacOptions: List[String],
     val scalacClasspath: List[AbsolutePath],
     val conf: Conf
 ) {
 
-  def withScalaVersion(version: String): Configuration = {
+  def withScalaVersion(version: ScalaVersion): Configuration = {
     copy(scalaVersion = version)
   }
 
@@ -30,7 +31,7 @@ final class Configuration private (
     s"Configuration($scalaVersion, $scalacOptions, $scalacClasspath, $conf)"
 
   private[this] def copy(
-      scalaVersion: String = this.scalaVersion,
+      scalaVersion: ScalaVersion = this.scalaVersion,
       scalacOptions: List[String] = this.scalacOptions,
       scalacClasspath: List[AbsolutePath] = this.scalacClasspath,
       conf: Conf = this.conf
@@ -45,9 +46,14 @@ final class Configuration private (
 }
 
 object Configuration {
+  val runtimeScalaV: ScalaVersion = ScalaVersion
+    .from(scala.util.Properties.versionNumberString)
+    .toOption
+    .getOrElse(ScalaVersion.scala2)
+
   def apply(): Configuration = {
     new Configuration(
-      scala.util.Properties.versionNumberString,
+      runtimeScalaV,
       Nil,
       Nil,
       Conf.Obj()

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/RuleTest.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/RuleTest.scala
@@ -6,6 +6,7 @@ import scala.meta.internal.symtab.SymbolTable
 import metaconfig.Conf
 import metaconfig.internal.ConfGet
 import metaconfig.typesafeconfig.typesafeConfigMetaconfigParser
+import scalafix.internal.config.ScalaVersion
 import scalafix.internal.config.ScalafixConfig
 import scalafix.internal.diff.DiffDisable
 import scalafix.internal.v1.LazyValue
@@ -55,7 +56,7 @@ object RuleTest {
         .getOrElse(Conf.Lst(Nil))
       val config = Configuration()
         .withConf(conf)
-        .withScalaVersion(props.scalaVersion)
+        .withScalaVersion(ScalaVersion.from(props.scalaVersion).get)
         .withScalacOptions(props.scalacOptions)
         .withScalacClasspath(props.inputClasspath.entries)
       val rules = decoder.read(rulesConf).get.withConfiguration(config).get

--- a/scalafix-tests/unit/src/main/scala/scalafix/test/ExplicitSynthetic.scala
+++ b/scalafix-tests/unit/src/main/scala/scalafix/test/ExplicitSynthetic.scala
@@ -15,7 +15,7 @@ class ExplicitSynthetic(insertInfixTypeParam: Boolean)
       new ExplicitSynthetic(
         // There is a Scala parser bug in 2.11 and below under -Yrangepos
         // that causes a crash for explicit type parameters on infix operators.
-        insertInfixTypeParam = !config.scalaVersion.startsWith("2.11")
+        insertInfixTypeParam = !config.scalaVersion.isScala211
       )
     )
 

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSyntacticSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSyntacticSuite.scala
@@ -502,7 +502,7 @@ class DeprecatedName
 
 class Scala2_9 extends SyntacticRule("Scala2_9") {
   override def withConfiguration(config: Configuration): Configured[Rule] =
-    if (!config.scalaVersion.startsWith("2.9")) {
+    if (!config.scalaVersion.value.startsWith("2.9")) {
       Configured.error("scalaVersion must start with 2.9")
     } else if (!config.scalacOptions.contains("-Ysource:2.9")) {
       Configured.error("scalacOptions must contain -Ysource:2.9")

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ExplicitResultTypesConfigSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ExplicitResultTypesConfigSuite.scala
@@ -1,13 +1,14 @@
 package scalafix.tests.config
 
 import org.scalatest.funsuite.AnyFunSuite
+import scalafix.internal.config.ScalaVersion
 import scalafix.internal.reflect.ClasspathOps
 import scalafix.internal.rule._
 import scalafix.v1.Configuration
 
 class ExplicitResultTypesConfigSuite extends AnyFunSuite {
   test("Unsupported Scala version") {
-    val scalaVersion = "2.12.0"
+    val scalaVersion = ScalaVersion.from("2.12.0").get
     val classpath = ClasspathOps.thisClasspath.entries
     val config = new ExplicitResultTypes().withConfiguration(
       Configuration()


### PR DESCRIPTION
- missing TestkitProperties, which still use a string as scalaVersion

Not to break binary incompat, we can keep both for now, but I don't know how to name scalaVersion differently 