### PR TITLE
Add accessor to `overriddenSymbols` to SymbolInformation

### DIFF
--- a/docs/developers/symbol-information.md
+++ b/docs/developers/symbol-information.md
@@ -16,6 +16,7 @@ definition. A symbol information describes the symbols's
 - properties: `final`, `abstract`, `implicit`
 - type signature: class declarations, class parents, method parameters, ...
 - visibility access: `private`, `protected`, ...
+- overridden symbols: list of symbols that this symbol overrides
 
 ```scala mdoc:passthrough
 import scalafix.internal.v1.SymbolInformationAnnotations._

--- a/scalafix-core/src/main/scala/scalafix/v1/SymbolInformation.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/SymbolInformation.scala
@@ -60,6 +60,8 @@ final class SymbolInformation private[scalafix] (
     info.annotations.iterator
       .map(annot => new SymtabFromProtobuf(symtab).sannotation(annot))
       .toList
+  def overriddenSymbols: List[Symbol] =
+    info.overriddenSymbols.map(Symbol(_)).toList
 
   /** @group utilty */
   @utility def isSetter: Boolean = displayName.endsWith("_=")


### PR DESCRIPTION
`overriddenSymbols` field has been added to SymbolInformation recently, but there's no way to access the field from scalafix API at this moment. https://github.com/scalameta/scalameta/pull/2233

This PR adds an accessor to `overriddenSymbols` to `SymbolInformation`.