### PR TITLE
Fix issues with backquotes in several case as seen in Metals

### DIFF
--- a/scalafix-rules/src/main/scala/scala/meta/internal/pc/ScalafixGlobal.scala
+++ b/scalafix-rules/src/main/scala/scala/meta/internal/pc/ScalafixGlobal.scala
@@ -177,8 +177,11 @@ class ScalafixGlobal(
     tpe match {
       case TypeRef(pre, sym, args)
           if Identifier.needsBacktick(sym.decodedName) &&
-            sym != definitions.ByNameParamClass // `=> T` is OK
-          =>
+            sym != definitions.ByNameParamClass && // `=> T` is OK
+            !sym.isPackageObject &&
+            !definitions.isRepeated(sym) &&
+            !sym.isAbstractType &&
+            sym.owner != definitions.ScalaPackageClass =>
         val rawPrettyName = Identifier.backtickWrapWithoutCheck(sym.decodedName)
         val prefix = if (withPrefix) pre.prefixString else ""
         if (args.isEmpty) {

--- a/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBackQuoteComplex.scala
+++ b/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBackQuoteComplex.scala
@@ -1,0 +1,13 @@
+/*
+rules = "ExplicitResultTypes"
+*/
+package test.explicitResultTypes
+
+// https://github.com/scalacenter/scalafix/issues/1219
+object ExplicitResultTypesBackQuoteComplex {
+  val it = null.asInstanceOf[Iterable[_]]
+  def method(a: String*) = a.head
+  val func = method _
+  val hash = new java.util.HashMap[String, Int]()
+  val func2 = hash.computeIfAbsent _
+}

--- a/scalafix-tests/output/src/main/scala-2.11/test/explicitResultTypes/ExplicitResultTypesBackQuoteComplex.scala
+++ b/scalafix-tests/output/src/main/scala-2.11/test/explicitResultTypes/ExplicitResultTypesBackQuoteComplex.scala
@@ -1,0 +1,11 @@
+package test.explicitResultTypes
+
+import java.util.function
+// https://github.com/scalacenter/scalafix/issues/1219
+object ExplicitResultTypesBackQuoteComplex {
+  val it: Iterable[Any] = null.asInstanceOf[Iterable[_]]
+  def method(a: String*) = a.head
+  val func: Seq[String] => String = method _
+  val hash = new java.util.HashMap[String, Int]()
+  val func2: (String, function.Function[_ >: String, _ <: Int]) => Int = hash.computeIfAbsent _
+}

--- a/scalafix-tests/output/src/main/scala-2.12/test/explicitResultTypes/ExplicitResultTypesBackQuoteComplex.scala
+++ b/scalafix-tests/output/src/main/scala-2.12/test/explicitResultTypes/ExplicitResultTypesBackQuoteComplex.scala
@@ -1,0 +1,11 @@
+package test.explicitResultTypes
+
+import java.util.function
+// https://github.com/scalacenter/scalafix/issues/1219
+object ExplicitResultTypesBackQuoteComplex {
+  val it: Iterable[Any] = null.asInstanceOf[Iterable[_]]
+  def method(a: String*) = a.head
+  val func: Seq[String] => String = method _
+  val hash = new java.util.HashMap[String, Int]()
+  val func2: (String, function.Function[_ >: String, _ <: Int]) => Int = hash.computeIfAbsent _
+}

--- a/scalafix-tests/output/src/main/scala-2.13/test/explicitResultTypes/ExplicitResultTypesBackQuoteComplex.scala
+++ b/scalafix-tests/output/src/main/scala-2.13/test/explicitResultTypes/ExplicitResultTypesBackQuoteComplex.scala
@@ -1,0 +1,11 @@
+package test.explicitResultTypes
+
+import java.util.function
+// https://github.com/scalacenter/scalafix/issues/1219
+object ExplicitResultTypesBackQuoteComplex {
+  val it: Iterable[Any] = null.asInstanceOf[Iterable[_]]
+  def method(a: String*) = a.head
+  val func: Seq[String] => String = method _
+  val hash = new java.util.HashMap[String, Int]()
+  val func2: (String, function.Function[_ >: String <: Object, _ <: Int]) => Int = hash.computeIfAbsent _
+}


### PR DESCRIPTION
I backported the changes to backquote types to Metals and found some issues. Some of that might not be needed for Scalafix, but it's better to be on the safe side.

Related https://github.com/scalameta/metals/pull/3829