### PR TITLE
define & apply binary compatibility strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,10 @@ jobs:
       - run: sbt "scalafixAll --check"
       - run: ./bin/scalafmt --test
   mima:
-    name: MiMa
+    name: Version Policy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: olafurpg/setup-scala@v13
       - run: git fetch --unshallow
-      - run: sbt +mimaReportBinaryIssues
+      - run: sbt +versionPolicyCheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ jobs:
       - uses: olafurpg/setup-scala@v13
       - uses: olafurpg/setup-gpg@v3
       - run: git fetch --unshallow
+      - name: Check that major or minor was bumped upon compatibility breakage
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: sbt versionCheck
       - name: Publish ${{ github.ref }}
         run: sbt ci-release
         env:

--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,6 @@ lazy val core = project
   .in(file("scalafix-core"))
   .settings(
     moduleName := "scalafix-core",
-    versionScheme := Some("early-semver"),
     buildInfoSettingsForCore,
     libraryDependencies ++= List(
       scalameta,

--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,7 @@ lazy val core = project
   .in(file("scalafix-core"))
   .settings(
     moduleName := "scalafix-core",
+    versionScheme := Some("early-semver"),
     buildInfoSettingsForCore,
     libraryDependencies ++= List(
       scalameta,

--- a/docs/developers/api.md
+++ b/docs/developers/api.md
@@ -4,9 +4,26 @@ title: API Overview
 sidebar_label: Overview
 ---
 
+## Compatibility considerations
+
+[`scalafix-core`](https://index.scala-lang.org/scalacenter/scalafix/scalafix-core)
+makes the packages below available to built-in and external rules.
+
+Its X.Y.Z version scheme follows [Early SemVer](https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html#early-semver-and-sbt-version-policy)
+for binary compatiblity and aims at keeping source compatibility across
+versions.
+- Running a rule built against an older X or 0.Y version of Scalafix may cause
+  either runtime errors, or false positive/negative tree selection. In that
+  case, a warning is issued when fetching the rules(s) artifact(s).
+- Running a rule built against a more recent X.Y or 0.Y.Z version of Scalafix
+  is not possible. In that case, a `ScalafixException` is raised when fetching
+  the rules(s) artifact(s).
+
+## Packages
+
 The Scalafix public API documentation is composed of several packages.
 
-## Scalafix v1
+### Scalafix v1
 
 Latest Scaladoc:
 [v@VERSION@](https://static.javadoc.io/ch.epfl.scala/scalafix-core_2.12/@VERSION@/scalafix/v1/index.html)
@@ -37,15 +54,7 @@ structures include:
   information such as trees/tokens and semantic information such as
   symbols/types/synthetics.
 
-## Scalafix v0
-
-Latest Scaladoc:
-[v@VERSION@](https://static.javadoc.io/ch.epfl.scala/scalafix-core_2.12/@VERSION@/scalafix/v0/index.html)
-
-This is a legacy API that exists to smoothen the migration for existing Scalafix
-v0.5 rules. If you are writing a new Scalafix rule, please use the v1 API.
-
-## Scalameta Trees
+### Scalameta Trees
 
 Latest Scaladoc:
 [v@SCALAMETA@](https://static.javadoc.io/org.scalameta/trees_2.12/@SCALAMETA@/scala/meta/index.html)
@@ -71,7 +80,7 @@ include:
   position". Statement position is the
 - `Defn`: the supertype for all definitions
 
-## Scalameta Tokens
+### Scalameta Tokens
 
 Latest Scaladoc:
 [v@SCALAMETA@](https://static.javadoc.io/org.scalameta/tokens_2.12/@SCALAMETA@/scala/meta/tokens/Token.html)

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -5,7 +5,8 @@ import sbt.nio.Keys._
 import sbt.plugins.JvmPlugin
 import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
 import sbtbuildinfo.BuildInfoKey
-import sbtbuildinfo.BuildInfoPlugin.autoImport.{BuildInfoKey, _}
+import sbtbuildinfo.BuildInfoPlugin.autoImport._
+import sbtversionpolicy.SbtVersionPolicyPlugin.autoImport._
 import com.typesafe.sbt.sbtghpages.GhpagesKeys
 import sbt.librarymanagement.ivy.IvyDependencyResolution
 import sbt.plugins.IvyPlugin
@@ -177,6 +178,13 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
   )
 
   private val PreviousScalaVersion: Map[String, String] = Map(
+  )
+
+  override def buildSettings: Seq[Setting[_]] = List(
+    versionPolicyIgnoredInternalDependencyVersions :=
+      Some("^\\d+\\.\\d+\\.\\d+\\+\\d+".r),
+    versionScheme := Some("early-semver"),
+    versionPolicyIntention := Compatibility.None // TODO: harden after 0.10.0
   )
 
   override def projectSettings: Seq[Def.Setting[_]] = List(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.0.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "2.0.1")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.1")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.34")

--- a/scalafix-cli/src/main/scala/scalafix/internal/util/Compatibility.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/util/Compatibility.scala
@@ -1,0 +1,35 @@
+package scalafix.internal.util
+
+sealed trait Compatibility
+
+object Compatibility {
+
+  case object Compatible extends Compatibility
+  case object Unknown extends Compatibility
+  case object Incompatible extends Compatibility
+
+  private val Snapshot = """.*-SNAPSHOT""".r
+  private val XYZ = """^([0-9]+)\.([0-9]+)\.([0-9]+)""".r
+
+  def earlySemver(builtAgainst: String, runWith: String): Compatibility = {
+    (builtAgainst, runWith) match {
+      case (Snapshot(), _) => Unknown
+      case (_, Snapshot()) => Unknown
+      case (XYZ(bX, _, _), XYZ(rX, _, _)) if bX.toInt > rX.toInt =>
+        Incompatible
+      case (XYZ(bX, _, _), XYZ(rX, _, _)) if bX.toInt < rX.toInt =>
+        Unknown
+      // --- X match given the cases above
+      case (XYZ(_, bY, _), XYZ(_, rY, _)) if bY.toInt > rY.toInt =>
+        Incompatible
+      case (XYZ("0", bY, _), XYZ("0", rY, _)) if bY.toInt < rY.toInt =>
+        Unknown
+      case (XYZ(_, bY, _), XYZ(_, rY, _)) if bY.toInt < rY.toInt =>
+        Compatible
+      // --- X.Y match given the cases above
+      case (XYZ("0", _, bZ), XYZ("0", _, rZ)) if bZ.toInt > rZ.toInt =>
+        Incompatible
+      case _ => Compatible
+    }
+  }
+}

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CompatibilitySuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CompatibilitySuite.scala
@@ -1,0 +1,104 @@
+package scalafix.tests.cli
+
+import org.scalatest.funsuite.AnyFunSuite
+import scalafix.internal.util.Compatibility
+import scalafix.internal.util.Compatibility._
+
+class CompatibilitySuite extends AnyFunSuite {
+
+  // to avoid struggles when testing nightlies
+  test("EarlySemver unknown if run or build is a snapshot") {
+    assert(
+      Compatibility.earlySemver(
+        builtAgainst = "0.9.34+52-a83785c4-SNAPSHOT",
+        runWith = "1.2.3"
+      ) == Unknown
+    )
+    assert(
+      Compatibility.earlySemver(
+        builtAgainst = "0.9.34",
+        runWith = "1.2.3+1-bfe5ccd4-SNAPSHOT"
+      ) == Unknown
+    )
+  }
+
+  // backward compatibility within X.*.*, 0.Y.*, ...
+  test(
+    "EarlySemver compatible if run is equal or greater by minor (or patch in 0.)"
+  ) {
+    assert(
+      Compatibility.earlySemver(
+        builtAgainst = "1.3.27",
+        runWith = "1.3.28"
+      ) == Compatible
+    )
+    assert(
+      Compatibility.earlySemver(
+        builtAgainst = "1.10.20",
+        runWith = "1.12.0"
+      ) == Compatible
+    )
+    assert(
+      Compatibility.earlySemver(
+        builtAgainst = "0.6.12",
+        runWith = "0.6.12"
+      ) == Compatible
+    )
+    assert(
+      Compatibility.earlySemver(
+        builtAgainst = "0.9.0",
+        runWith = "0.9.20"
+      ) == Compatible
+    )
+  }
+
+  // no forward compatibility: build might reference classes unknown to run
+  test("EarlySemver incompatible if run is lower by minor (or patch in 0.)") {
+    assert(
+      Compatibility.earlySemver(
+        builtAgainst = "0.10.8",
+        runWith = "0.9.16"
+      ) == Incompatible
+    )
+    assert(
+      Compatibility.earlySemver(
+        builtAgainst = "0.10.17",
+        runWith = "0.10.4"
+      ) == Incompatible
+    )
+    assert(
+      Compatibility.earlySemver(
+        builtAgainst = "2.0.0",
+        runWith = "1.1.1"
+      ) == Incompatible
+    )
+    assert(
+      Compatibility.earlySemver(
+        builtAgainst = "1.4.7",
+        runWith = "1.2.8"
+      ) == Incompatible
+    )
+  }
+
+  // might be false positive/negative tree matches or link failures
+  test("EarlySemver unknown if run is greater by major (or minor in 0.)") {
+    assert(
+      Compatibility.earlySemver(
+        builtAgainst = "1.0.41",
+        runWith = "2.0.0"
+      ) == Unknown
+    )
+    assert(
+      Compatibility.earlySemver(
+        builtAgainst = "0.9.38",
+        runWith = "0.10.2"
+      ) == Unknown
+    )
+    assert(
+      Compatibility.earlySemver(
+        builtAgainst = "0.9.38",
+        runWith = "1.0.0"
+      ) == Unknown
+    )
+  }
+}


### PR DESCRIPTION
In the last few weeks, 2 dependency bumps broke backward compatibility of nightlies
- metaconfig 0.10.0, at the [source](https://github.com/scalacenter/scalafix/pull/1546) & [binary](https://github.com/scalacenter/scalafix/pull/1530#issuecomment-1061174301) level because of [breaking changes in pprint](https://github.com/com-lihaoyi/PPrint/pull/72), despite [attempts to mitigate the problem](https://github.com/scalameta/metaconfig/pull/154)
- scalameta 4.5.0, at the [functional](https://github.com/typelevel/simulacrum-scalafix/pull/194) level, by [introducing a new node in the AST](https://github.com/scalameta/scalameta/pull/2601) ([detected thanks to the Scala 2 community build](https://github.com/scalacenter/scalafix/pull/1556))

Since these changes haven't made it to a release yet, that seems like a good moment to either
1. clarify compatibility guarantees for rule authors ahead of a minor bump for the upcoming release, or
1. revert the bumps for now and
   1. pin dependencies, or
   1. contribute upstream to mitigate the impact

This PR takes the path of (1).