### PR TITLE
`ExplicitResultTypes`: backquote types when needed

### DIFF
--- a/scalafix-rules/src/main/scala/scala/meta/internal/pc/Identifier.scala
+++ b/scalafix-rules/src/main/scala/scala/meta/internal/pc/Identifier.scala
@@ -114,6 +114,9 @@ object Identifier {
     else s
   }
 
-  def backtickWrapWithoutCheck(typeName: String, typeArgs: Option[String]): String =
+  def backtickWrapWithoutCheck(
+      typeName: String,
+      typeArgs: Option[String]
+  ): String =
     typeArgs.fold('`' + typeName + '`')(ta => '`' + typeName + '`' + ta)
 }

--- a/scalafix-rules/src/main/scala/scala/meta/internal/pc/Identifier.scala
+++ b/scalafix-rules/src/main/scala/scala/meta/internal/pc/Identifier.scala
@@ -114,9 +114,5 @@ object Identifier {
     else s
   }
 
-  def backtickWrapWithoutCheck(
-      typeName: String,
-      typeArgs: Option[String]
-  ): String =
-    typeArgs.fold('`' + typeName + '`')(ta => '`' + typeName + '`' + ta)
+  def backtickWrapWithoutCheck(typeName: String): String = '`' + typeName + '`'
 }

