### PR TITLE
Add an option to only add explicit result types to implicit definitions

### DIFF
--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/ExplicitResultTypes.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/ExplicitResultTypes.scala
@@ -174,6 +174,7 @@ final class ExplicitResultTypes(
       defn.parent.exists(_.is[Template])
 
     isImplicit && !isFinalLiteralVal || {
+      !onlyImplicits &&
       hasParentWihTemplate &&
       !defn.hasMod(mod"implicit") &&
       !matchesSimpleDefinition() &&

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/ExplicitResultTypesConfig.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/ExplicitResultTypesConfig.scala
@@ -37,6 +37,8 @@ case class ExplicitResultTypesConfig(
         " used `scala.language.reflectiveCalls` to access methods on structural types."
     )
     rewriteStructuralTypesToNamedSubclass: Boolean = true,
+    @Description("If true, adds result types only to implicit definitions.")
+    onlyImplicits: Boolean = false,
     @Hidden()
     symbolReplacements: Map[String, String] = Map.empty
 )

--- a/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesOnlyImplicits.scala
+++ b/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesOnlyImplicits.scala
@@ -1,0 +1,10 @@
+/*
+rules = ExplicitResultTypes
+ExplicitResultTypes.onlyImplicits = true
+ */
+package test.explicitResultTypes
+
+object ExplicitResultTypesOnlyImplicits {
+  def complex = List(1).map(_ + 1)
+  implicit val default = complex
+}

--- a/scalafix-tests/output/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesOnlyImplicits.scala
+++ b/scalafix-tests/output/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesOnlyImplicits.scala
@@ -1,0 +1,6 @@
+package test.explicitResultTypes
+
+object ExplicitResultTypesOnlyImplicits {
+  def complex = List(1).map(_ + 1)
+  implicit val default: List[Int] = complex
+}


### PR DESCRIPTION
This is useful for scala3 migration since it requires explicit return types for implicits