### PR TITLE
Scala3: test against both LTS & Next, build with LTS

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,8 @@ import sbt._
 object Dependencies {
   val scala212 = sys.props.getOrElse("scala212.nightly", "2.12.19")
   val scala213 = sys.props.getOrElse("scala213.nightly", "2.13.14")
-  val scala3 = sys.props.getOrElse("scala3.nightly", "3.4.2")
+  val scala3Latest = sys.props.getOrElse("scala3.nightly", "3.4.2")
+  val scala3LTS = "3.3.4-RC1"
 
   val bijectionCoreV = "0.9.7"
   val collectionCompatV = "2.12.0"

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -31,7 +31,7 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
       publish / skip := true
     )
     lazy val supportedScalaVersions = List(scala213, scala212)
-    lazy val buildScalaVersions = Seq(scala212, scala213, scala3)
+    lazy val buildScalaVersions = Seq(scala212, scala213, scala3LTS)
     lazy val buildScalaVersionsWithTargets: Seq[(String, TargetAxis)] =
       buildScalaVersions.map(sv => (sv, TargetAxis(sv))) ++
         Seq(scala213, scala212).flatMap { sv =>
@@ -56,10 +56,14 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
           }
 
           val prevVersions = previousVersions(sv).map(prev => TargetAxis(prev))
+          val scala3FromScala2 = TargetAxis(scala3Latest)
           val xsource3 = TargetAxis(sv, xsource3 = true)
 
           (prevVersions :+ xsource3).map((sv, _))
-        } :+ (scala213, TargetAxis(scala3))
+        } ++ Seq(
+          (scala213, TargetAxis(scala3Latest)),
+          (scala213, TargetAxis(scala3LTS))
+        )
 
     lazy val publishLocalTransitive =
       taskKey[Unit]("Run publishLocal on this project and its dependencies")

--- a/scalafix-core/src/main/scala/scalafix/internal/config/ScalafixMetaconfigReaders.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/config/ScalafixMetaconfigReaders.scala
@@ -11,7 +11,6 @@ import scala.util.Try
 import scala.util.control.NonFatal
 import scala.util.matching.Regex
 
-import scala.meta.Ref
 import scala.meta._
 import scala.meta.parsers.Parse
 
@@ -23,7 +22,6 @@ import metaconfig.Configured.NotOk
 import metaconfig.Configured.Ok
 import scalafix.internal.util.SymbolOps
 import scalafix.patch.Patch.internal._
-import scalafix.v0.Symbol
 import scalafix.v0._
 
 object ScalafixMetaconfigReaders extends ScalafixMetaconfigReaders

--- a/scalafix-core/src/main/scala/scalafix/internal/patch/LegacyPatchOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/patch/LegacyPatchOps.scala
@@ -10,7 +10,6 @@ import scalafix.internal.patch.LegacyPatchOps.DeprecationMessage
 import scalafix.internal.util.SymbolOps.Root
 import scalafix.patch.Patch.internal._
 import scalafix.patch.PatchOps
-import scalafix.v0.Symbol
 import scalafix.v0._
 
 trait LegacyPatchOps extends PatchOps {

--- a/scalafix-core/src/main/scala/scalafix/internal/util/DenotationOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/util/DenotationOps.scala
@@ -1,6 +1,5 @@
 package scalafix.internal.util
 
-import scala.meta.Dialect
 import scala.meta._
 
 import scalafix.v0._

--- a/scalafix-core/src/main/scala/scalafix/internal/util/ProductStructure.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/util/ProductStructure.scala
@@ -1,6 +1,5 @@
 package scalafix.internal.util
 
-import scala.meta.Tree
 import scala.meta._
 
 import org.typelevel.paiges._

--- a/scalafix-core/src/main/scala/scalafix/patch/Patch.scala
+++ b/scalafix-core/src/main/scala/scalafix/patch/Patch.scala
@@ -1,6 +1,5 @@
 package scalafix.patch
 
-import scala.meta.Token
 import scala.meta._
 
 import org.scalameta.logger

--- a/scalafix-reflect/src/main/scala/scalafix/internal/v0/LegacyInMemorySemanticdbIndex.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/v0/LegacyInMemorySemanticdbIndex.scala
@@ -11,7 +11,6 @@ import scala.meta.internal.{semanticdb => s}
 import scalafix.internal.config.ScalaVersion
 import scalafix.internal.patch.CrashingSemanticdbIndex
 import scalafix.internal.reflect.ClasspathOps
-import scalafix.internal.v1.TreePos
 import scalafix.internal.v1._
 import scalafix.util.SemanticdbIndex
 import scalafix.v0

--- a/scalafix-tests/integration/src/main/scala/scalafix/test/ScalatestAutofixRule.scala
+++ b/scalafix-tests/integration/src/main/scala/scalafix/test/ScalatestAutofixRule.scala
@@ -1,6 +1,5 @@
 package scalafix.test
 
-import scalafix.v1.SemanticRule
 import scalafix.v1._
 
 class ScalatestAutofixRule extends SemanticRule("ScalatestAutofixRule") {


### PR DESCRIPTION
Rationale
- test against LTS & Next -> test the 2 Scala3 versions we can expect in the wild
- build with LTS -> prepare for https://github.com/scalacenter/scalafix/issues/1680

TODO
- [ ] port something similar to https://github.com/scalacenter/scalafix.g8

```diff
 sbt:scalafix> projects
 [info] In file:/home/brice/git/scala/scalafix/
 [info] 	   cli2_12
 [info] 	   cli2_13
 [info] 	   cli3
 [info] 	   core2_12
 [info] 	   core2_13
 [info] 	   core3
 [info] 	   docs2_13
 [info] 	   expect2_12Target2_12_18
 [info] 	   expect2_12Target2_12_19
 [info] 	   expect2_12Target2_12_19xsource3
 [info] 	   expect2_13Target2_13_12
 [info] 	   expect2_13Target2_13_13
 [info] 	   expect2_13Target2_13_14
 [info] 	   expect2_13Target2_13_14xsource3
+[info] 	   expect2_13Target3_3_4-RC1
 [info] 	   expect2_13Target3_4_2
-[info] 	   expect3Target3_4_2
+[info] 	   expect3Target3_3_4-RC1
 [info] 	   input2_12_18
 [info] 	   input2_12_19
 [info] 	   input2_12_19xsource3
 [info] 	   input2_13_12
 [info] 	   input2_13_13
 [info] 	   input2_13_14
 [info] 	   input2_13_14xsource3
+[info] 	   input3_3_4_RC1
 [info] 	   input3_4_2
 [info] 	   integration2_12
 [info] 	   integration2_13
 [info] 	   integration3
 [info] 	   interfaces
 [info] 	   output2_12_19
 [info] 	   output2_12_19xsource3
 [info] 	   output2_13_14
 [info] 	   output2_13_14xsource3
-[info] 	   output3_4_2
+[info] 	   output3_3_4_RC1
 [info] 	   reflect2_12
 [info] 	   reflect2_13
 [info] 	   reflect3
 [info] 	   rules2_12
 [info] 	   rules2_13
 [info] 	   rules3
 [info] 	 * scalafix
 [info] 	   shared2_12
 [info] 	   shared2_13
 [info] 	   shared3
 [info] 	   testkit2_12
 [info] 	   testkit2_13
 [info] 	   testkit3
 [info] 	   unit2_12
 [info] 	   unit2_13
 [info] 	   unit3
```