### PR TITLE
force usage of shaded TPrint

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ lazy val core = project
           // metaconfig 0.10.0 shaded pprint but rules built with an old
           // scalafix-core must have the original package in the classpath to link
           // https://github.com/scalameta/metaconfig/pull/154/files#r794005161
-          pprint
+          pprint % Runtime
         )
     }
   )

--- a/scalafix-interfaces/src/main/java/scalafix/internal/interfaces/ScalafixCoursier.java
+++ b/scalafix-interfaces/src/main/java/scalafix/internal/interfaces/ScalafixCoursier.java
@@ -42,11 +42,23 @@ public class ScalafixCoursier {
             String scalafixVersion,
             String scalaVersion
     ) throws ScalafixException {
-        Dependency scalafixCli = Dependency.parse(
+        List<Dependency> dependencies = new ArrayList<Dependency>();
+        dependencies.add(
+            Dependency.parse(
                 "ch.epfl.scala:::scalafix-cli:" + scalafixVersion,
                 ScalaVersion.of(scalaVersion)
+            ).withConfiguration("runtime")
         );
-        return fetch(repositories, Collections.singletonList(scalafixCli), ResolutionParams.create());
+        // Coursier does not seem to fetch runtime dependencies transitively, despite what Maven dictates
+        // https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#dependency-scope
+        // so to be able to retrieve the runtime dependencies of scalafix-core, we need an explicit reference
+        dependencies.add(
+            Dependency.parse(
+                "ch.epfl.scala::scalafix-core:" + scalafixVersion,
+                ScalaVersion.of(scalaVersion)
+            ).withConfiguration("runtime")
+        );
+        return fetch(repositories, dependencies, ResolutionParams.create());
     }
 
     public static List<URL> toolClasspath(

--- a/scalafix-rules/src/main/scala-2.11/scalafix/internal/rule/TPrintImplicits.scala
+++ b/scalafix-rules/src/main/scala-2.11/scalafix/internal/rule/TPrintImplicits.scala
@@ -1,0 +1,11 @@
+package scalafix.internal.rule
+
+import java.util.regex.Pattern
+
+import pprint.TPrint
+import scalafix.config.CustomMessage
+
+class TPrintImplicits {
+  implicit val tprintPattern: TPrint[List[CustomMessage[Pattern]]] =
+    TPrint.literal("List[Regex]")
+}

--- a/scalafix-rules/src/main/scala-2.12+/scalafix/internal/rule/TPrintImplicits.scala
+++ b/scalafix-rules/src/main/scala-2.12+/scalafix/internal/rule/TPrintImplicits.scala
@@ -1,0 +1,14 @@
+package scalafix.internal.rule
+
+import java.util.regex.Pattern
+
+import metaconfig.pprint._
+import scalafix.config.CustomMessage
+
+class TPrintImplicits {
+  implicit val tprintPattern: TPrint[List[CustomMessage[Pattern]]] =
+    new TPrint[List[CustomMessage[Pattern]]] {
+      def render(implicit tpc: TPrintColors): fansi.Str =
+        fansi.Str("List[Regex]")
+    }
+}

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntaxConfig.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntaxConfig.scala
@@ -13,7 +13,6 @@ import metaconfig.annotation.ExampleValue
 import metaconfig.annotation.Hidden
 import metaconfig.generic
 import metaconfig.generic.Surface
-import pprint.TPrint
 import scalafix.config.CustomMessage
 import scalafix.config.Regex
 
@@ -108,8 +107,6 @@ case class DisableSyntaxConfig(
 }
 
 object DisableSyntaxConfig {
-  implicit val tprintPattern: TPrint[List[CustomMessage[Pattern]]] =
-    TPrint.literal("List[Regex]")
   val default: DisableSyntaxConfig = DisableSyntaxConfig()
   implicit val surface: Surface[DisableSyntaxConfig] =
     generic.deriveSurface[DisableSyntaxConfig]

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/TestkitPath.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/TestkitPath.scala
@@ -25,14 +25,6 @@ final class TestkitPath(
     val testPath: RelativePath,
     val semanticdbPath: RelativePath
 ) {
-  override def toString: String = {
-    val map = Map(
-      "input" -> input,
-      "testPath" -> testPath,
-      "semanticdbPath" -> semanticdbPath
-    )
-    pprint.PPrinter.BlackWhite.tokenize(map).mkString
-  }
   def testName: String = testPath.toURI(isDirectory = false).toString
   def toInput: Input =
     Input.VirtualFile(testName, FileIO.slurp(input, StandardCharsets.UTF_8))

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/TestkitProperties.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/TestkitProperties.scala
@@ -61,17 +61,6 @@ final class TestkitProperties(
         throw new NoSuchElementException(path.toString())
       }
   }
-  override def toString: String = {
-    val map = Map(
-      "inputSourceDirectories" -> inputSourceDirectories,
-      "outputSourceDirectories" -> outputSourceDirectories,
-      "inputClasspath" -> inputClasspath.syntax,
-      "sourceroot" -> sourceroot,
-      "scalaVersion" -> scalaVersion,
-      "scalacOptions" -> scalacOptions
-    )
-    pprint.PPrinter.BlackWhite.tokenize(map).mkString
-  }
 }
 
 object TestkitProperties {

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/PrettyTypeSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/PrettyTypeSuite.scala
@@ -150,7 +150,7 @@ class PrettyTypeFuzzSuite extends BasePrettyTypeSuite {
               checkPath(file)
             } catch {
               case scala.meta.internal.classpath.MissingSymbolException(e) =>
-                pprint.log(file)
+                println(file)
             }
           }
         }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/rule/MavenFuzzSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/rule/MavenFuzzSuite.scala
@@ -49,7 +49,7 @@ class MavenFuzzSuite extends AnyFunSuite with DiffAssertions {
               finally stream.close()
               result += out
             } else {
-              pprint.log(errors)
+              println(errors)
             }
           }
         }
@@ -154,7 +154,7 @@ class MavenFuzzSuite extends AnyFunSuite with DiffAssertions {
       exec("git", "init")
       exec("git", "add", ".")
       exec("git", "commit", "-m", "first-commit")
-      pprint.log(paths.length)
+      println(paths.length)
       val args = scalafix
         .newArguments()
         .withSourceroot(tmp)
@@ -163,19 +163,19 @@ class MavenFuzzSuite extends AnyFunSuite with DiffAssertions {
         .withClasspath(classfiles.asJava)
         .withMode(ScalafixMainMode.CHECK)
       val exit = args.run()
-      pprint.log(exit)
+      println(exit)
       // exec("git", "diff")
       FileIO.listAllFilesRecursively(AbsolutePath(tmp)).foreach { path =>
         if (path.toNIO.getFileName.toString.endsWith(".scala")) {
           val text = FileIO.slurp(path, StandardCharsets.UTF_8)
           val errors = compileErrors(g, text, path.toString())
           if (errors.nonEmpty) {
-            pprint.log(path)
-            pprint.log(errors)
+            println(path)
+            println(errors)
           }
         }
       }
-      pprint.log(tmp)
+      println(tmp)
     }
   }
   check("ExplicitResultTypes")


### PR DESCRIPTION
Follows https://github.com/scalacenter/scalafix/pull/1530
Should unblock https://github.com/scalacenter/scalafix/pull/1531

Injecting instances of `pprint.TPrint` to customize the docs no longer has effect as of https://github.com/scalacenter/scalafix/pull/1530, which was a silent breaking change. This commit exposes the breaking change so that rules built against the latest scalafix-core either drop usage of `TPrint` or switch to the shaded version which is used internally by metaconfig.