### PR TITLE
Fix RedundantSyntax raw interpolator handling

### DIFF
--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/RedundantSyntax.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/RedundantSyntax.scala
@@ -35,8 +35,7 @@ class RedundantSyntax(config: RedundantSyntaxConfig)
             Nil
           )
           if config.stringInterpolator
-            && (p == "s" || p == "f" || (p == "raw" && StringContext
-              .processEscapes(v) == v)) =>
+            && (p == "s" || p == "f" || (p == "raw" && !v.contains('\\'))) =>
         Patch.removeTokens(interpolator.prefix.tokens)
     }.asPatch
 }

--- a/scalafix-tests/input/src/main/scala/test/redundantSyntax/StringInterpolator.scala
+++ b/scalafix-tests/input/src/main/scala/test/redundantSyntax/StringInterpolator.scala
@@ -27,6 +27,7 @@ class StringInterpolator {
   b = raw"foo $a \nbar"
   b = raw"foo\nbar\\"
   b = raw"foo bar"
+  b = raw"a\*b\+"
 
   b = my"foo"
   b = my"foo $a bar"

--- a/scalafix-tests/output/src/main/scala/test/redundantSyntax/StringInterpolator.scala
+++ b/scalafix-tests/output/src/main/scala/test/redundantSyntax/StringInterpolator.scala
@@ -22,6 +22,7 @@ class StringInterpolator {
   b = raw"foo $a \nbar"
   b = raw"foo\nbar\\"
   b = "foo bar"
+  b = raw"a\*b\+"
 
   b = my"foo"
   b = my"foo $a bar"


### PR DESCRIPTION
`RedundantSyntax` raised an exception for some characters
were escaped in a raw interpolator.

```
scalafix.internal.v1.FileException: unexpected error processing file /workspace/A.scala
Caused by: scala.StringContext$InvalidEscapeException: invalid escape '\+' not one of [\b, \t, \n, \f, \r, \\, \", \', \uxxxx] at index 4 in "(.*)\+.*@(.*)". Use \\ for literal \.
at scala.StringContext$.loop$2(StringContext.scala:417)
at scala.StringContext$.replace(StringContext.scala:429)
at scala.StringContext$.processEscapes(StringContext.scala:387)
at scalafix.internal.rule.RedundantSyntax$$anonfun$fix$1.applyOrElse(RedundantSyntax.scala:39)
```