### PR TITLE
attempt at fixing versions in user-facing docs

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: olafurpg/setup-scala@v13
       - name: Publish ${{ github.ref }}
         run: sbt docs/docusaurusPublishGhpages


### PR DESCRIPTION
Since [versions](https://github.com/scalacenter/scalafix/blob/6c21e2662b0bec87e1495d14f20a775a10663ff9/project/ScalafixBuild.scala#L96-L98) used in docs (and in metadata available for clients) come from https://github.com/sbt/sbt-dynver, I don't understand how this ever worked with a shallow clone, so this might help with https://github.com/scalacenter/scalafix/issues/1538