### PR TITLE
testkit: extract targetroot from scalacOptions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -212,8 +212,7 @@ lazy val unit = project
       }
       put(
         "inputClasspath",
-        (testsInput / Compile / fullClasspath).value.map(_.data) :+
-          (testsInput / Compile / semanticdbTargetRoot).value
+        (testsInput / Compile / fullClasspath).value.map(_.data)
       )
       put(
         "inputSourceDirectories",
@@ -246,7 +245,10 @@ lazy val unit = project
       "testsInputResources" ->
         (testsInput / Compile / sourceDirectory).value / "resources",
       "semanticClasspath" ->
-        (testsShared / Compile / semanticdbTargetRoot).value,
+        Seq(
+          (testsInput / Compile / semanticdbTargetRoot).value,
+          (testsShared / Compile / semanticdbTargetRoot).value
+        ),
       "sharedSourceroot" ->
         (ThisBuild / baseDirectory).value /
         "scalafix-tests" / "shared" / "src" / "main",

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -34,7 +34,7 @@ object Mima {
       ProblemFilters.exclude[Problem]("scalafix.testkit.SemanticRuleSuite.*"),
       ProblemFilters.exclude[MissingClassProblem]("scalafix.testkit.SyntacticRuleSuite$"),
       ProblemFilters.exclude[Problem]("scalafix.testkit.SyntacticRuleSuite"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("scalafix.interfaces.ScalafixArguments.withSemanticdbTargetroot")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("scalafix.interfaces.ScalafixArguments.withSemanticdbTargetroots")
     )
   }
 }

--- a/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixArgumentsImpl.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixArgumentsImpl.scala
@@ -160,9 +160,13 @@ final case class ScalafixArgumentsImpl(args: Args = Args.default)
     copy(args = args.copy(sourceroot = Some(AbsolutePath(path)(args.cwd))))
   }
 
