### PR TITLE
fix: ensure scala 3 dirs use scala3 dialect for scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -12,3 +12,9 @@ project.excludeFilters = [
   scalafix-tests/shared/src/main/scala/test/PrettyTest.scala
   scalafix-sbt/src/main/scala/scalafix/internal/sbt/ScalafixRuleNames.scala
 ]
+
+fileOverride {
+  "glob:**/scala-3/**" {
+     runner.dialect = scala3
+  }
+}


### PR DESCRIPTION
I think this is the cause of the error we're seeing in the [Scala
Steward](https://github.com/scalacenter/steward/actions/runs/5470172748/jobs/9959938109#step:5:870)
where the scala213 dialect has issues with the Scala 3 code. This small
changes just adds in some fileOverrides to make sure the scala-3 dirs
set the runner.dialect as scala3 instead of scala213.
