### PR TITLE
scalameta 4.9.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -383,7 +383,8 @@ lazy val docs = projectMatrix
     scalacOptions += "-Wconf:msg='match may not be exhaustive':s", // silence exhaustive pattern matching warning for documentation
     scalacOptions += "-Xfatal-warnings",
     mdoc := (Compile / run).evaluated,
-    libraryDependencies += metaconfigDoc
+    libraryDependencies += metaconfigDoc,
+    dependencyOverrides += scalameta // force eviction of mdoc transitive dependency
   )
   .defaultAxes(VirtualAxis.jvm)
   .jvmPlatform(scalaVersions = Seq(scala213))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val metaconfigV = "0.12.0"
   val nailgunV = "0.9.1"
   val scalaXmlV = "2.2.0"
-  val scalametaV = "4.8.15"
+  val scalametaV = "4.9.0"
   val scalatestV = "3.2.18"
   val munitV = "0.7.29"
 

--- a/scalafix-core/src/main/scala/org/langmeta/internal/ScalametaInternals.scala
+++ b/scalafix-core/src/main/scala/org/langmeta/internal/ScalametaInternals.scala
@@ -4,8 +4,8 @@ import scala.meta._
 import scala.meta.internal.inputs.XtensionInputSyntaxStructure
 import scala.meta.internal.semanticdb.Scala.Descriptor
 import scala.meta.internal.semanticdb.Scala.DescriptorParser
-import scala.meta.internal.trees.Origin
 import scala.meta.internal.{semanticdb => s}
+import scala.meta.trees.Origin
 
 object ScalametaInternals {
   private val EOL = System.lineSeparator()

--- a/scalafix-core/src/main/scala/scala/meta/internal/scalafix/ScalafixScalametaHacks.scala
+++ b/scalafix-core/src/main/scala/scala/meta/internal/scalafix/ScalafixScalametaHacks.scala
@@ -1,10 +1,7 @@
 package scala.meta.internal.scalafix
 
-import scala.meta.Tree
 import scala.meta.internal.semanticdb.Scala.Names
-import scala.meta.internal.trees.Origin
 
 object ScalafixScalametaHacks {
-  def resetOrigin(tree: Tree): Tree = tree.withOrigin(Origin.None)
   def encode(name: String): String = Names.encode(name)
 }

--- a/scalafix-core/src/main/scala/scalafix/internal/patch/ImportPatchOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/patch/ImportPatchOps.scala
@@ -4,6 +4,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 
 import scala.meta._
+import scala.meta.trees.Origin
 
 import scalafix.XtensionOptionPatch
 import scalafix.XtensionSeqPatch
@@ -200,7 +201,11 @@ object ImportPatchOps {
       allImports.filter(_.importers.forall(isRemovedImporter))
 
     def remove(toRemove: Tree): Patch = {
-      if (toRemove.pos == Position.None) return Patch.empty
+      val isSameInput = (toRemove.origin, ctx.tree.origin) match {
+        case (a: Origin.Parsed, b: Origin.Parsed) => a.input == b.input
+        case _ => false
+      }
+      if (!isSameInput) return Patch.empty
       // Imagine "import a.b, c.d, e.f, g.h" where a.b, c.d and g.h are unused.
       // All unused imports are responible to delete their leading comma but
       // c.d is additionally responsible for deleting its trailling comma.

--- a/scalafix-docs/src/main/scala/scala/meta/internal/prettyprinters/Enquote.scala
+++ b/scalafix-docs/src/main/scala/scala/meta/internal/prettyprinters/Enquote.scala
@@ -1,0 +1,8 @@
+package scala.meta.internal.prettyprinters
+
+// compatibility hack until https://github.com/scalameta/mdoc/pull/842 is released
+object enquote {
+  def apply(s: String, style: QuoteStyle): String = {
+    style(s)
+  }
+}


### PR DESCRIPTION
https://github.com/scalameta/scalameta/releases/tag/v4.9.0

https://github.com/scalameta/scalameta/issues/3425 is a non-backward compatible feature, as quasiquotes expand to code referencing `scala.meta.trees.Origin` [which does not exist in 4.8.x](https://github.com/scalameta/scalameta/pull/3454).

This means that Scalafix rules containing quasiquotes compiled against scalameta 4.9.x will cause link errors if ran on older Scalafix versions. As a result, we need a minor Scalafix bump when taking that in, despite the fact [that it's "just" a minor bump in a SemVer lib](https://github.com/scalameta/scalameta/blob/6699cdedf3dd855e52254a2ed059c34554d09bb0/build.sbt#L667) (we could argue that a major bump of scalameta was needed, but backward compatibility guarantees with macros is not very well defined).