### PR TITLE
RedundantSyntax removes unnecessary string interpolator

### DIFF
--- a/docs/rules/RedundantSyntax.md
+++ b/docs/rules/RedundantSyntax.md
@@ -4,13 +4,34 @@ id: RedundantSyntax
 title: RedundantSyntax
 ---
 
-This rule removes redundant syntax. Currently the only syntax it removes is the `final` keyword on an `object`.
+This rule removes redundant syntax.
 
-Example:
+## `final` keyword on an `object`
 
 ```diff
 - final object foo
 + object Foo
 ```
 
-Note: in Scala 2.12 and earlier removing the `final` modifier will slightly change the resulting bytecode - see [this bug ticket](https://github.com/scala/bug/issues/11094) for further information.
+Note: in Scala 2.12 and earlier removing the `final` modifier will slightly change the resulting bytecode -
+see [this bug ticket](https://github.com/scala/bug/issues/11094) for further information.
+
+## String interpolators
+
+`RedundantSyntax` removes unnecessary [string interpolators](https://docs.scala-lang.org/overviews/core/string-interpolation.html). 
+Only out-of-the-box interpolators (`s`, `f` and `raw`) are supported.
+
+Example:
+
+```diff
+- println(s"Foo")
++ println("Foo")
+
+- println(f"Bar")
++ println("Bar")
+
+- println(raw"Baz")
++ println("Foo")
+
+println(raw"Foo\nBar")
+```

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/RedundantSyntax.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/RedundantSyntax.scala
@@ -29,5 +29,14 @@ class RedundantSyntax(config: RedundantSyntaxConfig)
             finalTok :: TokenList(o.tokens).trailingSpaces(finalTok).toList
           }
         }
+      case interpolator @ Term.Interpolate(
+            Term.Name(p),
+            Lit.String(v) :: Nil,
+            Nil
+          )
+          if config.stringInterpolator
+            && (p == "s" || p == "f" || (p == "raw" && StringContext
+              .processEscapes(v) == v)) =>
+        Patch.removeTokens(interpolator.prefix.tokens)
     }.asPatch
 }

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/RedundantSyntaxConfig.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/RedundantSyntaxConfig.scala
@@ -6,7 +6,9 @@ import metaconfig.generic.Surface
 
 final case class RedundantSyntaxConfig(
     @Description("Remove final modifier from objects")
-    finalObject: Boolean = true
+    finalObject: Boolean = true,
+    @Description("Remove unnecessary string interpolator")
+    stringInterpolator: Boolean = true
 )
 
 object RedundantSyntaxConfig {

--- a/scalafix-tests/input/src/main/scala/test/redundantSyntax/StringInterpolator.scala
+++ b/scalafix-tests/input/src/main/scala/test/redundantSyntax/StringInterpolator.scala
@@ -1,0 +1,37 @@
+/*
+rules = RedundantSyntax
+RedundantSyntax.stringInterpolator = true
+*/
+
+package test.redundantSyntax
+
+class StringInterpolator {
+
+  val a = 42d
+
+  var b = ""
+  b = "foo"
+  b = s"foo"
+  b = s"foo $a bar"
+
+  b = """foo"""
+  b =
+    s"""foo
+       |bar"""
+  b = s"""foo $a bar"""
+  b = s"""$a"""
+
+  b = f"foo"
+  b = f"foo $a%2.2f"
+
+  b = raw"foo $a \nbar"
+  b = raw"foo\nbar\\"
+  b = raw"foo bar"
+
+  b = my"foo"
+  b = my"foo $a bar"
+
+  implicit class MyInterpolator(sc: StringContext) {
+    def my(subs: Any*): String = sc.toString + subs.mkString("")
+  }
+}

--- a/scalafix-tests/output/src/main/scala/test/redundantSyntax/StringInterpolator.scala
+++ b/scalafix-tests/output/src/main/scala/test/redundantSyntax/StringInterpolator.scala
@@ -1,0 +1,32 @@
+package test.redundantSyntax
+
+class StringInterpolator {
+
+  val a = 42d
+
+  var b = ""
+  b = "foo"
+  b = "foo"
+  b = s"foo $a bar"
+
+  b = """foo"""
+  b =
+    """foo
+       |bar"""
+  b = s"""foo $a bar"""
+  b = s"""$a"""
+
+  b = "foo"
+  b = f"foo $a%2.2f"
+
+  b = raw"foo $a \nbar"
+  b = raw"foo\nbar\\"
+  b = "foo bar"
+
+  b = my"foo"
+  b = my"foo $a bar"
+
+  implicit class MyInterpolator(sc: StringContext) {
+    def my(subs: Any*): String = sc.toString + subs.mkString("")
+  }
+}


### PR DESCRIPTION

Idea from [gitter](https://gitter.im/scalacenter/scalafix?at=625756193ae95a1ec1e78751):

```diff
- println(s"Hi!")
+ println("Hi!")
```