### PR TITLE
Fix sonatype stats cron

### DIFF
--- a/.github/scripts/update.sc
+++ b/.github/scripts/update.sc
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S scala shebang
+#!/usr/bin/env -S scala-cli shebang
 
 // Adapted from https://github.com/alexarchambault/sonatype-stats
 //

--- a/.github/workflows/sonatype-stats.yml
+++ b/.github/workflows/sonatype-stats.yml
@@ -1,4 +1,4 @@
-
+name: Retrieve and commit Sonatype stats
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
https://github.com/scalacenter/scalafix/actions/runs/4975179404/jobs/8902103997
```
Run .github/scripts/update.sc
  .github/scripts/update.sc
  shell: /usr/bin/bash -e {0}
  env:
    MSYS: winsymlinks:nativestrict
    JAVA_HOME: /home/runner/.cache/coursier/arc/https/github.com/adoptium/temurin17-binaries/releases/download/jdk-17%252B35/OpenJDK17-jdk_x64_linux_hotspot_17_35.tar.gz/jdk-17+35
    COURSIER_BIN_DIR: /home/runner/cs/bin
    SONATYPE_USERNAME: ***
    SONATYPE_PASSWORD: ***
/usr/bin/env: ‘scala’: No such file or directory
Error: Process completed with exit code 127.
```