### PR TITLE
never wait to bump scalameta

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -9,3 +9,10 @@ updates.pin = [
   # https://github.com/com-lihaoyi/PPrint/pull/72 brought a breaking change, see https://github.com/scalacenter/scalafix/pull/1522
   { groupId = "com.lihaoyi", artifactId = "pprint", version = "0.6." },
 ]
+
+dependencyOverrides = [
+  {
+    dependency = { groupId = "org.scalameta" },
+    pullRequests = { frequency = "@asap" },
+  }
+]


### PR DESCRIPTION
Rationale: scalameta being at the heat of the Scalafix API, we should track the latest version