### PR TITLE
remove references to sbt-only, deprecated key

### DIFF
--- a/scalafix-reflect/src/main/scala-3/scalafix/internal/reflect/RuleCompiler.scala
+++ b/scalafix-reflect/src/main/scala-3/scalafix/internal/reflect/RuleCompiler.scala
@@ -60,8 +60,7 @@ class RuleCompiler(
       val lastError =
         "Error compiling rule(s) from source using Scala 3 compiler; " +
           "to use the Scala 2.x compiler instead, use the corresponding " +
-          "scalafix-cli artifact or force scalafixScalaBinaryVersion " +
-          "to 2.x in your build tool"
+          "scalafix-cli artifact"
       val errors = (reporter.allErrors.map(_.message) :+ lastError)
       ConfError.apply(errors.map(ConfError.message)).map(_.notOk).get
     }

--- a/scalafix-rules/src/main/scala-2/scalafix/internal/rule/ExplicitResultTypes.scala
+++ b/scalafix-rules/src/main/scala-2/scalafix/internal/rule/ExplicitResultTypes.scala
@@ -71,7 +71,7 @@ final class ExplicitResultTypes(
     ) {
       Configured.error(
         s"The ExplicitResultTypes rule needs to run with the same Scala binary version as the one used to compile target sources ($inputBinaryScalaVersion). " +
-          s"To fix this problem, either remove ExplicitResultTypes from .scalafix.conf or make sure the scalafixScalaBinaryVersion setting key matches $inputBinaryScalaVersion."
+          s"To fix this problem, either remove ExplicitResultTypes from .scalafix.conf or make sure Scalafix is loaded with $inputBinaryScalaVersion."
       )
     } else {
       config.conf // Support deprecated explicitReturnTypes config


### PR DESCRIPTION
Missed in https://github.com/scalacenter/scalafix/pull/1990