### PR TITLE
latest scalameta introduces new items in tree hierarchy

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val metaconfigV = "0.13.0"
   val nailgunV = "0.9.1"
   val scalaXmlV = "2.2.0"
-  val scalametaV = "4.9.9+89-fb896935-SNAPSHOT"
+  val scalametaV = "4.9.9+138-31ec8cdb-SNAPSHOT"
   val scalatestV = "3.2.19"
   val munitV = "1.0.2"
 

--- a/scalafix-rules/src/main/scala-2/scalafix/internal/rule/ExplicitResultTypes.scala
+++ b/scalafix-rules/src/main/scala-2/scalafix/internal/rule/ExplicitResultTypes.scala
@@ -171,7 +171,7 @@ final class ExplicitResultTypes(
       defn.hasMod(mod"implicit") && !isImplicitly(body)
 
     def hasParentWihTemplate: Boolean =
-      defn.parent.exists(_.is[Template])
+      defn.parent.exists(_.is[Template.Body])
 
     def qualifyingImplicit: Boolean =
       isImplicit && !isFinalLiteralVal


### PR DESCRIPTION
https://github.com/scalameta/scalameta/issues/3913 adds new elements in the tree hierarchy, effectively chaning the parents of
- https://github.com/scalameta/scalameta/pull/3928 (changes needed in this PR)
  - `Template.stats` 
- https://github.com/scalameta/scalameta/pull/3916
  - `Ctor.Secondary.stats` 
 - https://github.com/scalameta/scalameta/pull/3927
   - `Type.Match.cases` 
- https://github.com/scalameta/scalameta/pull/3929
  - `Type.Refine.stats` 
  - `Type.Existential.stats` 
  - `Pkg.stats` 
  - `Template.early`
- https://github.com/scalameta/scalameta/pull/3917
  - `Term.Match.cases`
  - `Term.Try.catchp`
  - ~`Term.PartialFunction.cases`~ (reverted in https://github.com/scalameta/scalameta/pull/3937)
- https://github.com/scalameta/scalameta/pull/3925
  - `Term.For.enums`
  - `Term.ForYield.enums` 