### PR TITLE
 fix docs: reflect new param signature after #907

### DIFF
--- a/scalafix-rules/src/main/scala-2.11/scalafix/internal/rule/TPrintImplicits.scala
+++ b/scalafix-rules/src/main/scala-2.11/scalafix/internal/rule/TPrintImplicits.scala
@@ -4,8 +4,10 @@ import java.util.regex.Pattern
 
 import pprint.TPrint
 import scalafix.config.CustomMessage
+import scalafix.config.Regex
 
 class TPrintImplicits {
-  implicit val tprintPattern: TPrint[List[CustomMessage[Pattern]]] =
+  implicit val tprintPattern
+      : TPrint[List[CustomMessage[Either[Regex, Pattern]]]] =
     TPrint.literal("List[Regex]")
 }

--- a/scalafix-rules/src/main/scala-2.12+/scalafix/internal/rule/TPrintImplicits.scala
+++ b/scalafix-rules/src/main/scala-2.12+/scalafix/internal/rule/TPrintImplicits.scala
@@ -4,10 +4,12 @@ import java.util.regex.Pattern
 
 import metaconfig.pprint._
 import scalafix.config.CustomMessage
+import scalafix.config.Regex
 
 class TPrintImplicits {
-  implicit val tprintPattern: TPrint[List[CustomMessage[Pattern]]] =
-    new TPrint[List[CustomMessage[Pattern]]] {
+  implicit val tprintPattern
+      : TPrint[List[CustomMessage[Either[Regex, Pattern]]]] =
+    new TPrint[List[CustomMessage[Either[Regex, Pattern]]]] {
       def render(implicit tpc: TPrintColors): fansi.Str =
         fansi.Str("List[Regex]")
     }


### PR DESCRIPTION
Follows https://github.com/scalacenter/scalafix/pull/907
Discovered in https://github.com/scalacenter/scalafix/pull/1546#discussion_r805798333

https://scalacenter.github.io/scalafix/docs/rules/DisableSyntax.html
> `List[CustomMessage[Either[Regex, Pattern]]]`