### PR TITLE
allow to use RC versions in arguments

### DIFF
--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ScalaVersionSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ScalaVersionSuite.scala
@@ -22,7 +22,7 @@ class ScalaVersionSuite extends munit.FunSuite {
 
   test("parse: 3.0.0-RC3") {
     val scala2 = ScalaVersion.from("3.0.0-RC3")
-    assert(scala2.get == Patch(Major.Scala3, 0, 0))
+    assert(scala2.get == RC(Major.Scala3, 0, 0, 3))
   }
 
   test("parse failure: 3.0.0RC3") {


### PR DESCRIPTION
Spin off from https://github.com/scalacenter/scalafix/pull/2023 since it's no longer needed there following rebases bringing final releases, but it can be useful in the future