### PR TITLE
sbt-scalafix scalafixScalaBinaryVersion is now deprecated

### DIFF
--- a/docs/developers/local-rules.md
+++ b/docs/developers/local-rules.md
@@ -16,15 +16,6 @@ change sets as the domain sources they will be run against.
 Make sure the sbt plugin, as well as the Scala compiler plugin and options [are
 set up correctly](../users/installation.md#sbt).
 
-Although it is possible to define your rules in a Scala binary version that
-does not match your build, it is highly recommended that you align them via:
-
-```diff
- // build.sbt
-+ThisBuild / scalafixScalaBinaryVersion :=
-+  CrossVersion.binaryScalaVersion(scalaVersion.value)
-```
-
 > Note that any potential external Scalafix rule, loaded with the
 > `scalafixDependencies` setting key, must be built and published against the
 > same Scala binary version.

--- a/docs/developers/setup.md
+++ b/docs/developers/setup.md
@@ -67,6 +67,15 @@ several sub-projects for each directory.
   can be applied.
 - `tests` verifies each `input` sub-project against a `rules` sub-project.
 
+> Failure to cross-build will reduce the reach of your rule, as users running
+> Scalafix in a Scala version you are not building for will get either
+> resolution errors (for published rules) or potential compilation errors (for
+> unpublished rules, compiled on-the-fly). Note that `scalafix-core` brings
+> [`scala-collection-compat`](https://github.com/scala/scala-collection-compat),
+> which allows to use the Scala 2.13 collection framework on Scala 2.12, and
+> therefore removes the need for maintaining different source files depending
+> on the Scala version.
+
 The `scalafix/` directory is a self-contained sbt build and can live in the same
 directory as your existing library.
 

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -158,7 +158,6 @@ Great! You are all set to use Scalafix with sbt :)
 | `scalafixDependencies` | `SettingKey[Seq[ModuleID]]` | Dependencies making [custom rules](#run-custom-rules) available via their simple name. Can be set in `ThisBuild` or at project-level. Defaults to `Nil`.
 | `scalafixOnCompile` | `SettingKey[Boolean]` | When `true`, Scalafix rule(s) declared in `scalafixConfig` are run on compilation, applying rewrites and failing on lint errors. Defaults to `false`.
 | `scalafixResolvers` | `SettingKey[Seq[Repository]]` | Custom resolvers where `scalafixDependencies` are resolved from, in addition to the user-defined sbt `ThisBuild / resolvers`. Must be set in `ThisBuild`. Defaults to: Ivy2 local, Maven Central, Sonatype releases & Sonatype snapshots.
-| `scalafixScalaBinaryVersion` | `SettingKey[String]` | Scala binary version used for Scalafix execution. Can be set in `ThisBuild` or at project-level. Defaults to 2.12. For advanced rules such as ExplicitResultTypes to work, it must match the binary version defined in the build for compiling sources. Note that `scalafixDependencies` artifacts must be published against that Scala version.
 
 
 ### Main and test sources

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -56,11 +56,10 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
           }
 
           val prevVersions = previousVersions(sv).map(prev => TargetAxis(prev))
-          val scala3FromScala2 = TargetAxis(scala3)
           val xsource3 = TargetAxis(sv, xsource3 = true)
 
-          (prevVersions :+ scala3FromScala2 :+ xsource3).map((sv, _))
-        }
+          (prevVersions :+ xsource3).map((sv, _))
+        } :+ (scala213, TargetAxis(scala3))
 
     lazy val publishLocalTransitive =
       taskKey[Unit]("Run publishLocal on this project and its dependencies")


### PR DESCRIPTION
Companion for https://github.com/scalacenter/sbt-scalafix/pull/419