### PR TITLE
don't bump JGit to keep Java 8 compatibility

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -2,4 +2,7 @@ pullRequests.frequency = "0 0 1,15 * ?"
 updates.pin = [
   # don't bump, to avoid forcing breaking changes on clients via eviction
   { groupId = "org.scalatest", artifactId = "scalatest", version = "3.0.8" },
+
+  # JGit 6.x requires Java 11, see https://www.eclipse.org/lists/cross-project-issues-dev/msg18654.html
+  { groupId = " org.eclipse.jgit", artifactId = "org.eclipse.jgit", version = "5." },
 ]


### PR DESCRIPTION
closes https://github.com/scalacenter/scalafix/pull/1505