### PR TITLE
Revert "java target should only be driven by scalacOptions"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:8
       - uses: olafurpg/setup-gpg@v3
       - name: Check that major or minor was bumped upon compatibility breakage
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Reverts scalacenter/scalafix#1781 as there is no way to force a class file version with scala 2.12 ([we can only use the `target` hint](https://github.com/scalacenter/scalafix/blob/3da6acdd9af4e77e40a6d9e9b88975de8b7e26a8/project/ScalafixBuild.scala#L62)). JDK11 being the default JVM of the coursier version brought by coursier/setup-action@v1, 2.12 artifacts are no longer compatible with JDK8 :8ball: 

Identified through sbt-scalafix JDK8 CI when bringing-in the latest scalafix-interfaces: https://github.com/scalacenter/sbt-scalafix/actions/runs/6114939069/job/16597532534?pr=368. It would obviously be better to have a check in the CI here, but I am not sure it's really worth it as we have that safety net anyway.