### PR TITLE
don't publish scala 3 artifacts for now

### DIFF
--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -197,6 +197,9 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
   )
 
   override def projectSettings: Seq[Def.Setting[_]] = List(
+    // don't publish scala 3 artifacts for now
+    publish / skip := (if ((publish / skip).value) true
+                       else scalaBinaryVersion.value == "3"),
     versionPolicyIntention := versionPolicyIntentionSetting.value,
     scalacOptions ++= compilerOptions.value,
     scalacOptions ++= semanticdbSyntheticsCompilerOption.value,


### PR DESCRIPTION
Blocks https://github.com/scalacenter/scalafix/issues/1668: snapshots are currently published, but we shouldn't be publishing stable releases just yet

```diff
 sbt:scalafix> show publish / skip
 ...
 [info] core3 / publish / skip
-[info] 	false
+[info] 	true
 ...
 [info] rules3 / publish / skip
-[info] 	false
+[info] 	true
```