### PR TITLE
run windows CI with latest LTS JDK21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         jvm: ["8", "11", "17", "21"]
         include:
           - os: windows
-            jvm: 17
+            jvm: 21
     name: ${{ matrix.os }} / JDK${{ matrix.jvm }}
     runs-on: ${{ matrix.os }}-latest
     steps:


### PR DESCRIPTION
There is no reason to stick to JDK17 - if we pick one we'd better pick the latest. Also, it might speed up slightly the build...

Follows https://github.com/scalacenter/scalafix/pull/1810