### PR TITLE
Update unit module scalatest version to 3.2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -219,7 +219,7 @@ lazy val unit = projectMatrix
       jgit,
       coursier,
       scalatest.withRevision(
-        "3.2.0"
+        "3.2.13"
       ), // make sure testkit clients can use recent 3.x versions
       scalametaTeskit
     ),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
 
   val bijectionCoreV = "0.9.7"
   val collectionCompatV = "2.8.0"
-  val coursierV = "2.0.0-RC5-6"
+  val coursierV = "2.1.0-M6-53-gb4f448130"
   val coursierInterfaceV = "1.0.8"
   val commontTextV = "1.9"
   val googleDiffV = "1.3.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
 
   val bijectionCoreV = "0.9.7"
   val collectionCompatV = "2.8.0"
-  val coursierV = "2.1.0-M6-53-gb4f448130"
+  val coursierV = "2.0.0-RC5-6"
   val coursierInterfaceV = "1.0.8"
   val commontTextV = "1.9"
   val googleDiffV = "1.3.0"

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -21,7 +21,8 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
     lazy val noPublishAndNoMima = Seq(
       mimaReportBinaryIssues := {},
       mimaPreviousArtifacts := Set.empty,
-      publish / skip := true
+      publish / skip := true,
+      libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % "always",
     )
     lazy val supportedScalaVersions = List(scala213, scala211, scala212)
     lazy val publishLocalTransitive =

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -22,7 +22,7 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
       mimaReportBinaryIssues := {},
       mimaPreviousArtifacts := Set.empty,
       publish / skip := true,
-      libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % "always",
+      libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % "always"
     )
     lazy val supportedScalaVersions = List(scala213, scala211, scala212)
     lazy val publishLocalTransitive =


### PR DESCRIPTION
The scalatest version update, needed for the work done in https://github.com/scalacenter/scalafix/pull/1650 , specifically because the old scalatest version in not found anymore.

When updating the versions there's a lib version conflict on `scala-xml` which is resolved by ignoring with a `libraryDependencySchemes` as suggested in the conflict output below:
```
sbt:scalafix> unit2_12Target3/update
[error] stack trace is suppressed; run last unit2_12Target3 / update for the full output
[error] (unit2_12Target3 / update) found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error] 
[error]         * org.scala-lang.modules:scala-xml_2.12:2.1.0 (early-semver) is selected over {1.3.0, 1.0.6}
[error]             +- org.scalatest:scalatest-core_2.12:3.2.13           (depends on 2.1.0)
[error]             +- org.scala-lang:scala-compiler:2.12.16              (depends on 1.0.6)
[error]             +- io.get-coursier:coursier-core_2.12:2.0.0-RC5-6 (depends on xxx)
[error] this can be overridden using libraryDependencySchemes or evictionErrorLevel
```