### PR TITLE
test JDK23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu"]
-        jvm: ["8", "11", "17", "21", "22"]
+        jvm: ["8", "11", "17", "21", "23"]
         include:
           - os: windows
             jvm: 21

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -33,14 +33,14 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
 
     // https://github.com/scalameta/scalameta/issues/2485
     lazy val coreScalaVersions = Seq(scala212, scala213)
-    lazy val cliScalaVersions = Seq(
-      scala212,
-      scala213,
-      scala33,
-      scala35,
-      scala36,
-      scala3Next
-    ).distinct
+    lazy val cliScalaVersions = {
+      val jdk = System.getProperty("java.specification.version").toDouble
+      val scala3Versions =
+        // Scala 3.5 will never support JDK 23
+        if (jdk >= 23) Seq(scala33, scala36)
+        else Seq(scala33, scala35, scala36)
+      (coreScalaVersions ++ scala3Versions :+ scala3Next).distinct
+    }
     lazy val cliScalaVersionsWithTargets: Seq[(String, TargetAxis)] =
       cliScalaVersions.map(sv => (sv, TargetAxis(sv))) ++
         Seq(scala213, scala212).flatMap { sv =>

--- a/scalafix-tests/integration/src/test/scala/scalafix/tests/interfaces/ScalafixSuite.scala
+++ b/scalafix-tests/integration/src/test/scala/scalafix/tests/interfaces/ScalafixSuite.scala
@@ -25,6 +25,8 @@ import scalafix.tests.BuildInfo
  */
 class ScalafixSuite extends AnyFunSuite {
 
+  val jdk: Double = System.getProperty("java.specification.version").toDouble
+
   val scalaVersion: String = BuildInfo.scalaVersion
 
   val repositories: java.util.List[Repository] = Seq[Repository](
@@ -117,11 +119,13 @@ class ScalafixSuite extends AnyFunSuite {
   }
 
   test("classload Scala 3.5 with full version") {
+    if (jdk >= 23) cancel("Scala 3.5 is not supported on JDK23+")
     val scalafixAPI = Scalafix.fetchAndClassloadInstance("3.5.2", repositories)
     assert(scalafixAPI.scalaVersion() == Versions.scala35)
   }
 
   test("classload Scala 3.5 with major.minor version") {
+    if (jdk >= 23) cancel("Scala 3.5 is not supported on JDK23+")
     val scalafixAPI = Scalafix.fetchAndClassloadInstance("3.5", repositories)
     assert(scalafixAPI.scalaVersion() == Versions.scala35)
   }


### PR DESCRIPTION
- [x] https://github.com/coursier/jvm-index/pull/270
- [x] https://github.com/scala/docs.scala-lang/commit/9c4b57832cc415a472104ec6ae2a7687c8b447d7 3.6.2, 3.3.5, 2.13.15 & 2.12.20
   - [x] https://github.com/scalacenter/scalafix/pull/2088 
   - [x] https://github.com/scalacenter/scalafix/pull/2183
   - [x] https://github.com/scalacenter/scalafix/pull/2052
   - [x] ~either https://github.com/scalacenter/scalafix/pull/2150 or~ remove 3.5.2 from JDK23 CI