### PR TITLE
bump coursier

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -236,7 +236,8 @@ lazy val unit = projectMatrix
         // exclude _2.13 artifacts that have their _3 counterpart in the classpath
         List(
           coursier
-            .exclude("org.scala-lang.modules", "scala-xml_2.13"),
+            .exclude("org.scala-lang.modules", "scala-xml_2.13")
+            .exclude("org.scala-lang.modules", "scala-collection-compat_2.13"),
           scalametaTeskit
             .exclude("com.lihaoyi", "sourcecode_2.13")
             .exclude("org.scala-lang.modules", "scala-collection-compat_2.13")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
 
   val bijectionCoreV = "0.9.7"
   val collectionCompatV = "2.9.0"
-  val coursierV = "2.0.0-RC5-6"
+  val coursierV = "2.1.0-RC5"
   val coursierInterfaceV = "1.0.9"
   val commontTextV = "1.10.0"
   val googleDiffV = "1.3.0"


### PR DESCRIPTION
Unlocked by https://github.com/scalacenter/scalafix/pull/1729

Note that this is only used for testing (coursier-interface is used otherwise).