### PR TITLE
Update `Integration tests` documentation.

### DIFF
--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -176,7 +176,7 @@ to your project settings
    .configs(IntegrationTest)
    .settings(
      Defaults.itSettings,
-+    inConfig(IntegrationTest)(scalafixConfigSettings(IntegrationTest))
++    scalafixConfigSettings(IntegrationTest)
      // ...
    )
 ```


### PR DESCRIPTION
## Implementation details

This PR updates obsolete documentation: we don't need to wrap settings into `inConfig(config)` method because it's already done in `scalafixConfigSettings` [implementation](https://github.com/scalacenter/sbt-scalafix/blob/169fc60c58304df00835795f717b634329549312/src/main/scala/scalafix/sbt/ScalafixPlugin.scala#L82-L83):
```scala
def scalafixConfigSettings(config: Configuration): Seq[Def.Setting[_]] =
  inConfig(config)(...)

```