### PR TITLE
Scalameta 4.5.0 (was 4.4.35)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Dependencies {
   val nailgunV = "0.9.1"
   val scalaXmlV = "2.0.1"
   val scalaXml211V = "1.3.0" // scala-xml stops publishing for scala 2.11
-  val scalametaV = "4.4.35"
+  val scalametaV = "4.5.0"
   val scalatestV = "3.0.8" // don't bump, to avoid forcing breaking changes on clients via eviction
 
   val bijectionCore = "com.twitter" %% "bijection-core" % bijectionCoreV

--- a/scalafix-core/src/main/scala/scalafix/internal/util/DenotationOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/util/DenotationOps.scala
@@ -7,7 +7,7 @@ import scalafix.v0._
 
 object DenotationOps {
   val defaultDialect: Dialect =
-    dialects.Scala212.copy(allowMethodTypes = true, allowTypeLambdas = true)
+    dialects.Scala212.copy(allowTypeLambdas = true)
 
   def resultType(
       symbol: Symbol,


### PR DESCRIPTION
In the Scala 2 community build, I noticed that 1) this upgrade hasn't happened here yet, and 2) it requires a small source change (because the deprecated `allowMethodTypes` was removed).

And then also I'm seeing failing tests downstream in simulacrum-scalafix, at https://scala-ci.typesafe.com/job/scala-2.13.x-jdk11-integrate-community-build/3535/artifact/logs/simulacrum-scalafix-build.log :

```
[simulacrum-scalafix] =======
[simulacrum-scalafix] => Diff
[simulacrum-scalafix] =======
[simulacrum-scalafix] --- obtained
[simulacrum-scalafix] +++ expected
[simulacrum-scalafix] @@ -24,9 +24,9 @@
[simulacrum-scalafix] âˆ™
[simulacrum-scalafix] -  val fk1 = Î»[FuncK[Option, List]](_.toList)
[simulacrum-scalafix] +  val fk1 = new FuncK[Option, List] { def apply[A$](a$: Option[A$]): List[A$] = a$.toList }
[simulacrum-scalafix]    val fk2 = new FuncK[Option, List] { def apply[A$](a$: Option[A$]): List[A$] = Nil }
[simulacrum-scalafix] -  val fk3 = Î»[List ~> Option](_.headOption)
[simulacrum-scalafix] +  val fk3 = new (List ~> Option) { def apply[A$](a$: List[A$]): Option[A$] = a$.headOption }
[simulacrum-scalafix]    val fk4 = new (List ~> Option) { def apply[A$](xs: List[A$]): Option[A$] = xs.lastOption }
[simulacrum-scalafix]    val fk5 = new (({ type Î»[Î±$] = Foo[Î±$, Int] })#Î» ~> Option) { def apply[A$](a$: Foo[A$, Int]): Option[A$] = None }
[simulacrum-scalafix] -  val fk6 = Î»[FuncK[List, Î»[x => List[List[x]]]]](List(_))
[simulacrum-scalafix] -  val fk7 = Î»[List ~> Option](_.headOption.map(identity))
[simulacrum-scalafix] +  val fk6 = new FuncK[List, ({ type Î»[x] = List[List[x]] })#Î»] { def apply[A$](a$: List[A$]): List[List[A$]] = List(a$) }
[simulacrum-scalafix] +  val fk7 = new (List ~> Option) { def apply[A$](a$: List[A$]): Option[A$] = a$.headOption.map(identity) }
[simulacrum-scalafix]    val fk8 = new (List ~> Option) { def apply[A$](list: List[A$]): Option[A$] = {
```

I don't know what to make of this. Regression in scalameta? Something in scalafix that needs to be adjusted for the new scalameta version? Or is it just something that the simulacrum-scalafix people (@sh0hei maybe?) need to adjust in their test suite?

Properly investigating isn't really something I can take on myself.

Regardless, opening this PR to get the ball rolling. (It isn't easy for the simulacrum-scalafix folks to investigate unless they have a scalafix release to use.)