### PR TITLE
remove unused scala-java8-compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -134,12 +134,6 @@ lazy val cli = projectMatrix
       commonText
     ),
     libraryDependencies ++= {
-      if (!isScala3.value)
-        Seq(java8Compat)
-      else
-        Seq()
-    },
-    libraryDependencies ++= {
       if (isScala3.value) Seq()
       else
         // Rules built with an old scalafix-core may need packages that

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,6 @@ object Dependencies {
   val coursierInterfaceV = "1.0.19"
   val commontTextV = "1.12.0"
   val googleDiffV = "1.3.0"
-  val java8CompatV = "1.0.2"
   val jgitV = "5.13.3.202401111512-r"
   val metaconfigV = "0.12.0"
   val nailgunV = "0.9.1"
@@ -40,7 +39,6 @@ object Dependencies {
     .cross(CrossVersion.for3Use2_13)
   val coursierInterfaces = "io.get-coursier" % "interface" % coursierInterfaceV
   val googleDiff = "com.googlecode.java-diff-utils" % "diffutils" % googleDiffV
-  val java8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % java8CompatV
   val jgit = "org.eclipse.jgit" % "org.eclipse.jgit" % jgitV
   val metaconfig = "com.geirsson" %% "metaconfig-typesafe-config" % metaconfigV
   val pprint = "com.lihaoyi" %% "pprint" % pprintV


### PR DESCRIPTION
Introduced in https://github.com/scalacenter/scalafix/commit/162db399bbf5584632e617bf7c3135a600dc06c8, but not actively used. Removal missed in https://github.com/scalacenter/scalafix/commit/e6bd39bcd70a31069b4dd8269b53a99627b8a5c6.