### PR TITLE
Allow package when referencing rules in github

### DIFF
--- a/docs/developers/tutorial.md
+++ b/docs/developers/tutorial.md
@@ -654,6 +654,7 @@ The expansion rules for `github:org/repo` are the following:
 | `github:org/repo`                      | `scalafix/rules/src/main/scala/fix/Repo.scala`                           |
 | `github:org/some-repo`                 | `scalafix/rules/src/main/scala/fix/SomeRepo.scala`                       |
 | `github:org/repo/RuleName`             | `scalafix/rules/src/main/scala/fix/RuleName.scala`                       |
+| `github:org/repo/package.RuleName`     | `scalafix/rules/src/main/scala/fix/package/RuleName.scala`               |
 | `github:org/repo/RuleName?sha=HASH125` | (at commit `HASH125`) `scalafix/rules/src/main/scala/fix/RuleName.scala` |
 
 ## Publish the rule to Maven Central

--- a/docs/developers/tutorial.md
+++ b/docs/developers/tutorial.md
@@ -650,11 +650,12 @@ scalafix --rules=github:scalacenter/named-literal-arguments
 The expansion rules for `github:org/repo` are the following:
 
 | Before                                 | After                                                                    |
-| -------------------------------------- | ------------------------------------------------------------------------ |
-| `github:org/repo`                      | `scalafix/rules/src/main/scala/fix/Repo.scala`                           |
-| `github:org/some-repo`                 | `scalafix/rules/src/main/scala/fix/SomeRepo.scala`                       |
-| `github:org/repo/RuleName`             | `scalafix/rules/src/main/scala/fix/RuleName.scala`                       |
-| `github:org/repo/package.RuleName`     | `scalafix/rules/src/main/scala/fix/package/RuleName.scala`               |
+|----------------------------------------|--------------------------------------------------------------------------|
+| `github:org/repo`                      | (on `master`) `scalafix/rules/src/main/scala/fix/Repo.scala`             |
+| `github:org/some-repo`                 | (on `master`) `scalafix/rules/src/main/scala/fix/SomeRepo.scala`         |
+| `github:org/repo/RuleName`             | (on `master`) `scalafix/rules/src/main/scala/fix/RuleName.scala`         |
+| `github:org/repo/com.example.RuleName` | (on `master`) `scalafix/rules/src/main/scala/com/example/RuleName.scala` |
+| `github:org/repo/RuleName?sha=main`    | (on `main`) `scalafix/rules/src/main/scala/fix/RuleName.scala`           |
 | `github:org/repo/RuleName?sha=HASH125` | (at commit `HASH125`) `scalafix/rules/src/main/scala/fix/RuleName.scala` |
 
 ## Publish the rule to Maven Central

--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/GitHubUrlRule.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/GitHubUrlRule.scala
@@ -2,21 +2,24 @@ package scalafix.internal.reflect
 
 import java.io.FileNotFoundException
 import java.net.URL
-
 import metaconfig.Conf
 import metaconfig.ConfError
 import metaconfig.Configured
 import metaconfig.Configured.Ok
 
