### PR TITLE
RedundantSyntax: honor suppression

### DIFF
--- a/scalafix-tests/input/src/main/scala/test/redundantSyntax/FinalObject.scala
+++ b/scalafix-tests/input/src/main/scala/test/redundantSyntax/FinalObject.scala
@@ -13,3 +13,6 @@ final object FinalObject {
 abstract class Class {
   final def bar: String = "bar"
 }
+
+@SuppressWarnings(Array("RedundantSyntax"))
+final object Suppressed

--- a/scalafix-tests/input/src/main/scala/test/redundantSyntax/StringInterpolator.scala
+++ b/scalafix-tests/input/src/main/scala/test/redundantSyntax/StringInterpolator.scala
@@ -32,6 +32,8 @@ class StringInterpolator {
   b = my"foo"
   b = my"foo $a bar"
 
+  b = s"foo" // scalafix:ok
+
   implicit class MyInterpolator(sc: StringContext) {
     def my(subs: Any*): String = sc.toString + subs.mkString("")
   }

--- a/scalafix-tests/output/src/main/scala/test/redundantSyntax/FinalObject.scala
+++ b/scalafix-tests/output/src/main/scala/test/redundantSyntax/FinalObject.scala
@@ -8,3 +8,6 @@ object FinalObject {
 abstract class Class {
   final def bar: String = "bar"
 }
+
+@SuppressWarnings(Array("RedundantSyntax"))
+final object Suppressed

--- a/scalafix-tests/output/src/main/scala/test/redundantSyntax/StringInterpolator.scala
+++ b/scalafix-tests/output/src/main/scala/test/redundantSyntax/StringInterpolator.scala
@@ -27,6 +27,8 @@ class StringInterpolator {
   b = my"foo"
   b = my"foo $a bar"
 
+  b = s"foo" // scalafix:ok
+
   implicit class MyInterpolator(sc: StringContext) {
     def my(subs: Any*): String = sc.toString + subs.mkString("")
   }


### PR DESCRIPTION
As reported on [Discord](https://discord.com/channels/632642981228314653/632683673417678860/1044516936463155200) by @GoreNuru, `RedundantSyntax` couldn't be suppressed