### PR TITLE
Remove redundant build setting

### DIFF
--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -226,8 +226,6 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
     // don't publish scala 3 artifacts for now
     publish / skip := (if ((publish / skip).value) true
                        else scalaBinaryVersion.value == "3"),
-    publishLocal / skip := (if ((publishLocal / skip).value) true
-                            else scalaBinaryVersion.value == "3"),
     versionPolicyIntention := Compatibility.BinaryCompatible,
     scalacOptions ++= compilerOptions.value,
     scalacOptions ++= semanticdbSyntheticsCompilerOption.value,


### PR DESCRIPTION
By default, the behavior of `publishLocal` is following `publish / skip`.

(found out about this while browing 1.9.0 changelog, where `publishLocal / skip` is now honored but [defaults to `publish / skip`](https://github.com/sbt/sbt/blob/cab5c48e244543c92ae1e0a59d1a23778c626aed/main/src/main/scala/sbt/Defaults.scala#L2625))