### PR TITLE
Revert metaconfig 0.9.11 bump

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,10 +67,9 @@ lazy val core = project
     libraryDependencies ++= List(
       scalameta,
       googleDiff,
+      metaconfig,
       collectionCompat
-    ),
-    libraryDependencies += (if (isScala211.value) metaconfigFor211
-                            else metaconfig)
+    )
   )
   .enablePlugins(BuildInfoPlugin)
 
@@ -273,8 +272,7 @@ lazy val docs = project
     scalacOptions += "-Xfatal-warnings",
     mdoc := (Compile / run).evaluated,
     crossScalaVersions := List(scala213),
-    libraryDependencies += (if (isScala211.value) metaconfigDocFor211
-                            else metaconfigDoc)
+    libraryDependencies += metaconfigDoc
   )
   .dependsOn(testkit, core, cli)
   .enablePlugins(DocusaurusPlugin)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,8 +20,7 @@ object Dependencies {
   val googleDiffV = "1.3.0"
   val java8CompatV = "0.9.0"
   val jgitV = "5.11.1.202105131744-r"
-  val metaconfigFor211V = "0.9.10" // metaconfig stops publishing for scala 2.11
-  val metaconfigV = "0.9.11"
+  val metaconfigV = "0.9.10" // blocked by https://github.com/scalameta/metaconfig/pull/131
   val nailgunV = "0.9.1"
   val scalaXmlV = "1.3.0"
   val scalametaV = "4.4.20"
@@ -35,9 +34,7 @@ object Dependencies {
   val googleDiff = "com.googlecode.java-diff-utils" % "diffutils" % googleDiffV
   val java8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % java8CompatV
   val jgit = "org.eclipse.jgit" % "org.eclipse.jgit" % jgitV
-  val metaconfigFor211 = "com.geirsson" %% "metaconfig-typesafe-config" % metaconfigFor211V
   val metaconfig = "com.geirsson" %% "metaconfig-typesafe-config" % metaconfigV
-  val metaconfigDocFor211 = "com.geirsson" %% "metaconfig-docs" % metaconfigFor211V
   val metaconfigDoc = "com.geirsson" %% "metaconfig-docs" % metaconfigV
   val metacp = "org.scalameta" %% "metacp" % scalametaV
   val nailgunServer = "com.martiansoftware" % "nailgun-server" % nailgunV

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/config/DisableSyntaxConfigSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/config/DisableSyntaxConfigSuite.scala
@@ -1,11 +1,11 @@
 package scalafix.tests.config
 
+import metaconfig.ConfError
 import metaconfig.Configured
 import metaconfig.Configured.NotOk
 import metaconfig.typesafeconfig._
 import org.scalatest.funsuite.AnyFunSuite
 import scalafix.internal.rule._
-import scalafix.tests.util.ScalaVersions
 
 class DisableSyntaxConfigSuite extends AnyFunSuite {
   test("Warn about invalid keywords") {
@@ -36,17 +36,9 @@ class DisableSyntaxConfigSuite extends AnyFunSuite {
         |]
         |""".stripMargin
     val errorMessage =
-      if (ScalaVersions.isScala211)
-        """|Type mismatch;
-          |  found    : Number (value: 42)
-          |  expected : String""".stripMargin
-      else
-        """|<input>:2:0 error: Type mismatch;
-          |  found    : Number (value: 42)
-          |  expected : String
-          |  42
-          |^
-          |""".stripMargin
+      """|Type mismatch;
+        |  found    : Number (value: 42)
+        |  expected : String""".stripMargin
     assertError(rawConfig, errorMessage)
   }
 
@@ -80,6 +72,7 @@ class DisableSyntaxConfigSuite extends AnyFunSuite {
 
   def assertError(rawConfig: String, errorMessage: String): Unit = {
     val obtained = read(rawConfig)
-    assert(obtained.asInstanceOf[NotOk].error.msg == errorMessage)
+    val expected = NotOk(ConfError.message(errorMessage))
+    assert(obtained == expected)
   }
 }


### PR DESCRIPTION
Fix https://github.com/scalacenter/scalafix/issues/1414 before a release of metaconfig is cut with https://github.com/scalameta/metaconfig/pull/131