### PR TITLE
RedundantSyntax: distinguish single and triple quotes

### DIFF
--- a/scalafix-tests/input/src/main/scala-2.12/test/redundantSyntax/StringInterpolator.scala
+++ b/scalafix-tests/input/src/main/scala-2.12/test/redundantSyntax/StringInterpolator.scala
@@ -1,0 +1,44 @@
+/*
+rules = RedundantSyntax
+RedundantSyntax.stringInterpolator = true
+*/
+
+package test.redundantSyntax
+
+class StringInterpolator {
+
+  val a = 42d
+
+  var b = ""
+  b = "foo"
+  b = s"foo"
+  b = s"foo $a bar"
+  //b = s"my \"quoted\" string" does not compile as of 2.12.18 as https://github.com/scala/scala/pull/8830 was not backported
+
+  b = """foo"""
+  b =
+    s"""foo
+       |bar"""
+  b = s"""my \"quoted\" string"""
+  b = s"""foo $a bar"""
+  b = s"""$a"""
+
+  b = f"foo"
+  b = f"foo $a%2.2f"
+  b = f"foo \n bar"
+
+  b = raw"foo $a \nbar"
+  b = raw"""foo\nbar\\"""
+  b = raw"foo\nbar\\"
+  b = raw"foo bar"
+  b = raw"a\*b\+"
+
+  b = my"foo"
+  b = my"foo $a bar"
+
+  b = s"foo" // scalafix:ok
+
+  implicit class MyInterpolator(sc: StringContext) {
+    def my(subs: Any*): String = sc.toString + subs.mkString("")
+  }
+}

--- a/scalafix-tests/input/src/main/scala-2.13/test/redundantSyntax/StringInterpolator.scala
+++ b/scalafix-tests/input/src/main/scala-2.13/test/redundantSyntax/StringInterpolator.scala
@@ -1,0 +1,44 @@
+/*
+rules = RedundantSyntax
+RedundantSyntax.stringInterpolator = true
+*/
+
+package test.redundantSyntax
+
+class StringInterpolator {
+
+  val a = 42d
+
+  var b = ""
+  b = "foo"
+  b = s"foo"
+  b = s"foo $a bar"
+  b = s"my \"quoted\" string"
+
+  b = """foo"""
+  b =
+    s"""foo
+       |bar"""
+  b = s"""my \"quoted\" string"""
+  b = s"""foo $a bar"""
+  b = s"""$a"""
+
+  b = f"foo"
+  b = f"foo $a%2.2f"
+  b = f"foo \n bar"
+
+  b = raw"foo $a \nbar"
+  b = raw"""foo\nbar\\"""
+  b = raw"foo\nbar\\"
+  b = raw"foo bar"
+  b = raw"a\*b\+"
+
+  b = my"foo"
+  b = my"foo $a bar"
+
+  b = s"foo" // scalafix:ok
+
+  implicit class MyInterpolator(sc: StringContext) {
+    def my(subs: Any*): String = sc.toString + subs.mkString("")
+  }
+}

--- a/scalafix-tests/input/src/main/scala-3/test/redundantSyntax/StringInterpolator.scala
+++ b/scalafix-tests/input/src/main/scala-3/test/redundantSyntax/StringInterpolator.scala
@@ -1,0 +1,44 @@
+/*
+rules = RedundantSyntax
+RedundantSyntax.stringInterpolator = true
+*/
+
+package test.redundantSyntax
+
+class StringInterpolator {
+
+  val a = 42d
+
+  var b = ""
+  b = "foo"
+  b = s"foo"
+  b = s"foo $a bar"
+  b = s"my \"quoted\" string"
+
+  b = """foo"""
+  b =
+    s"""foo
+       |bar"""
+  b = s"""my \"quoted\" string"""
+  b = s"""foo $a bar"""
+  b = s"""$a"""
+
+  b = f"foo"
+  b = f"foo $a%2.2f"
+  b = f"foo \n bar"
+
+  b = raw"foo $a \nbar"
+  b = raw"""foo\nbar\\"""
+  b = raw"foo\nbar\\"
+  b = raw"foo bar"
+  b = raw"a\*b\+"
+
+  b = my"foo"
+  b = my"foo $a bar"
+
+  b = s"foo" // scalafix:ok
+
+  implicit class MyInterpolator(sc: StringContext) {
+    def my(subs: Any*): String = sc.toString + subs.mkString("")
+  }
+}

