### PR TITLE
dogfooding: run scalafixAll with local scalafix-interfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: coursier/setup-action@v1
-      - run: sbt "scalafixAll --check"
+      - run: sbt "dogfoodScalafixInterfaces; scalafixAll --check"
       - run: ./bin/scalafmt --test
   mima:
     name: Version Policy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,8 @@ scalafix-tests
 
 ## Formatting
 We use scalafix to apply some rules that are configured in .scalafix.conf.
-Make sure to run `sbt scalafixAll` to apply those rules.
+Make sure to run `sbt "dogfoodScalafixInterfaces; scalafixAll"` to execute
+the latest version of those rules.
 
 Be sure to run `scalafmt` (available in the `bin` folder) to ensure code
 formatting. `./bin/scalafmt --diff` formats only the files that have changed

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ inThisBuild(
     onLoadMessage := s"Welcome to scalafix ${version.value}",
     semanticdbEnabled := true,
     semanticdbVersion := scalametaV,
-    scalafixScalaBinaryVersion := "2.13",
+    scalafixScalaBinaryVersion := "2.13"
   )
 )
 

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -171,6 +171,25 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
         "interfaces/doc" ::
         s
     },
+    commands += Command.command("dogfoodScalafixInterfaces") { state =>
+      val extracted = Project.extract(state)
+      val v =
+        (ThisBuild / version)
+          .get(extracted.structure.data)
+          .get
+      val suffix =
+        (ThisBuild / scalafixScalaBinaryVersion)
+          .get(extracted.structure.data)
+          .get
+          .replace('.', '_')
+
+      s"all cli$suffix/publishLocalTransitive interfaces/publishLocal" ::
+        "reload plugins" ::
+        s"""set dependencyOverrides += "ch.epfl.scala" % "scalafix-interfaces" % "$v"""" :: // as documented in installation.md
+        "session save" ::
+        "reload return" ::
+        state
+    },
     Test / publishArtifact := false,
     licenses := Seq(
       "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")
@@ -192,7 +211,7 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
       Some("^\\d+\\.\\d+\\.\\d+\\+\\d+".r),
     versionScheme := Some("early-semver"),
     // coursier-versions always return false for the *.*.*.*-r pattern jgit uses
-    libraryDependencySchemes += Dependencies.jgit.withRevision("always"),
+    libraryDependencySchemes += Dependencies.jgit.withRevision("always")
   )
 
   override def projectSettings: Seq[Def.Setting[_]] = List(


### PR DESCRIPTION
This adds a command to replace the `scalafix-interfaces` brought in by `sbt-scalafix` with the local one. Rationale: observe impact of changes & detect regressions.

The implementation is not great as it's slow and mutates state, but I ran into dead-ends for the 2 alternatives I explored:
- injecting a custom `scalafix-interfaces.properties` to force the default scalafix-interfaces to load a custom scalafix-cli would require changes in the classloading logic to favor the custom property file over the one embedded in the JAR
- sbt-scalafix's `scalafixInterfacesProvider` could be rewired to `cli2_12/fullClasspath` with [some minor addition](https://github.com/scalacenter/sbt-scalafix/pull/351), but it would require turning `scalafixInterfacesProvider` into a task key, which is not possible because the parser's completion [can only depend on setting keys](https://github.com/scalacenter/sbt-scalafix/blob/main/src/main/scala/scalafix/sbt/ScalafixPlugin.scala#L196-L197)