### PR TITLE
test loading of external rule built with metaconfig hack

### DIFF
--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/interfaces/ScalafixSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/interfaces/ScalafixSuite.scala
@@ -81,18 +81,22 @@ class ScalafixSuite extends AnyFunSuite {
       s"fetch & load instance for Scala version $scalaVersion with external dependencies"
     ) {
       val scalafixAPI = Scalafix.fetchAndClassloadInstance(scalaVersion)
-      val args = scalafixAPI.newArguments
+      val availableRules = scalafixAPI.newArguments
         .withToolClasspath(
           Seq[URL]().asJava,
-          Seq[String]("com.nequissimus::sort-imports:0.5.2").asJava,
+          Seq[String](
+            "com.nequissimus::sort-imports:0.5.2", // scalafix 0.9.16
+            "ch.epfl.scala::example-scalafix-rule:2.0.0" // scalafix 0.10.0
+          ).asJava,
           Seq[Repository](Repository.central()).asJava
         )
-      assert(
-        args.availableRules.asScala.map(_.name).contains("RemoveUnused")
-      ) // built-in rule
-      assert(
-        args.availableRules.asScala.map(_.name).contains("SortImports")
-      ) // community rule
+        .availableRules
+        .asScala
+        .map(_.name)
+
+      assert(availableRules.contains("RemoveUnused")) // built-in
+      assert(availableRules.contains("SortImports")) // sort-imports
+      assert(availableRules.contains("SemanticRule")) // example-scalafix-rule
     }
   }
   val supportedScalaBinaryVersions: Set[String] = Set("2.11", "2.12", "2.13")


### PR DESCRIPTION
Prevent potential regressions caused by https://github.com/scalacenter/scalafix/pull/1632#issuecomment-1185391771

Attempting to load a rule built with 0.10.0 on 0.10.x can help us identify classloading regressions that would violate https://scalacenter.github.io/scalafix/docs/developers/api.html#compatibility-considerations.