### PR TITLE
OrganizeImports: fix invalid recommended scalac option

### DIFF
--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -916,7 +916,7 @@ object OrganizeImports {
       Configured.error(
         "A Scala compiler option is required to use OrganizeImports with"
           + " \"OrganizeImports.removeUnused\" set to true. To fix this problem, update your"
-          + " build to add `-Ywarn-unused` (2.12), `-Wunused:imports` (2.13), or"
+          + " build to add `-Ywarn-unused` (2.12) or `-Wunused:imports` (2.13 and 3.4+)."
           + " `-Wunused:imports` (3.4+)."
       )
     else

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -917,7 +917,7 @@ object OrganizeImports {
         "A Scala compiler option is required to use OrganizeImports with"
           + " \"OrganizeImports.removeUnused\" set to true. To fix this problem, update your"
           + " build to add `-Ywarn-unused` (2.12), `-Wunused:imports` (2.13), or"
-          + " `-Wunused:import` (3.4+)."
+          + " `-Wunused:imports` (3.4+)."
       )
     else
       Configured.error(

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -917,7 +917,6 @@ object OrganizeImports {
         "A Scala compiler option is required to use OrganizeImports with"
           + " \"OrganizeImports.removeUnused\" set to true. To fix this problem, update your"
           + " build to add `-Ywarn-unused` (2.12) or `-Wunused:imports` (2.13 and 3.4+)."
-          + " `-Wunused:imports` (3.4+)."
       )
     else
       Configured.error(


### PR DESCRIPTION
When specifying '-Wunused:import' with Scala 3.4.0, the following error occurs, so I think '-Wunused:imports' is the correct option.

```
invalid choice(s) for -Wunused: import
 scalac -help  gives more information
```
