### PR TITLE
build JARs against Java 8 for max compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:8
       - uses: olafurpg/setup-gpg@v3
       - name: Check that major or minor was bumped upon compatibility breakage
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Fix regression introduced in https://github.com/scalacenter/scalafix/pull/1756/commits/34bf3d0910e021bd1a10fc77a3d762c9b4d2309c

https://github.com/scalacenter/sbt-scalafix/actions/runs/5152679793/jobs/9279036518?pr=346
> java.lang.UnsupportedClassVersionError: scalafix/interfaces/ScalafixMainCallback has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0