### PR TITLE
fail hard when running against 2.11 sources

### DIFF
--- a/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixArgumentsImpl.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixArgumentsImpl.scala
@@ -251,6 +251,10 @@ final case class ScalafixArgumentsImpl(args: Args = Args.default)
     copy(args = args.copy(scalacOptions = options.asScala.toList))
 
   override def withScalaVersion(version: String): ScalafixArguments = {
+    if (version.startsWith("2.11"))
+      throw new ScalafixMainArgsException(
+        "Scala 2.11 is no longer supported; the final version supporting it is Scalafix 0.10.4"
+      )
     ScalaVersion
       .from(version) match {
       case Success(value) => copy(args = args.copy(scalaVersion = value))

--- a/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixImpl.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixImpl.scala
@@ -24,7 +24,9 @@ final class ScalafixImpl extends Scalafix {
   override def supportedScalaVersions(): Array[String] =
     Versions.supportedScalaVersions.toArray
   override def scala211(): String =
-    throw new java.lang.UnsupportedOperationException()
+    throw new java.lang.UnsupportedOperationException(
+      "Scala 2.11 is no longer supported; the final version supporting it is Scalafix 0.10.4"
+    )
   override def scala212(): String =
     Versions.scala212
   override def scala213(): String =

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/interfaces/ScalafixArgumentsSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/interfaces/ScalafixArgumentsSuite.scala
@@ -7,7 +7,6 @@ import java.nio.file.Paths
 import java.util.Collections
 
 import scala.collection.JavaConverters._
-import scala.util.Failure
 import scala.util.Try
 
 import scala.meta.internal.io.FileIO
@@ -507,14 +506,15 @@ class ScalafixArgumentsSuite extends AnyFunSuite with DiffAssertions {
 
   test("withScalaVersion: non-parsable scala version") {
     val run = Try(api.withScalaVersion("213"))
-    assert(run.isFailure)
-    run match {
-      case Failure(exception) =>
-        assert(
-          exception.getMessage == "Failed to parse the Scala version"
-        )
-      case _ => ()
-    }
+    val expectedErrorMessage = "Failed to parse the Scala version"
+    assert(run.failed.toOption.map(_.getMessage) == Some(expectedErrorMessage))
+  }
+
+  test("Scala 2.11 is no longer supported") {
+    val run = Try(api.withScalaVersion("2.11.12"))
+    val expectedErrorMessage =
+      "Scala 2.11 is no longer supported; the final version supporting it is Scalafix 0.10.4"
+    assert(run.failed.toOption.map(_.getMessage) == Some(expectedErrorMessage))
   }
 
   def removeUnsuedRule(): SemanticRule = {


### PR DESCRIPTION
https://github.com/scalacenter/scalafix/pull/1729 dropped support for running Scalafix with Scala 2.11 but running against Scala 2.11 sources was still possible. However, since we no longer test scalafix-core and scalafix-rules against Scala 2.11 sources, it's safer to fail hard and ask the user to downgrade.