### PR TITLE
WIP - expose requirement for rules

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/v1/InputRequirements.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/InputRequirements.scala
@@ -1,0 +1,22 @@
+package scalafix.v1
+
+trait InputRequirements {
+  def scalaVersionsRequired: Seq[InputRequirements.ScalaVersion]
+  def scalacOptionsRequired: Seq[InputRequirements.ScalacOption]
+  def meetRequirements(sv: String, scalacOptions: Seq[String]): Boolean = {
+    (scalacOptionsRequired.isEmpty || scalaVersionsRequired
+      .map(_.value)
+      .contains(sv)) && (scalacOptionsRequired.isEmpty || scalacOptionsRequired
+      .map(_.value)
+      .iterator
+      .forall(scalacOptions.contains))
+  }
+
+  def messageRequirementNotMet: String = ""
+}
+
+object InputRequirements {
+  case class ScalaVersion(value: String)
+
+  case class ScalacOption(value: String)
+}

--- a/scalafix-core/src/main/scala/scalafix/v1/Rule.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/Rule.scala
@@ -2,7 +2,7 @@ package scalafix.v1
 
 import metaconfig.Configured
 
-abstract class Rule(val name: RuleName) {
+abstract class Rule(val name: RuleName) extends InputRequirements {
   override def toString: String = name.toString
 
   /**
@@ -21,7 +21,13 @@ abstract class Rule(val name: RuleName) {
    * @return A new version of this rule with loaded configuration or an error message.
    */
   def withConfiguration(config: Configuration): Configured[Rule] =
-    Configured.ok(this)
+    if (meetRequirements(config.scalaVersion, config.scalacOptions))
+      Configured.ok(this)
+    else Configured.error(messageRequirementNotMet)
+
+  def scalaVersionsRequired: Seq[InputRequirements.ScalaVersion] = Nil
+
+  def scalacOptionsRequired: Seq[InputRequirements.ScalacOption] = Nil
 
   /** If true, allows this rule to be grouped together with other linter rules for documentation purposes. */
   def isLinter: Boolean = false

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/ExplicitResultTypes.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/ExplicitResultTypes.scala
@@ -46,6 +46,9 @@ final class ExplicitResultTypes(
     }))
   }
 
+  override def scalaVersionsRequired: Seq[InputRequirements.ScalaVersion] = Nil
+  supportedScalaVersions.toSeq.map(InputRequirements.ScalaVersion)
+
   override def withConfiguration(config: Configuration): Configured[Rule] = {
     val symbolReplacements =
       config.conf.dynamic.ExplicitResultTypes.symbolReplacements


### PR DESCRIPTION
This implementation is just to start the discussion about #1199 #1394
- So with this implementation we allow rules authors to expose their constraints
- But, the concern raised in  #1199, about enabling the rule runner (sbt, mill, a tool ..) to propose a fix,  is not addressed. Those runners interact with scalafix through the Java interface Scalafx Arguments which can only return a unit or a `ScalafixError` which is just a string. 
Let's start a discussion here to see what we want and what the issue we want to adress. 


