### PR TITLE
remove unused plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -116,8 +116,6 @@ lazy val cli = project
   .settings(
     moduleName := "scalafix-cli",
     isFullCrossVersion,
-    assembly / mainClass := Some("scalafix.v1.Main"),
-    assembly / assemblyJarName := "scalafix.jar",
     libraryDependencies ++= Seq(
       java8Compat,
       nailgunServer,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.0.1")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")


### PR DESCRIPTION
Closes https://github.com/scalacenter/scalafix/pull/1548

Effectively reverts https://github.com/scalacenter/scalafix/commit/bdaadfde3314090d2759ff982f94649d317897fd since to my knowledge, it's not actively used (at least I don't)