### PR TITLE
Unused function params follow-up

### DIFF
--- a/docs/rules/RemoveUnused.md
+++ b/docs/rules/RemoveUnused.md
@@ -87,6 +87,19 @@ object Main {
 }
 ```
 
+Remove unused function parameters (Scala 2.12 & 2.13 only):
+
+```scala
+// before
+object Main {
+  val f: String => Unit = unused => println("f")
+}
+// after
+object Main {
+  val f: String => Unit = _ => println("f")
+}
+```
+
 ## Formatting
 
 > This rule does a best-effort at preserving original formatting. In some cases,

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
@@ -156,6 +156,12 @@ class RemoveUnused(config: RemoveUnusedConfig)
         case Term.Function(List(param @ Term.Param(_, name, _, _)), _)
             if isUnusedParam(posExclParens(param)) =>
           Patch.replaceTree(name, "_")
+        case Term.Function(params, _) =>
+          params.collect {
+            case param @ Term.Param(_, name, _, _)
+                if isUnusedParam(param.pos) =>
+              Patch.replaceTree(name, "_")
+          }.asPatch
       }.asPatch
     }
   }

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
@@ -153,6 +153,9 @@ class RemoveUnused(config: RemoveUnusedConfig)
         case Term.Function(List(param @ Term.Param(_, name, _, _)), _)
             if isUnusedParam(name.pos) =>
           Patch.replaceTree(param, "_")
+        case Term.Function(List(param @ Term.Param(_, name, _, _)), _)
+            if isUnusedParam(posExclParens(param)) =>
+          Patch.replaceTree(name, "_")
       }.asPatch
     }
   }

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnusedConfig.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnusedConfig.scala
@@ -16,7 +16,9 @@ case class RemoveUnusedConfig(
       "Remove unused pattern match variables (compatible with Scala 2.12 and 2.13)"
     )
     patternvars: Boolean = true,
-    @Description("Remove unused parameters")
+    @Description(
+      "Remove unused function parameters (compatible with Scala 2.12 and 2.13)"
+    )
     params: Boolean = true
 )
 

--- a/scalafix-tests/input/src/main/scala-2.12/test/removeUnused/RemoveUnusedImportsTrailingCommas.scala
+++ b/scalafix-tests/input/src/main/scala-2.12/test/removeUnused/RemoveUnusedImportsTrailingCommas.scala
@@ -1,7 +1,7 @@
 /*
 rule = RemoveUnused
  */
-package test
+package test.removeUnused
 
 import scala.util.{
   Failure,

--- a/scalafix-tests/input/src/main/scala-2.12/test/removeUnused/RemoveUnusedParams.scala
+++ b/scalafix-tests/input/src/main/scala-2.12/test/removeUnused/RemoveUnusedParams.scala
@@ -6,6 +6,7 @@ package test.removeUnused
 object UnusedParams {
   val f: String => Unit = unused => println("f")
   val ff = (unused: String) => println("f")
+  val fs = (used: String, unused: Long) => println(used)
   def g(x: String => Unit): Unit = ???
   g{implicit string => println("g")}
 }

--- a/scalafix-tests/input/src/main/scala-2.12/test/removeUnused/RemoveUnusedParams.scala
+++ b/scalafix-tests/input/src/main/scala-2.12/test/removeUnused/RemoveUnusedParams.scala
@@ -4,6 +4,7 @@ rule = RemoveUnused
 package test
 
 object UnusedParams {
+  val f: String => Unit = unused => println("f")
   def g(x: String => Unit): Unit = ???
   g{implicit string => println("g")}
 }

--- a/scalafix-tests/input/src/main/scala-2.12/test/removeUnused/RemoveUnusedParams.scala
+++ b/scalafix-tests/input/src/main/scala-2.12/test/removeUnused/RemoveUnusedParams.scala
@@ -1,7 +1,7 @@
 /*
 rule = RemoveUnused
  */
-package test
+package test.removeUnused
 
 object UnusedParams {
   val f: String => Unit = unused => println("f")

--- a/scalafix-tests/input/src/main/scala-2.12/test/removeUnused/RemoveUnusedParams.scala
+++ b/scalafix-tests/input/src/main/scala-2.12/test/removeUnused/RemoveUnusedParams.scala
@@ -5,6 +5,7 @@ package test.removeUnused
 
 object UnusedParams {
   val f: String => Unit = unused => println("f")
+  val ff = (unused: String) => println("f")
   def g(x: String => Unit): Unit = ???
   g{implicit string => println("g")}
 }

--- a/scalafix-tests/input/src/main/scala-2.12/test/removeUnused/RemoveUnusedPatternVars.scala
+++ b/scalafix-tests/input/src/main/scala-2.12/test/removeUnused/RemoveUnusedPatternVars.scala
@@ -1,7 +1,7 @@
 /*
 rule = RemoveUnused
  */
-package test
+package test.removeUnused
 
 case class AB(a: Int, b: String)
 

--- a/scalafix-tests/input/src/main/scala-2.13/test/removeUnused/RemoveUnusedParams.scala
+++ b/scalafix-tests/input/src/main/scala-2.13/test/removeUnused/RemoveUnusedParams.scala
@@ -4,6 +4,7 @@ rule = RemoveUnused
 package test.removeUnused
 
 object UnusedParams {
+  val f: String => Unit = unused => println("f")
   def g(x: String => Unit): Unit = ???
   g{implicit string => println("g")}
 }

--- a/scalafix-tests/input/src/main/scala-2.13/test/removeUnused/RemoveUnusedParams.scala
+++ b/scalafix-tests/input/src/main/scala-2.13/test/removeUnused/RemoveUnusedParams.scala
@@ -6,6 +6,7 @@ package test.removeUnused
 object UnusedParams {
   val f: String => Unit = unused => println("f")
   val ff = (unused: String) => println("f")
+  val fs = (used: String, unused: Long) => println(used)
   def g(x: String => Unit): Unit = ???
   g{implicit string => println("g")}
 }

--- a/scalafix-tests/input/src/main/scala-2.13/test/removeUnused/RemoveUnusedParams.scala
+++ b/scalafix-tests/input/src/main/scala-2.13/test/removeUnused/RemoveUnusedParams.scala
@@ -5,6 +5,7 @@ package test.removeUnused
 
 object UnusedParams {
   val f: String => Unit = unused => println("f")
+  val ff = (unused: String) => println("f")
   def g(x: String => Unit): Unit = ???
   g{implicit string => println("g")}
 }

--- a/scalafix-tests/output/src/main/scala-2.12/test/removeUnused/RemoveUnusedImportsTrailingCommas.scala
+++ b/scalafix-tests/output/src/main/scala-2.12/test/removeUnused/RemoveUnusedImportsTrailingCommas.scala
@@ -1,4 +1,4 @@
-package test
+package test.removeUnused
 
 import scala.util.Success
 

--- a/scalafix-tests/output/src/main/scala-2.12/test/removeUnused/RemoveUnusedParams.scala
+++ b/scalafix-tests/output/src/main/scala-2.12/test/removeUnused/RemoveUnusedParams.scala
@@ -1,4 +1,4 @@
-package test
+package test.removeUnused
 
 object UnusedParams {
   val f: String => Unit = _ => println("f")

--- a/scalafix-tests/output/src/main/scala-2.12/test/removeUnused/RemoveUnusedParams.scala
+++ b/scalafix-tests/output/src/main/scala-2.12/test/removeUnused/RemoveUnusedParams.scala
@@ -3,6 +3,7 @@ package test.removeUnused
 object UnusedParams {
   val f: String => Unit = _ => println("f")
   val ff = (_: String) => println("f")
+  val fs = (used: String, _: Long) => println(used)
   def g(x: String => Unit): Unit = ???
   g{_ => println("g")}
 }

--- a/scalafix-tests/output/src/main/scala-2.12/test/removeUnused/RemoveUnusedParams.scala
+++ b/scalafix-tests/output/src/main/scala-2.12/test/removeUnused/RemoveUnusedParams.scala
@@ -1,6 +1,7 @@
 package test
 
 object UnusedParams {
+  val f: String => Unit = _ => println("f")
   def g(x: String => Unit): Unit = ???
   g{_ => println("g")}
 }

--- a/scalafix-tests/output/src/main/scala-2.12/test/removeUnused/RemoveUnusedParams.scala
+++ b/scalafix-tests/output/src/main/scala-2.12/test/removeUnused/RemoveUnusedParams.scala
@@ -2,6 +2,7 @@ package test.removeUnused
 
 object UnusedParams {
   val f: String => Unit = _ => println("f")
+  val ff = (_: String) => println("f")
   def g(x: String => Unit): Unit = ???
   g{_ => println("g")}
 }

--- a/scalafix-tests/output/src/main/scala-2.12/test/removeUnused/RemoveUnusedPatternVars.scala
+++ b/scalafix-tests/output/src/main/scala-2.12/test/removeUnused/RemoveUnusedPatternVars.scala
@@ -1,4 +1,4 @@
-package test
+package test.removeUnused
 
 case class AB(a: Int, b: String)
 

--- a/scalafix-tests/output/src/main/scala-2.13/test/removeUnused/RemoveUnusedParams.scala
+++ b/scalafix-tests/output/src/main/scala-2.13/test/removeUnused/RemoveUnusedParams.scala
@@ -3,6 +3,7 @@ package test.removeUnused
 object UnusedParams {
   val f: String => Unit = _ => println("f")
   val ff = (_: String) => println("f")
+  val fs = (used: String, _: Long) => println(used)
   def g(x: String => Unit): Unit = ???
   g{_ => println("g")}
 }

--- a/scalafix-tests/output/src/main/scala-2.13/test/removeUnused/RemoveUnusedParams.scala
+++ b/scalafix-tests/output/src/main/scala-2.13/test/removeUnused/RemoveUnusedParams.scala
@@ -2,6 +2,7 @@ package test.removeUnused
 
 object UnusedParams {
   val f: String => Unit = _ => println("f")
+  val ff = (_: String) => println("f")
   def g(x: String => Unit): Unit = ???
   g{_ => println("g")}
 }

--- a/scalafix-tests/output/src/main/scala-2.13/test/removeUnused/RemoveUnusedParams.scala
+++ b/scalafix-tests/output/src/main/scala-2.13/test/removeUnused/RemoveUnusedParams.scala
@@ -1,6 +1,7 @@
 package test.removeUnused
 
 object UnusedParams {
+  val f: String => Unit = _ => println("f")
   def g(x: String => Unit): Unit = ???
   g{_ => println("g")}
 }


### PR DESCRIPTION
Follows https://github.com/scalacenter/scalafix/pull/1444 (and https://github.com/scalacenter/scalafix/pull/1434 for the second commit)

Note that the current rule implementation does not generate invalid code, it just misses some rewrites.