### PR TITLE
Add textEdits method to ScalafixPatch

### DIFF
--- a/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixFileEvaluationImpl.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixFileEvaluationImpl.scala
@@ -143,7 +143,10 @@ object ScalafixFileEvaluationImpl {
       ctx: RuleCtx,
       index: Option[v0.SemanticdbIndex]
   ): ScalafixFileEvaluationImpl = {
-    val scalafixPatches = patches.map(ScalafixPatchImpl.apply)
+    val indexOrEmpty = index.getOrElse(v0.SemanticdbIndex.empty)
+    val scalafixPatches = patches.map { p =>
+      ScalafixPatchImpl(p)(args, ctx, indexOrEmpty)
+    }
     ScalafixFileEvaluationImpl(
       originalPath = originalPath,
       fixedOpt = fixed,

--- a/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixPatchImpl.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixPatchImpl.scala
@@ -2,5 +2,26 @@ package scalafix.internal.interfaces
 
 import scalafix.Patch
 import scalafix.interfaces.ScalafixPatch
+import scalafix.interfaces.ScalafixTextEdit
+import scalafix.internal.patch.PatchInternals
+import scalafix.internal.v1.ValidatedArgs
+import scalafix.v0
+import scalafix.v0.RuleCtx
 
-case class ScalafixPatchImpl(patch: Patch) extends ScalafixPatch
+case class ScalafixPatchImpl(patch: Patch)(
+    args: ValidatedArgs,
+    ctx: RuleCtx,
+    index: v0.SemanticdbIndex
+) extends ScalafixPatch {
+
+  override def textEdits(): Array[ScalafixTextEdit] =
+    PatchInternals
+      .treePatchApply(patch)(ctx, index)
+      .map { t =>
+        ScalafixTextEditImpl(
+          PositionImpl.fromScala(t.tok.pos),
+          t.newTok
+        ): ScalafixTextEdit
+      }
+      .toArray
+}

--- a/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixTextEditImpl.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixTextEditImpl.scala
@@ -1,0 +1,9 @@
+package scalafix.internal.interfaces
+
+import scalafix.interfaces.ScalafixPosition
+import scalafix.interfaces.ScalafixTextEdit
+
+final case class ScalafixTextEditImpl(
+    position: ScalafixPosition,
+    newText: String
+) extends ScalafixTextEdit

--- a/scalafix-interfaces/src/main/java/scalafix/interfaces/ScalafixPatch.java
+++ b/scalafix-interfaces/src/main/java/scalafix/interfaces/ScalafixPatch.java
@@ -1,3 +1,11 @@
 package scalafix.interfaces;
 
-public interface ScalafixPatch {}
+public interface ScalafixPatch {
+    /**
+     *
+     * @return This patch as an array of text edits.
+     */
+    default ScalafixTextEdit[] textEdits() {
+        throw new UnsupportedOperationException("textEdits() is not implemented");
+    }
+}

--- a/scalafix-interfaces/src/main/java/scalafix/interfaces/ScalafixTextEdit.java
+++ b/scalafix-interfaces/src/main/java/scalafix/interfaces/ScalafixTextEdit.java
@@ -1,0 +1,7 @@
+package scalafix.interfaces;
+
+public interface ScalafixTextEdit {
+    ScalafixPosition position();
+
+    String newText();
+}


### PR DESCRIPTION
Hi!  I'd like to be able to obtain (LSP style)  text edit like information (essentially representing a diff as a start position, end position, and insert text) from the scalafix api (specifically a given `ScalafixFileEvaluation`) - AFAICS something like this is currently not exposed (?).

I've created an implementation (the method is similar to `PatchInternals.tokenPatchApply`).  Though I've found some rules don't give the greatest results, for example patches from the `OptionWhenUnless` rule (from https://github.com/xuwei-k/scalafix-rules):
```
Concat(Concat(Concat(Concat(Concat(Concat(Concat(Concat(Concat(Concat(Concat(Concat(Concat(Concat(Concat(Concat(Concat(Concat(Remove(if∙[142..144)),Remove(∙∙[144..145))),Remove((∙[145..146))),Remove(4∙[146..147))),Remove(∙∙[147..148))),Remove(>∙[148..149))),Remove(∙∙[149..150))),Remove(3∙[150..151))),Remove()∙[151..152))),Remove(∙∙[152..153))),Remove(Some∙[153..157))),Remove((∙[157..158))),Remove(43∙[158..160))),Remove()∙[160..161))),Remove(∙∙[161..162))),Remove(else∙[162..166))),Remove(∙∙[166..167))),Remove(None∙[167..171))),Add(if, if [142..144), ifOption.when(4 > 3)(43)))
```

Result in multiple overlapping text edits. Though I've had good results for many of the built in rules, for example a typical `LeakingImplicitVal` patch:

```
Add(val, val [202..205), private val)
```
results in a singular text edit.

Anyway, let me know if you are open to something like this, or if something like this is already implemented, thanks :slightly_smiling_face: 