### PR TITLE
run OrganizeImports despite scala-collection-compat

### DIFF
--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -237,6 +237,7 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
     publish / skip := (if ((publish / skip).value) true
                        else scalaBinaryVersion.value == "3"),
     versionPolicyIntention := Compatibility.BinaryCompatible,
+    scalacOptions += "-Wconf:origin=scala.collection.compat.*:s",
     scalacOptions ++= compilerOptions.value,
     scalacOptions ++= semanticdbSyntheticsCompilerOption.value,
     Compile / console / scalacOptions :=

--- a/scalafix-core/src/main/scala/scalafix/internal/patch/EscapeHatch.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/patch/EscapeHatch.scala
@@ -1,6 +1,7 @@
 package scalafix.internal.patch
 
 import scala.annotation.tailrec
+import scala.collection.compat._
 import scala.collection.immutable.TreeMap
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
@@ -21,8 +22,6 @@ import scalafix.patch.Patch.internal._
 import scalafix.rule.RuleName
 import scalafix.util.TreeExtractors.Mods
 import scalafix.v0._
-// used to cross-compile
-import scala.collection.compat._ // scalafix:ok
 
 /**
  * EscapeHatch is an algorithm to selectively disable rules. There are two

--- a/scalafix-rules/src/main/scala-2/scalafix/internal/pc/ScalafixGlobal.scala
+++ b/scalafix-rules/src/main/scala-2/scalafix/internal/pc/ScalafixGlobal.scala
@@ -2,19 +2,21 @@ package scala.meta.internal.pc
 
 import java.io.File
 import java.{util => ju}
+
+import scala.collection.compat._
 import scala.collection.mutable
 import scala.reflect.internal.{Flags => gf}
 import scala.reflect.io.VirtualDirectory
 import scala.tools.nsc.Settings
 import scala.tools.nsc.interactive.Global
 import scala.tools.nsc.reporters.StoreReporter
+import scala.util.Failure
+import scala.util.Try
 import scala.util.control.NonFatal
 import scala.{meta => m}
+
 import scala.meta.internal.semanticdb.scalac.SemanticdbOps
 import scala.meta.io.AbsolutePath
-import scala.util.{Failure, Success, Try}
-// used to cross-compile
-import scala.collection.compat._ // scalafix:ok
 
 object ScalafixGlobal {
   def newCompiler(

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/NoAutoTupling.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/NoAutoTupling.scala
@@ -1,10 +1,10 @@
 package scalafix.internal.rule
 
+import scala.collection.compat._
+
 import scala.meta._
 
 import scalafix.v1._
-// used to cross-compile
-import scala.collection.compat._ // scalafix:ok
 
 class NoAutoTupling extends SemanticRule("NoAutoTupling") {
 


### PR DESCRIPTION
As OrganizeImports rewrite the entire block of imports, adhoc `// scalafix:ok` suppressions were effectively disabling it on the entire block.