### PR TITLE
Fix small issues with the tutorial docs

### DIFF
--- a/docs/developers/tutorial.md
+++ b/docs/developers/tutorial.md
@@ -444,9 +444,10 @@ If we run `tests/test` we get an error like this
 
 ```scala
 ===========> Unreported <===========
-test/NoLiteralArgumentsConfig.scala:16:20: error
-  complete("done") // assert: NoLiteralArguments
-                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+fix/NoLiteralArgumentsConfig.scala:16:16: error
+  complete(42) // assert: NoLiteralArguments
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-------
 ```
 
 An "unreported" error message means we asserted a diagnostic would be reported
@@ -459,7 +460,7 @@ Start by writing a case class to hold the configuration
 case class NoLiteralArgumentsConfig(
     disabledLiterals: List[String] = List("Boolean")
 ) {
-  def isDisabled(literal: Lit): Boolean = {
+  def isDisabled(lit: Lit): Boolean = {
     val kind = lit.productPrefix.stripPrefix("Lit.")
     disabledLiterals.contains(kind)
   }


### PR DESCRIPTION
Fixed a couple of small discrepancies in the docs:

1 The diagnostic error states that this should be the error:

```
===========> Unreported <===========
test/NoLiteralArgumentsConfig.scala:16:20: error
  complete("done") // assert: NoLiteralArguments
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

but given the  config and code provided:

```scala
/*
rule = NoLiteralArguments
NoLiteralArguments.disabledLiterals = [
  Int
  Boolean
]
 */
package test

class NoLiteralArgumentsConfig {
  def complete(message: String): Unit = ()
  def complete(count: Int): Unit = ()
  def complete(isSuccess: Boolean): Unit = ()
  complete("done") // ok, no error message
  complete(42) // assert: NoLiteralArguments
  complete(true) // assert: NoLiteralArguments
}
```

`complete("done")` should not report a lint error. (it also has the `// ok, no error message` comment)

Updated to report `complete(42)` as the error.

2. `NoLiteralArgumentsConfig#isDisabled` is defined with a parameter named `literal` but that parameter is used as `lit`:

```scala
  def isDisabled(literal: Lit): Boolean = {
    val kind = lit.productPrefix.stripPrefix("Lit.") //should be literal.productPrefix or literal should be renamed to 'lit'
    disabledLiterals.contains(kind)
  }
  ``` 
  
 Renamed `literal: Lit` -> `lit: Lit` as it coincides with the [scalafix-named-literal-arguments](https://github.com/scalacenter/scalafix-named-literal-arguments/blob/main/scalafix) on [master](https://github.com/scalacenter/scalafix-named-literal-arguments/blob/main/scalafix/rules/src/main/scala/fix/NoLiteralArguments.scala#L16)