### PR TITLE
WIP - How to deal with rules that wont work right now in Scala 3

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/v1/SemanticDocument.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/SemanticDocument.scala
@@ -1,11 +1,12 @@
 package scalafix.v1
 
+import scalafix.internal.config.ScalaVersion
+
 import scala.meta._
 import scala.meta.contrib.AssociatedComments
 import scala.meta.internal.symtab.SymbolTable
 import scala.meta.internal.{semanticdb => s}
 import scala.meta.io.RelativePath
-
 import scalafix.internal.v1._
 import scalafix.util.MatchingParens
 import scalafix.util.TokenList
@@ -33,6 +34,8 @@ final class SemanticDocument private[scalafix] (
     internal.messages
   def synthetics: Iterator[SemanticTree] =
     internal.synthetics
+
+  def scalaVersion: ScalaVersion = internal.config.scalaVersion
 
   override def info(symbol: Symbol): Option[SymbolInformation] =
     internal.info(symbol)

--- a/scalafix-core/src/main/scala/scalafix/v1/SyntacticDocument.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/SyntacticDocument.scala
@@ -26,6 +26,7 @@ final class SyntacticDocument private[scalafix] (
   def comments: AssociatedComments = internal.comments.value
   def matchingParens: MatchingParens = internal.matchingParens.value
   def tokenList: TokenList = internal.tokenList.value
+  def scalaVersion: ScalaVersion = internal.config.scalaVersion
   override def toString: String = s"SyntacticDocument(${input.syntax})"
 }
 

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/ExplicitResultTypes.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/ExplicitResultTypes.scala
@@ -93,8 +93,11 @@ final class ExplicitResultTypes(
   }
 
   override def fix(implicit ctx: SemanticDocument): Patch = {
-    try unsafeFix()
-    catch {
+    try {
+      if (ctx.scalaVersion.isScala3) {
+        Patch.empty
+      } else unsafeFix()
+    } catch {
       case _: CompilerException =>
         shutdownCompiler()
         global.restart()


### PR DESCRIPTION
I have just noticed that we don't have accecss in the method fix to the scalaversion. 
this solution could work if we stop cross publishing rules to all scalaVersion.
What do you think about this? 