### PR TITLE
Use scalameta's Discord rather than gitter for support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Contributions to Scalafix are welcome! This document is a guide to help you get
 familiar with the Scalafix build, if you are unsure about anything, don't
-hesitate to ask in the [gitter channel](https://gitter.im/scalacenter/scalafix).
+hesitate to ask in the [Discord channel](https://discord.gg/8AHaqGx3Qj).
 
 ## Modules
 
@@ -145,8 +145,8 @@ Confirm that the documentation is advertising the new versions
 - https://scalacenter.github.io/scalafix/docs/users/installation.html#sbt
 - https://scalacenter.github.io/scalafix/docs/users/installation.html#help
 
-If everything went smoothly, congrats! Tweet about the release and comment with
-`@/all` on Gitter linking to the release notes.
+If everything went smoothly, congrats! Tweet about the release and comment on
+Discord linking to the release notes.
 
 If something goes wrong for any reason making the artifacts not reach maven,
 delete the pushed tag with the following command

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="website/static/img/scalafix-brand-small2x.png" alt="logo" width="37px" height="37px" style="margin-bottom:-8px;margin-right:-4px;"> Scalafix
 [![Latest version](https://index.scala-lang.org/scalacenter/scalafix/scalafix-core/latest.svg)](https://index.scala-lang.org/scalacenter/scalafix/scalafix-core)
 [![Build status](https://github.com/scalacenter/scalafix/workflows/CI/badge.svg)](https://github.com/scalacenter/scalafix/actions?query=workflow)
-[![Join the chat at https://gitter.im/scalacenter/scalafix](https://badges.gitter.im/scalacenter/scalafix.svg)](https://gitter.im/scalacenter/scalafix)
+[![Join the chat on Discord](https://badges.gitter.im/scalacenter/scalafix.svg)](https://discord.gg/8AHaqGx3Qj)
 ========
 
 Rewrite and linting tool for Scala..

--- a/scalafix-docs/src/main/scala/docs/Main.scala
+++ b/scalafix-docs/src/main/scala/docs/Main.scala
@@ -39,7 +39,6 @@ sidebar_label: Guide
       .withSiteVariables(
         Map(
           "SEMANTICDB" -> "[SemanticDB](https://scalameta.org/docs/semanticdb/specification.html)",
-          "GITTER" -> "[Gitter](http://gitter.im/scalacenter/scalafix)",
           "SCALA213" -> Versions.scala213,
           "SCALA212" -> Versions.scala212,
           "SCALA211" -> Versions.scala211,

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -51,8 +51,8 @@ class Footer extends React.Component {
           </div>
           <div>
             <h5>Community</h5>
-            <a href="https://gitter.im/scalacenter/scalafix" target="_blank">
-              Chat on Gitter
+            <a href="https://discord.gg/8AHaqGx3Qj" target="_blank">
+              Chat on Discord
             </a>
             <a href="https://users.scala-lang.org/" target="_blank">
               Discuss on Scala Users


### PR DESCRIPTION
I recently learnt about the #scalafix channel on the Scalameta servers (advertized in https://www.scala-lang.org/blog/2021/12/21/discord.html#what-other-chat-servers-exist). I am not fully convinced Discord is the way to go (sharing the same opacity concerns as https://alexn.org/blog/2022/04/09/scala-gitter-discord-mistake/), but I think it's better to stay close to the Scalameta community. We should delete the gitter room once this is merged. 