### PR TITLE
handle unused warnings for sources compiled with upcoming LTS 3.3.4

### DIFF
--- a/docs/rules/OrganizeImports.md
+++ b/docs/rules/OrganizeImports.md
@@ -1277,7 +1277,7 @@ Remove unused imports.
 
 > The `removeUnused` option is not supported for source files compiled with
 > early versions of Scala 3 as these do not export SemanticDB diagnostics for
-> unused imports. You must compile with Scala 3.4.0 or later to use it.
+> unused imports. You must compile with Scala 3.3.4 or later to use it.
 
 ### Value type
 

--- a/docs/rules/RemoveUnused.md
+++ b/docs/rules/RemoveUnused.md
@@ -15,7 +15,7 @@ example diff from running `sbt "scalafix RemoveUnused"`.
 To use this rule:
 
 - Enable the Scala compiler option `-Ywarn-unused` (2.12), `-Wunused` (2.13),
-  or `-Wunused:all` (3.4+).
+  or `-Wunused:all` (3.3.4+).
 - Disable `-Xfatal-warnings` if you have it enabled. This is required so the
   compiler warnings do not fail the build before running Scalafix. If you are
   running 2.12.13+ or 2.13.2+, you may keep `-Xfatal-warnings` by modifying how

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -864,7 +864,7 @@ object OrganizeImports {
       scalaVersion: String
   ): Configured[Rule] = {
     val hasCompilerSupport =
-      Seq("3.0", "3.1", "3.2", "3.3")
+      Seq("3.0", "3.1", "3.2", "3.3.0", "3.3.1", "3.3.2", "3.3.3")
         .forall(v => !scalaVersion.startsWith(v))
 
     val hasWarnUnused = hasCompilerSupport && {
@@ -915,13 +915,14 @@ object OrganizeImports {
     else if (hasCompilerSupport)
       Configured.error(
         "A Scala compiler option is required to use OrganizeImports with"
-          + " \"OrganizeImports.removeUnused\" set to true. To fix this problem, update your"
-          + " build to add `-Ywarn-unused-import` (2.12) or `-Wunused:imports` (2.13 and 3.4+)."
+          + " \"OrganizeImports.removeUnused\" set to true. To fix this"
+          + " problem, update your build to add `-Ywarn-unused-import` (2.12)"
+          + " or `-Wunused:imports` (2.13 and 3.3.4+)."
       )
     else
       Configured.error(
         "\"OrganizeImports.removeUnused\"" + s"is not supported on $scalaVersion as the compiler is"
-          + " not providing enough information. Please upgrade the Scala compiler to 3.4.0 or greater."
+          + " not providing enough information. Please upgrade the Scala compiler to 3.3.4 or greater."
           + " Otherwise, run the rule with \"OrganizeImports.removeUnused\" set to false"
           + " to organize imports while keeping potentially unused imports."
       )

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
@@ -33,7 +33,7 @@ class RemoveUnused(config: RemoveUnusedConfig)
   private def warnUnusedString = List("-Xlint", "-Xlint:unused")
   override def withConfiguration(config: Configuration): Configured[Rule] = {
     val diagnosticsAvailableInSemanticdb =
-      Seq("3.0", "3.1", "3.2", "3.3")
+      Seq("3.0", "3.1", "3.2", "3.3.0", "3.3.1", "3.3.2", "3.3.3")
         .forall(v => !config.scalaVersion.startsWith(v))
 
     val hasWarnUnused = config.scalacOptions.exists(option =>
@@ -44,11 +44,11 @@ class RemoveUnused(config: RemoveUnusedConfig)
       Configured.error(
         """|A Scala compiler option is required to use RemoveUnused. To fix this problem,
           |update your build to add -Ywarn-unused (with 2.12), -Wunused (with 2.13), or 
-          |-Wunused:all (with 3.4+)""".stripMargin
+          |-Wunused:all (with 3.3.4+)""".stripMargin
       )
     } else if (!diagnosticsAvailableInSemanticdb) {
       Configured.error(
-        "You must use a more recent version of the Scala 3 compiler (3.4+)"
+        "You must use a more recent version of the Scala 3 compiler (3.3.4+)"
       )
     } else {
       config.conf


### PR DESCRIPTION
- [x] https://github.com/scala/scala3/pull/20315
- [x] tested with https://github.com/scalacenter/scalafix/pull/1926
- [ ] bring to metals via a follow up of https://github.com/scalameta/metals/pull/6371