### PR TITLE
add spaceteams/scalafix-rules to list of projects that cross-publish

### DIFF
--- a/docs/developers/cross-publish-custom-rules.md
+++ b/docs/developers/cross-publish-custom-rules.md
@@ -35,7 +35,8 @@ Therefore, no change is required if you are writing a new rule.
 
 ## Projects that already cross-publish
 [Edit](https://github.com/scalacenter/scalafix/edit/main/docs/developers/cross-publish-custom-rules.md) this page to submit a pull request that adds more project that cross-publish their rule.
-This is a non-exhaustive list of pull request that have cross-published their rules:
+This is a non-exhaustive list of projects and pull requests that have cross-published their rules:
 - [liancheng/**scalafix-organize-imports**](https://github.com/liancheng/scalafix-organize-imports/pull/69)
 - [scala/**scala-rewrites**](https://github.com/scala/scala-rewrites/pull/33)
 - [NeQuissimus/**sort-imports**](https://github.com/NeQuissimus/sort-imports/pull/66)
+- [spaceteams/**scalafix-rules**](https://github.com/spaceteams/scalafix-rules)


### PR DESCRIPTION
spaceteams/scalafix-rules was already created with cross-publishing capability, so there is no pull request per se, that added it.