+import scala.util.Try
+
 object GitHubUrlRule {
 
+  private val DefaultBranch = "master"
+
   def unapply(arg: Conf.Str): Option[Configured[URL]] = arg.value match {
-    case GitHubOrgRepoVersionSha(org, repo, version, sha) =>
-      Option(Ok(guessGitHubURL(org, repo, version, sha)))
-    case GitHubOrgRepoVersion(org, repo, version) =>
-      Option(Ok(guessGitHubURL(org, repo, version, "master")))
+    case GitHubOrgRepoVersionSha(org, repo, rule, sha) =>
+      Some(Ok(guessGitHubURL(org, repo, rule, sha)))
+    case GitHubOrgRepoVersion(org, repo, rule) =>
+      Some(Ok(guessGitHubURL(org, repo, rule, DefaultBranch)))
     case GitHubOrgRepo(org, repo) =>
-      Option(Ok(guessGitHubURL(org, repo, normalCamelCase(repo), "master")))
+      Some(Ok(guessGitHubURL(org, repo, normalCamelCase(repo), DefaultBranch)))
     case GitHubFallback(invalid) =>
       Some(
         ConfError
@@ -32,17 +35,21 @@ object GitHubUrlRule {
   private def guessGitHubURL(
       org: String,
       repo: String,
-      filename: String,
+      rule: String,
       sha: String
   ): URL = {
-    val firstGuess = expandGitHubURL(org, repo, filename, sha)
-    if (is404(firstGuess)) {
-      val secondGuess = expandGitHubURL(org, repo, g8CamelCase(filename), sha)
-      if (is404(secondGuess)) firstGuess
-      else secondGuess
-    } else {
-      firstGuess
+    val (path, name) = rule.split("\\.").toList match {
+      case name :: Nil => ("", name)
+      case p :+ name => (p.mkString("", "/", "/"), name)
     }
+    val file = path + name + ".scala"
+    val url = expandGitHubURL(org, repo, file, sha)
+    checkUrl(url)
+      .recoverWith { case _: FileNotFoundException =>
+        val fallbackFile = path + g8CamelCase(name) + ".scala"
+        checkUrl(expandGitHubURL(org, repo, fallbackFile, sha))
+      }
+      .getOrElse(url)
   }
 
   private val GitHubOrgRepo =
@@ -54,35 +61,27 @@ object GitHubUrlRule {
   private val GitHubFallback =
     """github:(.*)""".r
 
-  private val alphanumerical = "[^a-zA-Z0-9]"
+  private val NonAlphaNumeric = "[^a-zA-Z0-9]"
 
   // approximates the "format=Camel" formatter in giter8.
   // http://www.foundweekends.org/giter8/Combined+Pages.html#Formatting+template+fields
   // toLowerCase is required to fix https://github.com/scalacenter/scalafix/issues/342
   private def g8CamelCase(string: String): String =
-    string.split(alphanumerical).mkString.toLowerCase.capitalize
+    string.split(NonAlphaNumeric).mkString.toLowerCase.capitalize
 
   private def normalCamelCase(string: String): String =
-    string.split(alphanumerical).map(_.capitalize).mkString
+    string.split(NonAlphaNumeric).map(_.capitalize).mkString
 
-  private def is404(url: URL): Boolean = {
-    try {
-      url.openStream().close()
-      false
-    } catch {
-      case _: FileNotFoundException =>
-        true
-    }
-  }
+  private def checkUrl(url: URL): Try[URL] =
+    Try(url.openStream().close()).map(_ => url)
+
   private def expandGitHubURL(
       org: String,
       repo: String,
-      filename: String,
+      file: String,
       sha: String
-  ): URL = {
-    new URL(
-      s"https://raw.githubusercontent.com/$org/$repo/$sha/scalafix/rules/src/main/scala/fix/$filename.scala"
-    )
-  }
+  ): URL = new URL(
+    s"https://raw.githubusercontent.com/$org/$repo/$sha/scalafix/rules/src/main/scala/fix/$file"
+  )
 
 }

--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/GitHubUrlRule.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/GitHubUrlRule.scala
@@ -36,18 +36,21 @@ object GitHubUrlRule {
   private def guessGitHubURL(
       org: String,
       repo: String,
-      rule: String,
+      className: String,
       sha: String
   ): URL = {
-    val (path, name) = rule.split("\\.").toList match {
-      case name :: Nil => ("", name)
-      case p :+ name => (p.mkString("", "/", "/"), name)
+    val (path, name) = className.split("\\.").toList match {
+      case name :: Nil =>
+        // use default fix package when given class simple name
+        ("fix", name)
+      case p :+ name =>
+        (p.mkString("/"), name)
     }
-    val file = path + name + ".scala"
+    val file = s"$path/$name.scala"
     val url = expandGitHubURL(org, repo, file, sha)
     checkUrl(url)
       .recoverWith { case _: FileNotFoundException =>
-        val fallbackFile = path + g8CamelCase(name) + ".scala"
+        val fallbackFile = s"$path/${g8CamelCase(name)}.scala"
         checkUrl(expandGitHubURL(org, repo, fallbackFile, sha))
       }
       .getOrElse(url)
@@ -82,7 +85,7 @@ object GitHubUrlRule {
       file: String,
       sha: String
   ): URL = new URL(
-    s"https://raw.githubusercontent.com/$org/$repo/$sha/scalafix/rules/src/main/scala/fix/$file"
+    s"https://raw.githubusercontent.com/$org/$repo/$sha/scalafix/rules/src/main/scala/$file"
   )
 
 }

--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/GitHubUrlRule.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/GitHubUrlRule.scala
@@ -2,12 +2,13 @@ package scalafix.internal.reflect
 
 import java.io.FileNotFoundException
 import java.net.URL
+
+import scala.util.Try
+
 import metaconfig.Conf
 import metaconfig.ConfError
 import metaconfig.Configured
 import metaconfig.Configured.Ok
-
-import scala.util.Try
 
 object GitHubUrlRule {
 

--- a/scalafix-tests/integration/src/test/scala/scalafix/tests/config/GitHubUrlRuleSuite.scala
+++ b/scalafix-tests/integration/src/test/scala/scalafix/tests/config/GitHubUrlRuleSuite.scala
@@ -38,14 +38,19 @@ class GitHubUrlRuleSuite extends AnyFunSuite with DiffAssertions {
       "src/main/scala/fix/RuleName.scala"
   )
   check(
-    "github:someorg/some-repo/version.RuleName",
+    "github:someorg/some-repo/com.example.RuleName",
     "https://raw.githubusercontent.com/someorg/some-repo/master/scalafix/rules/" +
-      "src/main/scala/fix/version/RuleName.scala"
+      "src/main/scala/com/example/RuleName.scala"
   )
   check(
     "github:someorg/some-repo/RuleName?sha=master~1",
     "https://raw.githubusercontent.com/someorg/some-repo/master~1/scalafix/rules/" +
       "src/main/scala/fix/RuleName.scala"
+  )
+  check(
+    "github:someorg/some-repo/com.example.RuleName?sha=1234abc",
+    "https://raw.githubusercontent.com/someorg/some-repo/1234abc/scalafix/rules/" +
+      "src/main/scala/com/example/RuleName.scala"
   )
   check(
     "github:someorg/42some-repo/RuleName",

--- a/scalafix-tests/integration/src/test/scala/scalafix/tests/config/GitHubUrlRuleSuite.scala
+++ b/scalafix-tests/integration/src/test/scala/scalafix/tests/config/GitHubUrlRuleSuite.scala
@@ -38,6 +38,11 @@ class GitHubUrlRuleSuite extends AnyFunSuite with DiffAssertions {
       "src/main/scala/fix/RuleName.scala"
   )
   check(
+    "github:someorg/some-repo/version.RuleName",
+    "https://raw.githubusercontent.com/someorg/some-repo/master/scalafix/rules/" +
+      "src/main/scala/fix/version/RuleName.scala"
+  )
+  check(
     "github:someorg/some-repo/RuleName?sha=master~1",
     "https://raw.githubusercontent.com/someorg/some-repo/master~1/scalafix/rules/" +
       "src/main/scala/fix/RuleName.scala"


### PR DESCRIPTION
Referencing scalafix rules does not currently allow rules to be located in a package other than `fix`.
Eg. in [scio](https://github.com/spotify/scio/tree/main/scalafix/rules/src/main/scala/fix) we've grouped rules in packages corresponding to the breaking version.

This change allows to reference a rule based on its package name (stripping the required `fix` package prefix)