### PR TITLE
docs: remove stale instructions to verify setup

### DIFF
--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -393,22 +393,6 @@ the next `compile`.
 > The `scalafixEnable` command must be re-executed after every `reload` and when
 > sbt shell is exited.
 
-### Verify installation
-
-To verify that the SemanticDB compiler plugin is enabled, check that the
-settings `scalacOptions` and `allDependencies` contain the values below.
-
-```sh
-> show Compile / scalacOptions
-...
-[info] * List(..., -Yrangepos, ...)
-...
-> show allDependencies
-...
-[info] List(..., org.scalameta:semanticdb-scalac:@SCALA213@:plugin->default(compile), ...)
-...
-```
-
 ### Example project
 
 For a minimal example project using sbt-scalafix, see the


### PR DESCRIPTION
- the output is specific to Scala 2
- sbt's SemanticdbPlugin is now the only documented setup and is trivial