### PR TITLE
update the directory to run the tests/test command from

### DIFF
--- a/docs/developers/tutorial.md
+++ b/docs/developers/tutorial.md
@@ -41,7 +41,7 @@ Start by cloning the repository
 
 ```
 git clone https://github.com/scalacenter/scalafix-named-literal-arguments.git
-cd scalafix-named-literal-arguments
+cd scalafix-named-literal-arguments/scalafix
 sbt
 ...
 [info] sbt server started at local://$HOME/.sbt/1.0/server/93fc24de3bb97dec3e5b/sock


### PR DESCRIPTION
# Problem

Given the existing [tutorial](https://scalacenter.github.io/scalafix/docs/developers/tutorial.html#import-the-build) instructions when I run the `tests/test` command form inside the `scalafix-named-literal-arguments` directory I get the following sbt error

```
sbt:scalafix-named-literal-arguments> tests/test
[error] Expected ID character
[error] Not a valid command: tests (similar: tasks, set, last)
[error] Expected project ID
[error] Expected configuration
[error] Expected ':'
[error] Expected key
[error] Not a valid key: tests (similar: test, testOnly, testOptions)
[error] tests/test
[error]
```

# Solution

Updating the instructions to run the command from the `scalafix-named-literal-arguments/scalafix` directory fixes the issue.

```
~/sandbox/scalafix-named-literal-arguments-test/scalafix on main ?1                                                                                                                                                                        at 14:15:41
> sbt
[info] welcome to sbt 1.9.0 (Amazon.com Inc. Java 1.8.0_382)
[info] loading global plugins from /Users/mack.solomon/.sbt/1.0/plugins
[info] loading settings for project scalafix-build from plugins.sbt ...
[info] loading project definition from /Users/mack.solomon/sandbox/scalafix-named-literal-arguments-test/scalafix/project
[info] loading settings for project scalafix from build.sbt ...
[info] set current project to scalafix (in build file:/Users/mack.solomon/sandbox/scalafix-named-literal-arguments-test/scalafix/)
[info]
[info] Here are some highlights of sbt 1.9.0:
[info]   - POM consistency of sbt plugin publishing
[info]   - sbt new, a text-based adventure
[info]   - Deprecation of IntegrationTest configuration
[info] See https://eed3si9n.com/sbt-1.9.0 for full release notes.
[info] Hide the banner for this release by running `skipBanner`.
[info] sbt server started at local:///Users/mack.solomon/.sbt/1.0/server/6d3503f5ad29fae7fdad/sock
[info] started sbt server
sbt:scalafix> tests/test
[info] compiling 3 Scala sources to /Users/mack.solomon/sandbox/scalafix-named-literal-arguments-test/scalafix/input/target/scala-2.13/classes ...
[info] compiling 2 Scala sources to /Users/mack.solomon/sandbox/scalafix-named-literal-arguments-test/scalafix/rules/target/scala-2.13/classes ...
[warn] /Users/mack.solomon/sandbox/scalafix-named-literal-arguments-test/scalafix/rules/src/main/scala/fix/NoLiteralArguments.scala:24:16: Implicit definition should have explicit type (inferred metaconfig.generic.Surface[fix.NoLiteralArgumentsConfig])
[warn]   implicit val surface =
[warn]                ^
[warn] /Users/mack.solomon/sandbox/scalafix-named-literal-arguments-test/scalafix/rules/src/main/scala/fix/NoLiteralArguments.scala:26:16: Implicit definition should have explicit type (inferred metaconfig.ConfDecoder[fix.NoLiteralArgumentsConfig])
[warn]   implicit val decoder =
[warn]                ^
[warn] 4 deprecations; re-run with -deprecation for details
[warn] three warnings found
[info] compiling 1 Scala source to /Users/mack.solomon/sandbox/scalafix-named-literal-arguments-test/scalafix/tests/target/scala-2.13/test-classes ...
[info] RuleSuite:
[info] - test/NamedLiteralArguments.scala
[info] - test/NoLiteralArgumentsConfig.scala
[info] - test/NoLiteralArguments.scala
[info] Run completed in 1 second, 33 milliseconds.
[info] Total number of tests run: 3
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 3, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 7 s, completed Sep 2, 2023 2:16:00 PM
```