-  override def withSemanticdbTargetroot(path: Path): ScalafixArguments = {
+  override def withSemanticdbTargetroots(
+      paths: util.List[Path]
+  ): ScalafixArguments = {
     copy(args =
-      args.copy(semanticdbTargetroot = Some(AbsolutePath(path)(args.cwd)))
+      args.copy(semanticdbTargetroots =
+        paths.asScala.toList.map(AbsolutePath(_)(args.cwd))
+      )
     )
   }
 

--- a/scalafix-interfaces/src/main/java/scalafix/interfaces/ScalafixArguments.java
+++ b/scalafix-interfaces/src/main/java/scalafix/interfaces/ScalafixArguments.java
@@ -140,10 +140,10 @@ public interface ScalafixArguments {
     ScalafixArguments withSourceroot(Path path);
 
     /**
-     * @param path The SemanticDB targetroot path passed via --targetroot. Must match <code>path</code>
-     *             in <code>-Xplugin:semanticdb:targetroot:{path}</path></code> if used.
+     * @param path The SemanticDB targetroot paths passed via --semanticdb-targetroots. Must match
+     *             <code>path</code> in <code>-Xplugin:semanticdb:targetroot:{path}</path></code> if used.
      */
-    ScalafixArguments withSemanticdbTargetroot(Path path);
+    ScalafixArguments withSemanticdbTargetroots(List<Path> path);
 
     /**
      * @param callback Handler for reported linter messages. If not provided, defaults to printing

--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ClasspathOps.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/ClasspathOps.scala
@@ -43,6 +43,11 @@ object ClasspathOps {
     new URLClassLoader(url +: getURLs(classLoader), classLoader)
   }
 
+  def thisClassLoaderWith(urls: Seq[URL]): URLClassLoader = {
+    val classLoader = this.getClass.getClassLoader
+    new URLClassLoader(urls.toArray ++ getURLs(classLoader), classLoader)
+  }
+
   def thisClasspath: Classpath = {
     Classpath(
       getURLs(this.getClass().getClassLoader())

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/AbstractSemanticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/AbstractSemanticRuleSuite.scala
@@ -10,10 +10,12 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.Suite
 import org.scalatest.TestRegistration
 import org.scalatest.exceptions.TestFailedException
+import scalafix.internal.config.ScalaVersion
 import scalafix.internal.patch.PatchInternals
 import scalafix.internal.reflect.ClasspathOps
 import scalafix.internal.testkit.AssertDiff
 import scalafix.internal.testkit.CommentAssertion
+import scalafix.internal.v1.Args
 
 /**
  * Construct a test suite for running semantic Scalafix rules.
@@ -98,8 +100,13 @@ abstract class AbstractSemanticRuleSuite(
   }
 
   lazy val testsToRun: List[RuleTest] = {
+    val args = Args.default.copy(
+      scalaVersion = ScalaVersion.from(props.scalaVersion).get,
+      scalacOptions = props.scalacOptions,
+      classpath = props.inputClasspath
+    )
     val symtab = ClasspathOps.newSymbolTable(props.inputClasspath)
-    val classLoader = ClasspathOps.toClassLoader(props.inputClasspath)
+    val classLoader = ClasspathOps.toClassLoader(args.validatedClasspath)
     val tests = TestkitPath.fromProperties(props)
     tests.map { test =>
       RuleTest.fromPath(props, test, classLoader, symtab)

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/BaseCliSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/BaseCliSuite.scala
@@ -10,8 +10,6 @@ import java.nio.file.SimpleFileVisitor
 import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.BasicFileAttributes
 
-import scala.collection.immutable.Seq
-
 import scala.meta.internal.io.FileIO
 import scala.meta.io.AbsolutePath
 import scala.meta.io.RelativePath
@@ -23,6 +21,7 @@ import scalafix.test.StringFS
 import scalafix.testkit.DiffAssertions
 import scalafix.testkit.SemanticRuleSuite
 import scalafix.testkit.TestkitProperties
+import scalafix.tests.BuildInfo
 import scalafix.tests.util.ScalaVersions
 import scalafix.v1.Main
 
@@ -179,6 +178,8 @@ trait BaseCliSuite extends AnyFunSuite with DiffAssertions {
   def checkSemantic(
       name: String,
       args: Array[String],
+      targetroots: Seq[String] =
+        BuildInfo.semanticClasspath.map(_.getAbsolutePath),
       expectedExit: ExitStatus,
       preprocess: AbsolutePath => Unit = _ => (),
       outputAssert: String => Unit = _ => (),
@@ -207,11 +208,13 @@ trait BaseCliSuite extends AnyFunSuite with DiffAssertions {
       val sourceroot =
         if (args.contains("--sourceroot")) Array[String]()
         else Array("--sourceroot", cwd.toString)
+      val targetroots0 =
+        targetroots.flatMap(Seq("--semanticdb-targetroots", _))
       val scalaOption =
         if (ScalaVersions.isScala213)
           "-Wunused:imports"
         else "-Ywarn-unused-import"
-      val allArguments = args ++ sourceroot ++ Seq(
+      val allArguments = args ++ sourceroot ++ targetroots0 ++ Seq(
         "--scalac-options",
         scalaOption,
         "-r",

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSemanticSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliSemanticSuite.scala
@@ -9,6 +9,7 @@ import scala.meta.io.Classpath
 import scala.meta.testkit.StringFS
 
 import scalafix.cli._
+import scalafix.tests.BuildInfo
 import scalafix.tests.core.Classpaths
 
 class CliSemanticSuite extends BaseCliSuite {
@@ -50,6 +51,7 @@ class CliSemanticSuite extends BaseCliSuite {
   checkSemantic(
     name = "missing --classpath",
     args = Array(),
+    targetroots = Seq.empty,
     expectedExit = ExitStatus.MissingSemanticdbError
   )
 
@@ -170,13 +172,13 @@ class CliSemanticSuite extends BaseCliSuite {
   checkSemantic(
     name = "-P:semanticdb:targetroot",
     args = {
-      val (_ :: targetroot :: Nil, jars) =
-        props.inputClasspath.entries.partition(_.isDirectory)
+      val jars = props.inputClasspath.entries.filter(_.isDirectory)
+      val targetroot = BuildInfo.semanticClasspath.last.getAbsolutePath
       Array(
         s"--scalacOptions",
         s"-P:semanticdb:targetroot:shouldBeIgnored",
         s"--scalacOptions",
-        s"-P:semanticdb:targetroot:${targetroot.toString()}",
+        s"-P:semanticdb:targetroot:$targetroot",
         "--classpath",
         Classpath(jars).syntax
       )

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/BaseSemanticSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/BaseSemanticSuite.scala
@@ -31,7 +31,9 @@ object BaseSemanticSuite {
     SemanticDocument.fromPath(
       doc,
       relpath,
-      ClasspathOps.thisClassLoaderWith(BuildInfo.semanticClasspath.toURI.toURL),
+      ClasspathOps.thisClassLoaderWith(
+        BuildInfo.semanticClasspath.map(_.toURI.toURL)
+      ),
       symtab
     )
   }
@@ -50,9 +52,10 @@ abstract class BaseSemanticSuite(filename: String)
   }
 
   override def beforeAll(): Unit = {
-    val dir = AbsolutePath(scalafix.tests.BuildInfo.semanticClasspath)
+    val dirs =
+      scalafix.tests.BuildInfo.semanticClasspath.map(AbsolutePath.apply)
     _db = LegacyInMemorySemanticdbIndex.load(
-      Classpaths.withDirectory(dir),
+      Classpaths.withDirectories(dirs.toList),
       PathIO.workingDirectory
     )
     _input = _db.inputs

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/PrettyTypeSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/PrettyTypeSuite.scala
@@ -24,11 +24,11 @@ class BasePrettyTypeSuite extends BaseSemanticSuite("TypeToTreeInput") {
   super.beforeAll()
   val classDir: m.AbsolutePath =
     m.AbsolutePath(scalafix.tests.BuildInfo.sharedClasspath)
-  val semanticdbTargetRoot: AbsolutePath =
-    m.AbsolutePath(scalafix.tests.BuildInfo.semanticClasspath)
+  val semanticdbTargetRoots: List[AbsolutePath] =
+    scalafix.tests.BuildInfo.semanticClasspath.map(m.AbsolutePath.apply).toList
 
   val classpath: Classpath =
-    Classpaths.withDirectories(List(semanticdbTargetRoot, classDir))
+    Classpaths.withDirectories(semanticdbTargetRoots :+ classDir)
   val table: GlobalSymbolTable = GlobalSymbolTable(classpath, includeJdk = true)
 }
 


### PR DESCRIPTION
Second take at https://github.com/scalacenter/scalafix/pull/1275 leveraging https://github.com/scalacenter/scalafix/pull/1389 (with the addition of the first preliminary commit, allowing the targetroot to be repeated in the CLI when dealing with a complex classpath)

Unlocks https://github.com/scalacenter/sbt-scalafix/pull/219