### PR TITLE
pprint is only required on -cli for 0.9.x compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,16 +69,9 @@ lazy val core = projectMatrix
       googleDiff,
       collectionCompat
     ),
-    libraryDependencies ++= {
-      if (isScala211.value) Seq(metaconfigFor211)
-      else
-        Seq(
-          metaconfig,
-          // metaconfig 0.10.0 shaded pprint but rules built with an old
-          // scalafix-core must have the original package in the classpath to link
-          // https://github.com/scalameta/metaconfig/pull/154/files#r794005161
-          pprint % Runtime
-        )
+    libraryDependencies += {
+      if (isScala211.value) metaconfigFor211
+      else metaconfig
     }
   )
   .defaultAxes(VirtualAxis.jvm)
@@ -128,6 +121,16 @@ lazy val cli = projectMatrix
       jgit,
       commonText
     ),
+    libraryDependencies ++= {
+      if (isScala211.value) Seq()
+      else
+        Seq(
+          // metaconfig 0.10.0 shaded pprint but rules built with an old
+          // scalafix-core must have the original package in the classpath to link
+          // https://github.com/scalameta/metaconfig/pull/154/files#r794005161
+          pprint % Runtime
+        )
+    },
     publishLocalTransitive := Def.taskDyn {
       val ref = thisProjectRef.value
       publishLocal.all(ScopeFilter(inDependencies(ref)))

--- a/scalafix-interfaces/src/main/java/scalafix/internal/interfaces/ScalafixCoursier.java
+++ b/scalafix-interfaces/src/main/java/scalafix/internal/interfaces/ScalafixCoursier.java
@@ -49,23 +49,10 @@ public class ScalafixCoursier {
             String scalafixVersion,
             String scalaVersion
     ) throws ScalafixException {
-        List<Dependency> dependencies = new ArrayList<Dependency>();
-        dependencies.add(
-            Dependency.parse(
-                "ch.epfl.scala:::scalafix-cli:" + scalafixVersion,
-                ScalaVersion.of(scalaVersion)
-            ).withConfiguration("runtime")
-        );
-        // Coursier does not seem to fetch runtime dependencies transitively, despite what Maven dictates
-        // https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#dependency-scope
-        // so to be able to retrieve the runtime dependencies of scalafix-core, we need an explicit reference
-        dependencies.add(
-            Dependency.parse(
-                "ch.epfl.scala::scalafix-core:" + scalafixVersion,
-                ScalaVersion.of(scalaVersion)
-            ).withConfiguration("runtime")
-        );
-        return toURLs(fetch(repositories, dependencies, ResolutionParams.create()));
+        Dependency scalafixCli = Dependency
+				.parse("ch.epfl.scala:::scalafix-cli:" + scalafixVersion, ScalaVersion.of(scalaVersion))
+				.withConfiguration("runtime");
+        return toURLs(fetch(repositories, Collections.singletonList(scalafixCli), ResolutionParams.create()));
     }
 
     public static FetchResult toolClasspath(


### PR DESCRIPTION
Follows https://github.com/scalacenter/scalafix/pull/1546

Tested against regressions via https://github.com/scalacenter/scalafix/blob/c5633c67a449b0ed8658c26910805f6893485007/scalafix-tests/unit/src/test/scala/scalafix/tests/interfaces/ScalafixSuite.scala#L84-L95 (`com.nequissimus::sort-imports:0.5.2` is built against [0.9.x](https://github.com/NeQuissimus/sort-imports/blob/v0.5.2/project/plugins.sbt#L2))