### PR TITLE
Original MIT license for OrganizeImports

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -27,7 +27,8 @@ limitations under the License.
 The `scalafix.v0` package contains copy-pasted sources from [Scalameta](https://github.com/scalameta/scalameta/).
 We include the text of the original license below:
 
-``` Copyright (c) 2014-2018 EPFL
+```
+Copyright (c) 2014-2018 EPFL
 Copyright (c) 2016-2018 Twitter, Inc.
 
 All rights reserved.
@@ -55,4 +56,31 @@ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+## Licence for source code in OrganizeImports
+
+The `OrganizeImports` rule was imported from [scalafix-organize-imports](https://github.com/liancheng/scalafix-organize-imports).
+We include the text of the original license below:
+
+```
+Copyright (c) 2020 Cheng Lian
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```


### PR DESCRIPTION
Follows https://github.com/scalacenter/scalafix/pull/1480

cc @liancheng 