### PR TITLE
run command potentially changing build files last

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: coursier/setup-action@v1
-      - run: sbt "dogfoodScalafixInterfaces; scalafixAll --check"
       - run: ./bin/scalafmt --test
+      - run: sbt "dogfoodScalafixInterfaces; scalafixAll --check"
   mima:
     name: Version Policy
     runs-on: ubuntu-latest


### PR DESCRIPTION
[sbt's `session save`](https://github.com/scalacenter/scalafix/pull/1784/files#diff-cf70a614681abb9e33115a49e0b4a52865bdfcdb24c4c0df4af6546d92f88f5fR189) was seen updating `project/plugins.sbt` in a way that scalafmt does not like (missing trailing LF).

See https://github.com/scalacenter/scalafix/pull/1813#issuecomment-1626233607