### PR TITLE
bump sbt-ci-release to fix JDK8 support

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.6.0")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.6.1")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")
 addSbtPlugin("com.github.sbt" % "sbt-ghpages" % "0.8.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")


### PR DESCRIPTION
Follows https://github.com/scalacenter/scalafix/pull/2036
See https://github.com/xerial/sbt-sonatype/issues/507

The regression is not visible on master  as the new client is apparently not used for OSS snapshots.