### PR TITLE
Add isAtomic to ScalafixPatch interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ metals.sbt
 
 # Scala CLI specific
 .scala-build/
+
+# Emacs Backups
+*~

--- a/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixPatchImpl.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixPatchImpl.scala
@@ -24,4 +24,7 @@ case class ScalafixPatchImpl(patch: Patch)(
         ): ScalafixTextEdit
       }
       .toArray
+
+  override def isAtomic: Boolean =
+    patch.isInstanceOf[Patch.internal.AtomicPatch]
 }

--- a/scalafix-interfaces/src/main/java/scalafix/interfaces/ScalafixPatch.java
+++ b/scalafix-interfaces/src/main/java/scalafix/interfaces/ScalafixPatch.java
@@ -8,4 +8,12 @@ public interface ScalafixPatch {
     default ScalafixTextEdit[] textEdits() {
         throw new UnsupportedOperationException("textEdits() is not implemented");
     }
+
+    /**
+     *
+     * @return True if this patch is atomic, else false.
+     */
+    default boolean isAtomic() {
+        throw new UnsupportedOperationException("isAtmoic() is not implemented");
+    }
 }

--- a/scalafix-interfaces/src/main/java/scalafix/interfaces/ScalafixPatch.java
+++ b/scalafix-interfaces/src/main/java/scalafix/interfaces/ScalafixPatch.java
@@ -14,6 +14,6 @@ public interface ScalafixPatch {
      * @return True if this patch is atomic, else false.
      */
     default boolean isAtomic() {
-        throw new UnsupportedOperationException("isAtmoic() is not implemented");
+        throw new UnsupportedOperationException("isAtomic() is not implemented");
     }
 }


### PR DESCRIPTION
Hi, I thought it might be helpful to surface whether or not a patch is atomic in the `ScalafixPatch` API.  The idea is this indicates whether or not this patch makes sense to apply in isolation (e.g. through the `textEdits` method).

Thanks!