### PR TITLE
improvement: Support script files

### DIFF
--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
@@ -444,7 +444,7 @@ case class Args(
 
 object Args extends TPrintImplicits {
   val baseMatcher: PathMatcher =
-    FileSystems.getDefault.getPathMatcher("glob:**.{scala,sbt}")
+    FileSystems.getDefault.getPathMatcher("glob:**.{scala,sbt,sc}")
   val runtimeScalaVersion: ScalaVersion = ScalaVersion
     .from(scala.util.Properties.versionNumberString) // can be empty
     .toOption

--- a/scalafix-core/src/main/scala/scalafix/internal/config/ScalafixConfig.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/config/ScalafixConfig.scala
@@ -22,6 +22,9 @@ case class ScalafixConfig(
 
   def dialectForFile(path: String): Dialect =
     if (path.endsWith(".sbt")) DefaultSbtDialect
+    else if (path.endsWith(".sc"))
+      dialect
+        .withAllowToplevelTerms(true)
     else dialect
 
   val reader: ConfDecoder[ScalafixConfig] =

--- a/scalafix-tests/integration/src/test/scala-2/scalafix/tests/cli/CliSyntacticSuite.scala
+++ b/scalafix-tests/integration/src/test/scala-2/scalafix/tests/cli/CliSyntacticSuite.scala
@@ -311,6 +311,24 @@ class CliSyntacticSuite extends BaseCliSuite {
   )
 
   check(
+    name = "fix script files",
+    originalLayout = s"""|/a.sc
+      |def foo { println(1) }
+      |lazy val bar = project
+      |""".stripMargin,
+    args = Array(
+      "-r",
+      "ProcedureSyntax",
+      "a.sc"
+    ),
+    expectedLayout = s"""|/a.sc
+      |def foo: Unit = { println(1) }
+      |lazy val bar = project
+      |""".stripMargin,
+    expectedExit = ExitStatus.Ok
+  )
+
+  check(
     name = "deprecated name emits warning",
     originalLayout = s"""|/a.scala
       |object a {


### PR DESCRIPTION
Previously, scripts would not be supported. Now, they should be correctly picked up by Scalafix.

I also tested it in Metals with the organize imports rule.

Fixes https://github.com/scalacenter/scalafix/issues/1534