### PR TITLE
drop support for JDK8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu"]
-        jvm: ["8", "11", "17", "21", "22"]
+        jvm: ["11", "17", "21", "22"]
         include:
           - os: windows
             jvm: 21

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0
       - uses: coursier/setup-action@v1
         with:
-          jvm: temurin:8
+          jvm: temurin:11
       - uses: olafurpg/setup-gpg@v3
       - name: Check that major or minor was bumped upon compatibility breakage
         if: startsWith(github.ref, 'refs/tags/v')

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -8,7 +8,7 @@ title: Installation
 Scalafix is tested to work with:
 
 * **macOS, Linux or Windows**
-* **Java LTS (8, 11, 17 or 21)**
+* **Java LTS 11, 17 and 21**
 * **Scala @SCALA212@, @SCALA213@, @SCALA3LTS@ LTS or @SCALA3NEXT@**
 
 Note that other setups may work, but could result in unexpected behavior.


### PR DESCRIPTION
The latest versions of mtags-interfaces that https://github.com/scalacenter/scalafix/pull/2023 is about to bring are built with JDK11. It's [possible to work it around](https://github.com/scala/scala3/pull/20771) but considering the ecosystem is moving away from JDK8, I think it's time to say goodbye here as well.

The sbt-scalafix build will also be simplified following this.