### PR TITLE
Scalameta 4.9.1-RC1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val metaconfigV = "0.12.0"
   val nailgunV = "0.9.1"
   val scalaXmlV = "2.2.0"
-  val scalametaV = "4.9.0"
+  val scalametaV = "4.9.1-RC1"
   val scalatestV = "3.2.18"
   val munitV = "0.7.29"
 


### PR DESCRIPTION
https://github.com/scalameta/scalameta/releases/tag/v4.9.1-RC1

Brings-in https://github.com/scalameta/scalameta/pull/3581