### PR TITLE
Make NoAutoTupling fixes the insertion of unit

### DIFF
--- a/docs/rules/NoAutoTupling.md
+++ b/docs/rules/NoAutoTupling.md
@@ -4,27 +4,23 @@ id: NoAutoTupling
 title: NoAutoTupling
 ---
 
-> ⚠️ This rule does not work with Scala 2.13 since `-Yno-adapter-args` has been
-> removed.
-
 Adds explicit tuples around argument lists where auto-tupling is occurring.
 
 To use this rule:
 
-- enable `-Ywarn-adapted-args` (note, `-Yno-adapted-args` will fail compilation,
-  which prevents scalafix from running)
-- disable `-Xfatal-warnings`. Unfortunately, the Scala compiler does not support
-  finer grained control over the severity level per message kind. See
-  [scalameta/scalameta#924](https://github.com/scalameta/scalameta/issues/924)
-  for a possible workaround in the near future.
+- enable `-Ywarn-adapted-args` for Scala 2.11 and 2.12 (note, `-Yno-adapted-args` will fail compilation,
+  which prevents scalafix from running). For Scala 2.13, use instead `-Xlint:adapted-args`.
+- enable also `-deprecation` to get warnings on insertions of `Unit`.
 
 ```scala
 // before
 def someMethod(t: (Int, String)) = ...
 someMethod(1, "something")
+val c: Option[Unit] = Some()
 // after
 def someMethod(t: (Int, String)) = ...
 someMethod((1, "something"))
+val c: Option[Unit] = Some(())
 ```
 
 Auto-tupling is a feature that can lead to unexpected results, making code to

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -60,8 +60,8 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
     }
     val warnAdaptedArgs = Def.setting {
       if (isScala3.value) Nil
-      else if (isScala213.value) Seq("-Xlint:adapted-args")
-      else Seq("-Ywarn-adapted-args")
+      else if (isScala213.value) Seq("-Xlint:adapted-args", "-deprecation")
+      else Seq("-Ywarn-adapted-args", "-deprecation")
     }
     lazy val scaladocOptions = Seq(
       "-groups",

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/NoAutoTupling.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/NoAutoTupling.scala
@@ -25,6 +25,8 @@ class NoAutoTupling extends SemanticRule("NoAutoTupling") {
         case message
             if message.message.startsWith(
               "Adaptation of argument list by inserting ()"
+            ) || message.message.startsWith(
+              "adaptation of an empty argument list by inserting ()"
             ) =>
           message.position
       }.toSet

--- a/scalafix-tests/input/src/main/scala-2/test/noAutoTupling/NoAutoTupling.scala
+++ b/scalafix-tests/input/src/main/scala-2/test/noAutoTupling/NoAutoTupling.scala
@@ -1,37 +1,40 @@
-package test
+/*
+rules = NoAutoTupling
+ */
+package test.noAutoTupling
 
-class NoAutoTupling2 {
+class NoAutoTupling {
   def a(x: (Int, Boolean)) = x
-  a((2, true))
+  a(2, true)
 
   def b(x: Int, y: Boolean) = (x, y)
   b(2, true)
 
   def c(x: Int, y: Boolean)(z: (String, List[Int])) = (x, y, z)
-  c(2, true)(("foo", 1 :: 2 :: Nil))
+  c(2, true)("foo", 1 :: 2 :: Nil)
 
   def d(x: (Int, Boolean))(y: (String, List[Int])) = (x, y)
-  d((2, true))(("foo", 1 :: 2 :: Nil))
+  d(2, true)("foo", 1 :: 2 :: Nil)
   d(2, true)("foo", 1 :: 2 :: Nil) // scalafix:ok NoAutoTupling
 
   def e(x: (Int, Boolean))(s: List[String], c: Char)(y: (String, List[Int])) = (x, y)
-  e((2, true))("a" :: "b" :: Nil, 'z')(("foo", 1 :: 2 :: Nil))
+  e(2, true)("a" :: "b" :: Nil, 'z')("foo", 1 :: 2 :: Nil)
 
   def f: (((Int, String)) => ((String, List[Int])) => Int) = a => b => a._1
-  f((1 + 2, "foo"))(("bar", 1 :: 2 :: Nil))
+  f(1 + 2, "foo")("bar", 1 :: 2 :: Nil)
 
   val g = (x: (Int, Boolean)) => x
-  g((2, true))
+  g(2, true)
 
   case class Foo(t: (Int, String))(s: (Boolean, List[Int]))
   // new Foo(1, "foo")(true, Nil)
-  Foo((1, "foo"))((true, Nil))
-  Foo.apply((1, "foo"))((true, Nil))
+  Foo(1, "foo")(true, Nil)
+  Foo.apply(1, "foo")(true, Nil)
 
   case class Bar(x: Int, y: String)(s: (Boolean, List[Int]))
   // new Bar(1, "foo")(true, Nil)
-  Bar(1, "foo")((true, Nil))
-  Bar.apply(1, "foo")((true, Nil))
+  Bar(1, "foo")(true, Nil)
+  Bar.apply(1, "foo")(true, Nil)
 
   object NoFalsePositives {
     def a(a: (Int, Boolean), b: Int) = (a, b)
@@ -45,8 +48,4 @@ class NoAutoTupling2 {
     Foo(42, "foo", ('z', true))
     Foo.apply(42, "foo", ('z', true))
   }
-
-  //todo: Fix Adaptation of argument list by inserting ()
-  val c: Option[Unit] = Some()
 }
-

--- a/scalafix-tests/input/src/main/scala-2/test/noAutoTupling/NoUnitInsertion.scala
+++ b/scalafix-tests/input/src/main/scala-2/test/noAutoTupling/NoUnitInsertion.scala
@@ -1,7 +1,7 @@
 /*
 rules = NoAutoTupling
  */
-package test
+package test.noAutoTupling
 
 class NoUnitInsertion {
 

--- a/scalafix-tests/output/src/main/scala-2.11/test/noAutoTupling/NoAutoTupling.scala
+++ b/scalafix-tests/output/src/main/scala-2.11/test/noAutoTupling/NoAutoTupling.scala
@@ -1,6 +1,6 @@
-package test
+package test.noAutoTupling
 
-class NoAutoTupling2 {
+class NoAutoTupling {
   def a(x: (Int, Boolean)) = x
   a((2, true))
 
@@ -11,22 +11,22 @@ class NoAutoTupling2 {
   c(2, true)(("foo", 1 :: 2 :: Nil))
 
   def d(x: (Int, Boolean))(y: (String, List[Int])) = (x, y)
-  d((2, true))(("foo", 1 :: 2 :: Nil))
+  d(2, true)(("foo", 1 :: 2 :: Nil))
   d(2, true)("foo", 1 :: 2 :: Nil) // scalafix:ok NoAutoTupling
 
   def e(x: (Int, Boolean))(s: List[String], c: Char)(y: (String, List[Int])) = (x, y)
-  e((2, true))("a" :: "b" :: Nil, 'z')(("foo", 1 :: 2 :: Nil))
+  e(2, true)("a" :: "b" :: Nil, 'z')(("foo", 1 :: 2 :: Nil))
 
   def f: (((Int, String)) => ((String, List[Int])) => Int) = a => b => a._1
-  f((1 + 2, "foo"))(("bar", 1 :: 2 :: Nil))
+  f(1 + 2, "foo")(("bar", 1 :: 2 :: Nil))
 
   val g = (x: (Int, Boolean)) => x
   g((2, true))
 
   case class Foo(t: (Int, String))(s: (Boolean, List[Int]))
   // new Foo(1, "foo")(true, Nil)
-  Foo((1, "foo"))((true, Nil))
-  Foo.apply((1, "foo"))((true, Nil))
+  Foo(1, "foo")((true, Nil))
+  Foo.apply(1, "foo")((true, Nil))
 
   case class Bar(x: Int, y: String)(s: (Boolean, List[Int]))
   // new Bar(1, "foo")(true, Nil)
@@ -45,8 +45,5 @@ class NoAutoTupling2 {
     Foo(42, "foo", ('z', true))
     Foo.apply(42, "foo", ('z', true))
   }
-
-  //todo: Fix Adaptation of argument list by inserting ()
-  val c: Option[Unit] = Some()
 }
 

--- a/scalafix-tests/output/src/main/scala-2.12/test/noAutoTupling/NoAutoTupling.scala
+++ b/scalafix-tests/output/src/main/scala-2.12/test/noAutoTupling/NoAutoTupling.scala
@@ -1,40 +1,37 @@
-/*
-rules = NoAutoTupling
- */
-package test
+package test.noAutoTupling
 
-class NoAutoTupling2 {
+class NoAutoTupling {
   def a(x: (Int, Boolean)) = x
-  a(2, true)
+  a((2, true))
 
   def b(x: Int, y: Boolean) = (x, y)
   b(2, true)
 
   def c(x: Int, y: Boolean)(z: (String, List[Int])) = (x, y, z)
-  c(2, true)("foo", 1 :: 2 :: Nil)
+  c(2, true)(("foo", 1 :: 2 :: Nil))
 
   def d(x: (Int, Boolean))(y: (String, List[Int])) = (x, y)
-  d(2, true)("foo", 1 :: 2 :: Nil)
+  d((2, true))(("foo", 1 :: 2 :: Nil))
   d(2, true)("foo", 1 :: 2 :: Nil) // scalafix:ok NoAutoTupling
 
   def e(x: (Int, Boolean))(s: List[String], c: Char)(y: (String, List[Int])) = (x, y)
-  e(2, true)("a" :: "b" :: Nil, 'z')("foo", 1 :: 2 :: Nil)
+  e((2, true))("a" :: "b" :: Nil, 'z')(("foo", 1 :: 2 :: Nil))
 
   def f: (((Int, String)) => ((String, List[Int])) => Int) = a => b => a._1
-  f(1 + 2, "foo")("bar", 1 :: 2 :: Nil)
+  f((1 + 2, "foo"))(("bar", 1 :: 2 :: Nil))
 
   val g = (x: (Int, Boolean)) => x
-  g(2, true)
+  g((2, true))
 
   case class Foo(t: (Int, String))(s: (Boolean, List[Int]))
   // new Foo(1, "foo")(true, Nil)
-  Foo(1, "foo")(true, Nil)
-  Foo.apply(1, "foo")(true, Nil)
+  Foo((1, "foo"))((true, Nil))
+  Foo.apply((1, "foo"))((true, Nil))
 
   case class Bar(x: Int, y: String)(s: (Boolean, List[Int]))
   // new Bar(1, "foo")(true, Nil)
-  Bar(1, "foo")(true, Nil)
-  Bar.apply(1, "foo")(true, Nil)
+  Bar(1, "foo")((true, Nil))
+  Bar.apply(1, "foo")((true, Nil))
 
   object NoFalsePositives {
     def a(a: (Int, Boolean), b: Int) = (a, b)
@@ -48,7 +45,5 @@ class NoAutoTupling2 {
     Foo(42, "foo", ('z', true))
     Foo.apply(42, "foo", ('z', true))
   }
-
-  //todo: Fix Adaptation of argument list by inserting ()
-  val c: Option[Unit] = Some()
 }
+

--- a/scalafix-tests/output/src/main/scala-2.13/test/noAutoTupling/NoAutoTupling.scala
+++ b/scalafix-tests/output/src/main/scala-2.13/test/noAutoTupling/NoAutoTupling.scala
@@ -1,6 +1,6 @@
-package test
+package test.noAutoTupling
 
-class NoAutoTupling2 {
+class NoAutoTupling {
   def a(x: (Int, Boolean)) = x
   a((2, true))
 
@@ -11,22 +11,22 @@ class NoAutoTupling2 {
   c(2, true)(("foo", 1 :: 2 :: Nil))
 
   def d(x: (Int, Boolean))(y: (String, List[Int])) = (x, y)
-  d(2, true)(("foo", 1 :: 2 :: Nil))
+  d((2, true))(("foo", 1 :: 2 :: Nil))
   d(2, true)("foo", 1 :: 2 :: Nil) // scalafix:ok NoAutoTupling
 
   def e(x: (Int, Boolean))(s: List[String], c: Char)(y: (String, List[Int])) = (x, y)
-  e(2, true)("a" :: "b" :: Nil, 'z')(("foo", 1 :: 2 :: Nil))
+  e((2, true))("a" :: "b" :: Nil, 'z')(("foo", 1 :: 2 :: Nil))
 
   def f: (((Int, String)) => ((String, List[Int])) => Int) = a => b => a._1
-  f(1 + 2, "foo")(("bar", 1 :: 2 :: Nil))
+  f((1 + 2, "foo"))(("bar", 1 :: 2 :: Nil))
 
   val g = (x: (Int, Boolean)) => x
   g((2, true))
 
   case class Foo(t: (Int, String))(s: (Boolean, List[Int]))
   // new Foo(1, "foo")(true, Nil)
-  Foo(1, "foo")((true, Nil))
-  Foo.apply(1, "foo")((true, Nil))
+  Foo((1, "foo"))((true, Nil))
+  Foo.apply((1, "foo"))((true, Nil))
 
   case class Bar(x: Int, y: String)(s: (Boolean, List[Int]))
   // new Bar(1, "foo")(true, Nil)
@@ -45,8 +45,5 @@ class NoAutoTupling2 {
     Foo(42, "foo", ('z', true))
     Foo.apply(42, "foo", ('z', true))
   }
-
-  //todo: Fix Adaptation of argument list by inserting ()
-  val c: Option[Unit] = Some()
 }
 

--- a/scalafix-tests/output/src/main/scala-2/test/noAutoTupling/NoUnitInsertion.scala
+++ b/scalafix-tests/output/src/main/scala-2/test/noAutoTupling/NoUnitInsertion.scala
@@ -1,0 +1,24 @@
+package test.noAutoTupling
+
+class NoUnitInsertion {
+
+  val x: Option[Unit] = Option(())
+
+  def a(u: Unit): Unit = u
+  a(())
+
+  def b(x: Int)(u: Unit): Unit = (x, u)
+  b(2)(())
+
+  val c: Unit => Unit =
+    u => u
+  c(())
+
+  case class Foo(u: Unit)
+  Foo(())
+  Foo.apply(())
+
+  case class Bar(i: Int)(u: Unit)
+  Bar.apply(2)(())
+
+}


### PR DESCRIPTION
- and refactoring tests

I don't know if want to insert `()` when we have this kind of warnings (that are only reported by `-deprecation`)
```
adaptation of an empty argument list by inserting () is deprecated: this is unlikely to be what you want
        signature: Some.apply[A](value: A): Some[A]
  given arguments: <none>
 after adaptation: Some((): Unit)
 ```
 
 The test was called NoUnitInsertion. Not clear for me if we want that or not. In the other hand, even if it's not a behavior we want, noAutoTupling insert (), if the user has added -deprecation in his options. It wasn't working for 2.13 since the warning message changed from `Adaptation ...` to `adaptation ...` for unit insertions.
 
 - other point: For this rule, we don't have `withConfiguration`: should we do the same than in removeUnused ? 