--- a/scalafix-rules/src/main/scala/scala/meta/internal/pc/Identifier.scala
+++ b/scalafix-rules/src/main/scala/scala/meta/internal/pc/Identifier.scala
@@ -106,6 +106,7 @@ object Identifier {
   def backtickWrap(name: Global#Name): String = {
     backtickWrap(name.decoded.trim)
   }
+
   def backtickWrap(s: String): String = {
     if (s.isEmpty) "``"
     else if (s(0) == '`' && s.last == '`') s
@@ -113,4 +114,6 @@ object Identifier {
     else s
   }
 
+  def backtickWrapWithoutCheck(typeName: String, typeArgs: Option[String]): String =
+    typeArgs.fold('`' + typeName + '`')(ta => '`' + typeName + '`' + ta)
 }

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/CompilerTypePrinter.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/CompilerTypePrinter.scala
@@ -109,26 +109,7 @@ class CompilerTypePrinter(g: ScalafixGlobal, config: ExplicitResultTypesConfig)(
     }
     val preProcessed = preProcess(toLoop, inverseSemanticdbSymbol).widen
     val shortType = g.shortType(preProcessed, history)
-    val shortTypeStr = shortType.toString()
-
-    // currently wrapping in backticks supported only for case classes
-    val isCaseClass = shortType.typeSymbol.isCaseClass
-    val typeSymbolName = shortType.typeSymbol.decodedName
-    val short =
-      if (isCaseClass && Identifier.needsBacktick(typeSymbolName)) {
-        if (shortType.typeArgs.nonEmpty) {
-          val typeConstructorStr = shortType.typeConstructor.toString()
-          val typeArgsStr = shortType.typeArgs.mkString("[", ", ", "]")
-          Identifier.backtickWrapWithoutCheck(
-            typeConstructorStr,
-            Some(typeArgsStr)
-          )
-        } else {
-          Identifier.backtickWrapWithoutCheck(shortTypeStr, None)
-        }
-      } else
-        shortTypeStr
-
+    val short = shortType.toString()
     willBeImported ++= history.missingImports
     val addImports = importPatches(history, context)
     val isConstantType = toLoop.finalResultType match {

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/CompilerTypePrinter.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/CompilerTypePrinter.scala
@@ -119,7 +119,10 @@ class CompilerTypePrinter(g: ScalafixGlobal, config: ExplicitResultTypesConfig)(
         if (shortType.typeArgs.nonEmpty) {
           val typeConstructorStr = shortType.typeConstructor.toString()
           val typeArgsStr = shortType.typeArgs.mkString("[", ", ", "]")
-          Identifier.backtickWrapWithoutCheck(typeConstructorStr, Some(typeArgsStr))
+          Identifier.backtickWrapWithoutCheck(
+            typeConstructorStr,
+            Some(typeArgsStr)
+          )
         } else {
           Identifier.backtickWrapWithoutCheck(shortTypeStr, None)
         }

--- a/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBackQuote.scala
+++ b/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBackQuote.scala
@@ -9,6 +9,7 @@ object ExplicitResultTypesBackQuote {
 
   case class `Foo-Bar`[A](i: A)
   trait `Foo-Trait` {}
+  class `Foo-Class`
   final case class `Bar[,?! $42Baz`[F[_], G[_]](fi: F[Int], gs: G[String])
 
   object Nested {
@@ -25,9 +26,11 @@ object ExplicitResultTypesBackQuote {
 
   val foobar = `Foo-Bar`(42)
   val fooTrait = null.asInstanceOf[`Foo-Trait`]
+  val fooClass: `Foo-Class` = null.asInstanceOf[`Foo-Class`]
   val barbaz = `Bar[,?! $42Baz`[List, Option](List(42), Some(""))
   val qux = Nested.Inner.`Qux Qux`(42)
   val quxqux = Nested.Inner.`Qux.Qux`[List](List(42))
   val quux = `Quux !`(42)
   val nestedTrait = null.asInstanceOf[Nested.Inner.`Nested-Trait`[`Foo-Bar`]]
+  def byname[A] = null.asInstanceOf[(=> `Foo-Bar`[A]) => `Quux !`]
 }

--- a/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBackQuote.scala
+++ b/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBackQuote.scala
@@ -1,0 +1,13 @@
+/*
+rules = "ExplicitResultTypes"
+*/
+package test.explicitResultTypes
+
+// https://github.com/scalacenter/scalafix/issues/1219
+object ExplicitResultTypesBackQuote {
+  case class `Foo-Bar`(i: Int)
+  final case class `Bar[,?! $42Baz`[F[_], G[_]](fi: F[Int], gs: G[String])
+
+  val foobar = `Foo-Bar`(42)
+  val barbaz = `Bar[,?! $42Baz`[List, Option](List(42), Some(""))
+}

--- a/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBackQuote.scala
+++ b/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBackQuote.scala
@@ -5,9 +5,29 @@ package test.explicitResultTypes
 
 // https://github.com/scalacenter/scalafix/issues/1219
 object ExplicitResultTypesBackQuote {
-  case class `Foo-Bar`(i: Int)
+  import ImportObject._
+
+  case class `Foo-Bar`[A](i: A)
+  trait `Foo-Trait` {}
   final case class `Bar[,?! $42Baz`[F[_], G[_]](fi: F[Int], gs: G[String])
 
+  object Nested {
+    object Inner {
+      case class `Qux Qux`(i: Int)
+      final case class `Qux.Qux`[F[_]](fi: F[Int])
+      trait `Nested-Trait`[F[_]] {}
+    }
+  }
+
+  object ImportObject {
+    case class `Quux !`(i: Int)
+  }
+
   val foobar = `Foo-Bar`(42)
+  val fooTrait = null.asInstanceOf[`Foo-Trait`]
   val barbaz = `Bar[,?! $42Baz`[List, Option](List(42), Some(""))
+  val qux = Nested.Inner.`Qux Qux`(42)
+  val quxqux = Nested.Inner.`Qux.Qux`[List](List(42))
+  val quux = `Quux !`(42)
+  val nestedTrait = null.asInstanceOf[Nested.Inner.`Nested-Trait`[`Foo-Bar`]]
 }

--- a/scalafix-tests/output/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBackQuote.scala
+++ b/scalafix-tests/output/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBackQuote.scala
@@ -1,0 +1,10 @@
+package test.explicitResultTypes
+
+// https://github.com/scalacenter/scalafix/issues/1219
+object ExplicitResultTypesBackQuote {
+  case class `Foo-Bar`(i: Int)
+  final case class `Bar[,?! $42Baz`[F[_], G[_]](fi: F[Int], gs: G[String])
+
+  val foobar: `Foo-Bar` = `Foo-Bar`(42)
+  val barbaz: `Bar[,?! $42Baz`[List, Option] = `Bar[,?! $42Baz`[List, Option](List(42), Some(""))
+}

--- a/scalafix-tests/output/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBackQuote.scala
+++ b/scalafix-tests/output/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBackQuote.scala
@@ -2,9 +2,29 @@ package test.explicitResultTypes
 
 // https://github.com/scalacenter/scalafix/issues/1219
 object ExplicitResultTypesBackQuote {
-  case class `Foo-Bar`(i: Int)
+  import ImportObject._
+
+  case class `Foo-Bar`[A](i: A)
+  trait `Foo-Trait` {}
   final case class `Bar[,?! $42Baz`[F[_], G[_]](fi: F[Int], gs: G[String])
 
-  val foobar: `Foo-Bar` = `Foo-Bar`(42)
+  object Nested {
+    object Inner {
+      case class `Qux Qux`(i: Int)
+      final case class `Qux.Qux`[F[_]](fi: F[Int])
+      trait `Nested-Trait`[F[_]] {}
+    }
+  }
+
+  object ImportObject {
+    case class `Quux !`(i: Int)
+  }
+
+  val foobar: `Foo-Bar`[Int] = `Foo-Bar`(42)
+  val fooTrait: `Foo-Trait` = null.asInstanceOf[`Foo-Trait`]
   val barbaz: `Bar[,?! $42Baz`[List, Option] = `Bar[,?! $42Baz`[List, Option](List(42), Some(""))
+  val qux: Nested.Inner.`Qux Qux` = Nested.Inner.`Qux Qux`(42)
+  val quxqux: Nested.Inner.`Qux.Qux`[List] = Nested.Inner.`Qux.Qux`[List](List(42))
+  val quux: `Quux !` = `Quux !`(42)
+  val nestedTrait: Nested.Inner.`Nested-Trait`[`Foo-Bar`] = null.asInstanceOf[Nested.Inner.`Nested-Trait`[`Foo-Bar`]]
 }

--- a/scalafix-tests/output/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBackQuote.scala
+++ b/scalafix-tests/output/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBackQuote.scala
@@ -6,6 +6,7 @@ object ExplicitResultTypesBackQuote {
 
   case class `Foo-Bar`[A](i: A)
   trait `Foo-Trait` {}
+  class `Foo-Class`
   final case class `Bar[,?! $42Baz`[F[_], G[_]](fi: F[Int], gs: G[String])
 
   object Nested {
@@ -22,9 +23,11 @@ object ExplicitResultTypesBackQuote {
 
   val foobar: `Foo-Bar`[Int] = `Foo-Bar`(42)
   val fooTrait: `Foo-Trait` = null.asInstanceOf[`Foo-Trait`]
+  val fooClass: `Foo-Class` = null.asInstanceOf[`Foo-Class`]
   val barbaz: `Bar[,?! $42Baz`[List, Option] = `Bar[,?! $42Baz`[List, Option](List(42), Some(""))
   val qux: Nested.Inner.`Qux Qux` = Nested.Inner.`Qux Qux`(42)
   val quxqux: Nested.Inner.`Qux.Qux`[List] = Nested.Inner.`Qux.Qux`[List](List(42))
   val quux: `Quux !` = `Quux !`(42)
   val nestedTrait: Nested.Inner.`Nested-Trait`[`Foo-Bar`] = null.asInstanceOf[Nested.Inner.`Nested-Trait`[`Foo-Bar`]]
+  def byname[A]: (=> `Foo-Bar`[A]) => `Quux !` = null.asInstanceOf[(=> `Foo-Bar`[A]) => `Quux !`]
 }


### PR DESCRIPTION
This fixes #1219. I was struggled with a working fix for all type-symbols but didn't succeed. I'd be glad to get help in moving this onward.