### PR TITLE
docs: stop using deprecated rule name

### DIFF
--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -421,7 +421,7 @@ repository.
 ```sh
 git clone https://github.com/scalacenter/sbt-scalafix-example
 cd sbt-scalafix-example
-sbt "scalafix RemoveUnusedImports"
+sbt "scalafix RemoveUnused"
 git diff // should produce a diff
 ```
 


### PR DESCRIPTION
Blocked by https://github.com/scalacenter/sbt-scalafix-example/pull/4/commits/e5ea9a5b86401fe3e8c1176d7525a7859f9f1d0a

https://github.com/scalacenter/scalafix/blob/9af04d5d50983a079cffcc6631c2cf241be247af/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala#L13-L17