### PR TITLE
skip src and doc packaging when publishing locally

### DIFF
--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -1,5 +1,6 @@
 import Dependencies._
 import sbt._
+import sbt.Classpaths
 import sbt.Keys._
 import sbt.nio.Keys._
 import sbt.plugins.JvmPlugin
@@ -209,6 +210,11 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
         case _ => Seq()
       }
     },
+    // Don't package sources & docs when publishing locally as it adds a significant
+    // overhead when testing because of publishLocalTransitive. Tweaking publishArtifact
+    // would more readable, but it would also affect remote (sonatype) publishing.
+    publishLocal / packagedArtifacts :=
+      Classpaths.packaged(Seq(Compile / packageBin)).value,
     publishTo := Some {
       if (isSnapshot.value) Opts.resolver.sonatypeSnapshots
       else Opts.resolver.sonatypeStaging


### PR DESCRIPTION
Follows https://github.com/scalacenter/scalafix/pull/1528/commits/e099cc451aa0e5252bc933a78dbc56a4cb571369#r846677704. This brings back time savings of ~1-2 minutes for `test` on cold invocations, but also on warm ones, as it seems that scaladoc is not incremental/cached.

This should also benefit https://github.com/scalacenter/scalafix/pull/1650, where [we observe exceptions generating docs with scala 3.2.0 on windows](https://github.com/scalacenter/scalafix/runs/8272351990):
```
[error] Caused by: java.nio.file.InvalidPathException: Illegal char <:> at index 30: scalafix/util/TreeExtractors$$:&&:$.html
[error] 	at sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
[error] 	at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
[error] 	at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
[error] 	at sun.nio.fs.WindowsPath.parse(WindowsPath.java:94)
[error] 	at sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:255)
[error] 	at sun.nio.fs.AbstractPath.resolve(AbstractPath.java:53)
[error] 	at dotty.tools.scaladoc.renderers.Writer.dest(Writer.scala:17)
[error] 	at dotty.tools.scaladoc.renderers.Writer.write(Writer.scala:23)
[error] 	at dotty.tools.scaladoc.renderers.Writer.write$(Writer.scala:13)
[error] 	at dotty.tools.scaladoc.renderers.Renderer.write(Renderer.scala:27)
[error] 	at dotty.tools.scaladoc.renderers.Renderer.renderPage(Renderer.scala:177)
[error] 	at dotty.tools.scaladoc.renderers.Renderer.renderPage$$anonfun$1(Renderer.scala:177)
```