### PR TITLE
Add description to the OrganizeImports rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ re-generate on file save.
 
 ```sh
 $ sbt
-> docs/run -w
+> ci-docs
 ```
 
 To view the website in your browser, start the Docusaurus live reload server

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -60,6 +60,8 @@ class OrganizeImports(config: OrganizeImportsConfig)
 
   def this() = this(OrganizeImportsConfig())
 
+  override def description: String = "Organize import statements"
+
   override def isLinter: Boolean = true
 
   override def isRewrite: Boolean = true


### PR DESCRIPTION
The [Built-in Rules](https://scalacenter.github.io/scalafix/docs/rules/overview.html) section of the docs shows an empty description for the `OrganizeImports` rule.