### PR TITLE
only warn when loading rules built with newer core

### DIFF
--- a/docs/developers/api.md
+++ b/docs/developers/api.md
@@ -14,10 +14,12 @@ for binary compatiblity and aims at keeping source compatibility across
 versions.
 - Running a rule built against an older X or 0.Y version of Scalafix may cause
   either runtime errors, or false positive/negative tree selection. In that
-  case, a warning is issued when resolving the rules(s) artifact(s).
+  case, a warning calling the user to use a more recent version of the rule
+  or downgrading Scalafix is issued when resolving the rules(s) artifact(s).
 - Running a rule built against a more recent X.Y or 0.Y.Z version of Scalafix
-  is not possible. In that case, a `ScalafixException` is raised when resolving
-  the rules(s) artifact(s).
+  is also a potential source of incompatibility. In that case, a warning
+  calling the user to upgrade Scalafix is issued when resolving the rules(s)
+  artifact(s).
 
 ## Packages
 

--- a/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixArgumentsImpl.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixArgumentsImpl.scala
@@ -101,12 +101,14 @@ final case class ScalafixArgumentsImpl(args: Args = Args.default)
           dependency.getVersion,
           Versions.nightly
         ) match {
-          case Incompatible =>
-            throw new ScalafixException(
-              s"Scalafix version ${Versions.nightly} cannot load the registered external rules, " +
-                s"please upgrade to ${dependency.getVersion} or later"
+          case TemptativeUp(compatibleRunWith) =>
+            args.out.println(
+              s"""Loading external rule(s) built against a recent version of Scalafix (${dependency.getVersion}).
+                |This might not be a problem, but in case you run into unexpected behavior, you
+                |should upgrade Scalafix to ${compatibleRunWith}.
+              """.stripMargin
             )
-          case Temptative(compatibleRunWith) =>
+          case TemptativeDown(compatibleRunWith) =>
             args.out.println(
               s"""Loading external rule(s) built against an old version of Scalafix (${dependency.getVersion}).
                 |This might not be a problem, but in case you run into unexpected behavior, you

--- a/scalafix-cli/src/main/scala/scalafix/internal/util/Compatibility.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/util/Compatibility.scala
@@ -7,8 +7,8 @@ object Compatibility {
 
   case object Compatible extends Compatibility
   case object Unknown extends Compatibility
-  case object Incompatible extends Compatibility
-  case class Temptative(compatibleRunWith: String) extends Compatibility
+  case class TemptativeUp(compatibleRunWith: String) extends Compatibility
+  case class TemptativeDown(compatibleRunWith: String) extends Compatibility
 
   private val Snapshot = """.*-SNAPSHOT""".r
   val XYZ: Regex = """^([0-9]+)\.([0-9]+)\.([0-9]+).*""".r
@@ -17,20 +17,20 @@ object Compatibility {
     (builtAgainst, runWith) match {
       case (Snapshot(), _) => Unknown
       case (_, Snapshot()) => Unknown
-      case (XYZ(bX, _, _), XYZ(rX, _, _)) if bX.toInt > rX.toInt =>
-        Incompatible
+      case (XYZ(bX, bY, _), XYZ(rX, _, _)) if bX.toInt > rX.toInt =>
+        TemptativeUp(s"$bX.x" + (if (bY.toInt > 0) s" (x>=$bY)" else ""))
       case (XYZ("0", bY, bZ), XYZ(rX, _, _)) if 0 < rX.toInt =>
-        Temptative(s"0.$bY.x" + (if (bZ.toInt > 0) s" (x>=$bZ)" else ""))
+        TemptativeDown(s"0.$bY.x" + (if (bZ.toInt > 0) s" (x>=$bZ)" else ""))
       case (XYZ(bX, bY, _), XYZ(rX, _, _)) if bX.toInt < rX.toInt =>
-        Temptative(s"$bX.x" + (if (bY.toInt > 0) s" (x>=$bY)" else ""))
+        TemptativeDown(s"$bX.x" + (if (bY.toInt > 0) s" (x>=$bY)" else ""))
       // --- X match given the cases above
-      case (XYZ(_, bY, _), XYZ(_, rY, _)) if bY.toInt > rY.toInt =>
-        Incompatible
+      case (XYZ(bX, bY, bZ), XYZ(_, rY, _)) if bY.toInt > rY.toInt =>
+        TemptativeUp(s"$bX.$bY.x" + (if (bZ.toInt > 0) s" (x>=$bZ)" else ""))
       case (XYZ("0", bY, bZ), XYZ("0", rY, _)) if bY.toInt < rY.toInt =>
-        Temptative(s"0.$bY.x" + (if (bZ.toInt > 0) s" (x>=$bZ)" else ""))
+        TemptativeDown(s"0.$bY.x" + (if (bZ.toInt > 0) s" (x>=$bZ)" else ""))
       // --- X.Y match given the cases above
-      case (XYZ("0", _, bZ), XYZ("0", _, rZ)) if bZ.toInt > rZ.toInt =>
-        Incompatible
+      case (XYZ("0", bY, bZ), XYZ("0", _, rZ)) if bZ.toInt > rZ.toInt =>
+        TemptativeUp(s"0.$bY.x (x>=$bZ)")
       case _ => Compatible
     }
   }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CompatibilitySuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CompatibilitySuite.scala
@@ -59,31 +59,50 @@ class CompatibilitySuite extends AnyFunSuite {
     )
   }
 
-  // no forward compatibility: build might reference classes unknown to run
-  test("EarlySemver incompatible if run is lower by minor (or patch in 0.)") {
+  // no guaranteed forward compatibility: build might reference classes unknown
+  // to run or run might be missing bugfixes build contains
+  test("EarlySemver temptative if run is lower") {
     assert(
       Compatibility.earlySemver(
         builtAgainst = "0.10.8",
         runWith = "0.9.16"
-      ) == Incompatible
+      ) == TemptativeUp("0.10.x (x>=8)")
+    )
+    assert(
+      Compatibility.earlySemver(
+        builtAgainst = "0.10.0",
+        runWith = "0.9.16"
+      ) == TemptativeUp("0.10.x")
     )
     assert(
       Compatibility.earlySemver(
         builtAgainst = "0.10.17",
         runWith = "0.10.4"
-      ) == Incompatible
+      ) == TemptativeUp("0.10.x (x>=17)")
+    )
+    assert(
+      Compatibility.earlySemver(
+        builtAgainst = "2.3.0",
+        runWith = "1.1.1"
+      ) == TemptativeUp("2.x (x>=3)")
     )
     assert(
       Compatibility.earlySemver(
         builtAgainst = "2.0.0",
         runWith = "1.1.1"
-      ) == Incompatible
+      ) == TemptativeUp("2.x")
     )
     assert(
       Compatibility.earlySemver(
         builtAgainst = "1.4.7",
         runWith = "1.2.8"
-      ) == Incompatible
+      ) == TemptativeUp("1.4.x (x>=7)")
+    )
+    assert(
+      Compatibility.earlySemver(
+        builtAgainst = "1.5.0",
+        runWith = "1.2.8"
+      ) == TemptativeUp("1.5.x")
     )
   }
 
@@ -93,37 +112,37 @@ class CompatibilitySuite extends AnyFunSuite {
       Compatibility.earlySemver(
         builtAgainst = "1.3.0",
         runWith = "2.0.0"
-      ) == Temptative("1.x (x>=3)")
+      ) == TemptativeDown("1.x (x>=3)")
     )
     assert(
       Compatibility.earlySemver(
         builtAgainst = "1.0.41",
         runWith = "2.0.0"
-      ) == Temptative("1.x")
+      ) == TemptativeDown("1.x")
     )
     assert(
       Compatibility.earlySemver(
         builtAgainst = "0.9.38",
         runWith = "0.10.2"
-      ) == Temptative("0.9.x (x>=38)")
+      ) == TemptativeDown("0.9.x (x>=38)")
     )
     assert(
       Compatibility.earlySemver(
         builtAgainst = "0.8.0",
         runWith = "0.10.2"
-      ) == Temptative("0.8.x")
+      ) == TemptativeDown("0.8.x")
     )
     assert(
       Compatibility.earlySemver(
         builtAgainst = "0.7.12",
         runWith = "1.2.1"
-      ) == Temptative("0.7.x (x>=12)")
+      ) == TemptativeDown("0.7.x (x>=12)")
     )
     assert(
       Compatibility.earlySemver(
         builtAgainst = "0.9.0",
         runWith = "1.0.0"
-      ) == Temptative("0.9.x")
+      ) == TemptativeDown("0.9.x")
     )
   }
 }


### PR DESCRIPTION
Follow-up of https://github.com/scalacenter/scalafix/pull/1565 (https://github.com/scalacenter/scalafix/commit/c4c1f1e686367f1bcf7d627526d93416fa8de07b#r69611050)