### PR TITLE
ExplicitResultTypes: honor skipSimpleDefinitions on implicits

### DIFF
--- a/scalafix-rules/src/main/scala-2/scalafix/internal/rule/ExplicitResultTypes.scala
+++ b/scalafix-rules/src/main/scala-2/scalafix/internal/rule/ExplicitResultTypes.scala
@@ -176,17 +176,16 @@ final class ExplicitResultTypes(
     def qualifyingImplicit: Boolean =
       isImplicit && !isFinalLiteralVal
 
-    def matchesMemberKindAndVisibility: Boolean =
-      matchesMemberKind && matchesMemberVisibility
+    def matchesConfig: Boolean =
+      matchesMemberKind && matchesMemberVisibility && !matchesSimpleDefinition
 
     def qualifyingNonImplicit: Boolean = {
       !onlyImplicits &&
       hasParentWihTemplate &&
-      !defn.hasMod(mod"implicit") &&
-      !matchesSimpleDefinition()
+      !defn.hasMod(mod"implicit")
     }
 
-    matchesMemberKindAndVisibility && {
+    matchesConfig && {
       qualifyingImplicit || qualifyingNonImplicit
     }
   }

--- a/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesOnlyImplicits.scala
+++ b/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesOnlyImplicits.scala
@@ -1,6 +1,7 @@
 /*
 rules = ExplicitResultTypes
 ExplicitResultTypes.onlyImplicits = true
+ExplicitResultTypes.skipSimpleDefinitions = []
  */
 package test.explicitResultTypes
 

--- a/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesSingleton.scala
+++ b/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesSingleton.scala
@@ -1,5 +1,6 @@
 /*
 rules = ExplicitResultTypes
+ExplicitResultTypes.skipSimpleDefinitions = []
  */
 package test.explicitResultTypes
 

--- a/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ImplicitMembersWithSkipSimpleDefinition.scala
+++ b/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ImplicitMembersWithSkipSimpleDefinition.scala
@@ -9,5 +9,9 @@ object ImplicitMembersWithSkipSimpleDefinition {
     val x = 42
 
     implicit var y = 43
-  
+
+    val map_x = null.asInstanceOf[Map[Int,String]]
+
+    implicit val map_y = null.asInstanceOf[Map[Int,String]]
+
 }

--- a/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ImplicitMembersWithSkipSimpleDefinition.scala
+++ b/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ImplicitMembersWithSkipSimpleDefinition.scala
@@ -1,0 +1,13 @@
+/*
+rules = "ExplicitResultTypes"
+ExplicitResultTypes.skipSimpleDefinitions = ["Lit"]
+*/
+package test.explicitResultTypes
+
+object ImplicitMembersWithSkipSimpleDefinition {
+
+    val x = 42
+
+    implicit var y = 43
+  
+}

--- a/scalafix-tests/output/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBase.scala
+++ b/scalafix-tests/output/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBase.scala
@@ -19,8 +19,8 @@ object ExplicitResultTypesBase {
   val k: (Int, String) = (1, "msg")
   implicit val L: List[Int] = List(1)
   implicit val M: Map[Int,String] = Map(1 -> "STRING")
-  implicit def D: Int = 2
-  implicit def tparam[T](e: T): T = e
+  implicit def D = 2
+  implicit def tparam[T](e: T) = e
   implicit def tparam2[T](e: T): List[T] = List(e)
   implicit def tparam3[T](e: T): Map[T,T] = Map(e -> e)
   class implicitlytrick {

--- a/scalafix-tests/output/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesShort.scala
+++ b/scalafix-tests/output/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesShort.scala
@@ -14,7 +14,7 @@ object ExplicitResultTypesShort {
   implicit def z(x: Int): List[String] = Nil
   implicit var zz: ListSet[String] = scala.collection.immutable.ListSet.empty[String]
   implicit val FALSE: Any => Boolean = (x: Any) => false
-  implicit def tparam[T](e: T): T = e
+  implicit def tparam[T](e: T) = e
   implicit val opt: Option[Int] = None
   implicit val seq: Seq[List[Int]] = Nil
   object Shadow {

--- a/scalafix-tests/output/src/main/scala-2/test/explicitResultTypes/ImplicitMembersWithSkipSimpleDefinition.scala
+++ b/scalafix-tests/output/src/main/scala-2/test/explicitResultTypes/ImplicitMembersWithSkipSimpleDefinition.scala
@@ -1,0 +1,9 @@
+package test.explicitResultTypes
+
+object ImplicitMembersWithSkipSimpleDefinition {
+
+    val x: Int = 42
+
+    implicit var y: Int = 43
+  
+}

--- a/scalafix-tests/output/src/main/scala-2/test/explicitResultTypes/ImplicitMembersWithSkipSimpleDefinition.scala
+++ b/scalafix-tests/output/src/main/scala-2/test/explicitResultTypes/ImplicitMembersWithSkipSimpleDefinition.scala
@@ -2,8 +2,12 @@ package test.explicitResultTypes
 
 object ImplicitMembersWithSkipSimpleDefinition {
 
-    val x: Int = 42
+    val x = 42
 
-    implicit var y: Int = 43
-  
+    implicit var y = 43
+
+    val map_x: Map[Int,String] = null.asInstanceOf[Map[Int,String]]
+
+    implicit val map_y: Map[Int,String] = null.asInstanceOf[Map[Int,String]]
+
 }


### PR DESCRIPTION
Fixes #1628 

The `skipSimpleDefinitions` configuration wasn't always applied correctly (specifically when members are implicit the configuration wasn't considered)

- A unit test for this specific case was added
- Old unit tests are fixed based on the default value of `skipSimpleDefinitions` or on the intent of the test