### PR TITLE
update docs to document that sbt resolvers are now handled

### DIFF
--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -157,7 +157,7 @@ Great! You are all set to use Scalafix with sbt :)
 | `scalafixConfig` | `SettingKey[Option[File]]` | `.scalafix.conf` file to specify which scalafix rules should run, together with their potential options. Defaults to `.scalafix.conf` in the root directory, if it exists.
 | `scalafixDependencies` | `SettingKey[Seq[ModuleID]]` | Dependencies making [custom rules](#run-custom-rules) available via their simple name. Can be set in `ThisBuild` or at project-level. Defaults to `Nil`.
 | `scalafixOnCompile` | `SettingKey[Boolean]` | When `true`, Scalafix rule(s) declared in `scalafixConfig` are run on compilation, applying rewrites and failing on lint errors. Defaults to `false`.
-| `scalafixResolvers` | `SettingKey[Seq[Repository]]` | Custom resolvers where `scalafixDependencies` are resolved from. Can be set in `ThisBuild` or at project-level. Defaults to: Ivy2 local, Maven Central, Sonatype releases & Sonatype snapshots.
+| `scalafixResolvers` | `SettingKey[Seq[Repository]]` | Custom resolvers where `scalafixDependencies` are resolved from, in addition to user-defined sbt `resolvers`. Must be set in `ThisBuild`. Defaults to: Ivy2 local, Maven Central, Sonatype releases & Sonatype snapshots.
 | `scalafixScalaBinaryVersion` | `SettingKey[String]` | Scala binary version used for Scalafix execution. Can be set in `ThisBuild` or at project-level. Defaults to 2.12. For advanced rules such as ExplicitResultTypes to work, it must match the binary version defined in the build for compiling sources. Note that `scalafixDependencies` artifacts must be published against that Scala version.
 
 


### PR DESCRIPTION
https://github.com/scalacenter/sbt-scalafix/pull/404 effectively [removes the ability to define project-level `scalafixResolvers`](https://github.com/scalacenter/sbt-scalafix/pull/404/files#diff-06169c9b17ca1913e8659adfb6e67d1360dcfadd638128457e2d74a9e4dcc72aR440), but it was not working for some cases (with local rules), and I think it's really not needed anyway.