### PR TITLE
testkit: build against ScalaTest 3.2

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,8 +1,5 @@
 pullRequests.frequency = "0 0 1,15 * ?"
 updates.pin = [
-  # don't bump, to avoid forcing breaking changes on clients via eviction
-  { groupId = "org.scalatest", artifactId = "scalatest", version = "3.0.8" },
-
   # JGit 6.x requires Java 11, see https://www.eclipse.org/lists/cross-project-issues-dev/msg18654.html
   { groupId = "org.eclipse.jgit", artifactId = "org.eclipse.jgit", version = "5." },
 

--- a/build.sbt
+++ b/build.sbt
@@ -168,7 +168,7 @@ lazy val testkit = projectMatrix
     moduleName := "scalafix-testkit",
     isFullCrossVersion,
     libraryDependencies += googleDiff,
-    libraryDependencies += scalatestDep.value
+    libraryDependencies += scalatest
   )
   .defaultAxes(VirtualAxis.jvm)
   .jvmPlatform(buildScalaVersions)
@@ -209,7 +209,7 @@ lazy val unit = projectMatrix
     libraryDependencies ++= List(
       jgit,
       munit,
-      scalatest.withRevision(scalatestLatestV)
+      scalatest
     ),
     libraryDependencies += {
       if (!isScala3.value) {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,8 +30,7 @@ object Dependencies {
   val nailgunV = "0.9.1"
   val scalaXmlV = "2.1.0"
   val scalametaV = "4.7.8"
-  val scalatestMinV = "3.0.8" // don't bump, to avoid forcing breaking changes on clients via eviction
-  val scalatestLatestV = "3.2.13"
+  val scalatestV = "3.2.13"
   val munitV = "0.7.29"
 
   val bijectionCore = "com.twitter" %% "bijection-core" % bijectionCoreV
@@ -54,7 +53,7 @@ object Dependencies {
     .cross(CrossVersion.for3Use2_13)
   val scalametaTeskit = ("org.scalameta" %% "testkit" % scalametaV)
     .cross(CrossVersion.for3Use2_13)
-  val scalatest = "org.scalatest" %% "scalatest" % scalatestMinV
+  val scalatest = "org.scalatest" %% "scalatest" % scalatestV
   val munit = "org.scalameta" %% "munit" % munitV
   val semanticdbScalacCore = "org.scalameta" % "semanticdb-scalac-core" % scalametaV cross CrossVersion.full
 

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -118,11 +118,6 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
       buildInfoObject := "RulesBuildInfo"
     )
 
-    lazy val scalatestDep = Def.setting {
-      if (isScala3.value) scalatest.withRevision(scalatestLatestV)
-      else scalatest
-    }
-
     lazy val testWindows =
       taskKey[Unit]("run tests, excluding those incompatible with Windows")
 
@@ -233,7 +228,7 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
                        else scalaBinaryVersion.value == "3"),
     publishLocal / skip := (if ((publishLocal / skip).value) true
                             else scalaBinaryVersion.value == "3"),
-    versionPolicyIntention := Compatibility.BinaryCompatible,
+    versionPolicyIntention := Compatibility.None,
     scalacOptions ++= compilerOptions.value,
     scalacOptions ++= semanticdbSyntheticsCompilerOption.value,
     Compile / console / scalacOptions :=

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/AbstractSemanticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/AbstractSemanticRuleSuite.scala
@@ -19,8 +19,8 @@ import scalafix.internal.v1.Args
 
 /**
  * Construct a test suite for running semantic Scalafix rules. <p> Mix-in
- * FunSuiteLike (ScalaTest 3.0), AnyFunSuiteLike (ScalaTest 3.1+) or the testing
- * style of your choice if you add your own tests.
+ * AnyFunSuiteLike or the testing style of your choice if you add your own
+ * tests.
  */
 abstract class AbstractSemanticRuleSuite(
     val props: TestkitProperties,

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/AbstractSyntacticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/AbstractSyntacticRuleSuite.scala
@@ -12,9 +12,8 @@ import scalafix.syntax._
 import scalafix.v1._
 
 /**
- * Utility to unit test syntactic rules. <p> Mix-in FunSuiteLike (ScalaTest
- * 3.0), AnyFunSuiteLike (ScalaTest 3.1+) or the testing style of your choice if
- * you add your own tests.
+ * Utility to unit test syntactic rules. <p> Mix-in AnyFunSuiteLike or the
+ * testing style of your choice if you add your own tests.
  *
  * @param rule
  *   the default rule to use from `check`/`checkDiff`.


### PR DESCRIPTION
This is a source-breaking change for testkit users that were relying on the ScalaTest 3.0 package hierarchy, deprecated 3 years ago in 3.1 and removed in 3.2 (despite no major bump).

Scalafix rules were made available to ease that transition, see https://github.com/scalatest/autofix/tree/master.

Closes https://github.com/scalacenter/scalafix/issues/1662.