--- a/scalafix-tests/output/src/main/scala-2.12/test/redundantSyntax/StringInterpolator.scala
+++ b/scalafix-tests/output/src/main/scala-2.12/test/redundantSyntax/StringInterpolator.scala
@@ -8,18 +8,22 @@ class StringInterpolator {
   b = "foo"
   b = "foo"
   b = s"foo $a bar"
+  //b = s"my \"quoted\" string" does not compile as of 2.12.18 as https://github.com/scala/scala/pull/8830 was not backported
 
   b = """foo"""
   b =
     """foo
        |bar"""
+  b = s"""my \"quoted\" string"""
   b = s"""foo $a bar"""
   b = s"""$a"""
 
   b = "foo"
   b = f"foo $a%2.2f"
+  b = "foo \n bar"
 
   b = raw"foo $a \nbar"
+  b = """foo\nbar\\"""
   b = raw"foo\nbar\\"
   b = "foo bar"
   b = raw"a\*b\+"

--- a/scalafix-tests/output/src/main/scala-2.13/test/redundantSyntax/StringInterpolator.scala
+++ b/scalafix-tests/output/src/main/scala-2.13/test/redundantSyntax/StringInterpolator.scala
@@ -1,8 +1,3 @@
-/*
-rules = RedundantSyntax
-RedundantSyntax.stringInterpolator = true
-*/
-
 package test.redundantSyntax
 
 class StringInterpolator {
@@ -11,22 +6,26 @@ class StringInterpolator {
 
   var b = ""
   b = "foo"
-  b = s"foo"
+  b = "foo"
   b = s"foo $a bar"
+  b = "my \"quoted\" string"
 
   b = """foo"""
   b =
-    s"""foo
+    """foo
        |bar"""
+  b = s"""my \"quoted\" string"""
   b = s"""foo $a bar"""
   b = s"""$a"""
 
-  b = f"foo"
+  b = "foo"
   b = f"foo $a%2.2f"
+  b = "foo \n bar"
 
   b = raw"foo $a \nbar"
+  b = """foo\nbar\\"""
   b = raw"foo\nbar\\"
-  b = raw"foo bar"
+  b = "foo bar"
   b = raw"a\*b\+"
 
   b = my"foo"

--- a/scalafix-tests/output/src/main/scala-3/test/redundantSyntax/StringInterpolator.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/redundantSyntax/StringInterpolator.scala
@@ -1,0 +1,39 @@
+package test.redundantSyntax
+
+class StringInterpolator {
+
+  val a = 42d
+
+  var b = ""
+  b = "foo"
+  b = "foo"
+  b = s"foo $a bar"
+  b = "my \"quoted\" string"
+
+  b = """foo"""
+  b =
+    """foo
+       |bar"""
+  b = s"""my \"quoted\" string"""
+  b = s"""foo $a bar"""
+  b = s"""$a"""
+
+  b = "foo"
+  b = f"foo $a%2.2f"
+  b = "foo \n bar"
+
+  b = raw"foo $a \nbar"
+  b = """foo\nbar\\"""
+  b = raw"foo\nbar\\"
+  b = "foo bar"
+  b = raw"a\*b\+"
+
+  b = my"foo"
+  b = my"foo $a bar"
+
+  b = s"foo" // scalafix:ok
+
+  implicit class MyInterpolator(sc: StringContext) {
+    def my(subs: Any*): String = sc.toString + subs.mkString("")
+  }
+}


### PR DESCRIPTION
:exploding_head: 

```scala
Welcome to Scala 2.13.11 (OpenJDK 64-Bit Server VM, Java 17.0.7).
Type in expressions for evaluation. Or try :help.

scala> s""" \n """ == """ \n """ 
val res0: Boolean = false

scala> s" \n " == " \n "
val res1: Boolean = true

scala> f""" \n """ == """ \n """
val res2: Boolean = false

scala> f" \n " == " \n "
val res3: Boolean = true

scala> raw""" \n """ == """ \n """
val res4: Boolean = true

scala> raw" \n " == " \n "
val res5: Boolean = false
```

Test input/output had to be duplicated because 2.12 does not support `s"my \"quoted\" string"`