### PR TITLE
tweak JVM options to better handle project cardinality

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,6 +1,7 @@
--Xss4m
--Xms1G
--Xmx2G
--XX:ReservedCodeCacheSize=1024m
+-Xss2m
+-Xms2G
+-Xmx4G
+-XX:ReservedCodeCacheSize=512m
+-XX:+UseG1GC
 -XX:+TieredCompilation
 -Dfile.encoding=UTF-8


### PR DESCRIPTION
Lately, we have seen many warnings like this on JDK8.
```
[warn] In the last 10 seconds, 8.954 (97.6%) were spent in GC. [Heap: 0.20GB free of 1.76GB, max 1.78GB] Consider increasing the JVM heap using `-Xmx` or try a different collector, e.g. `-XX:+UseG1GC`, for better performance.
```

The cardinality/complexity of the build has greatly increased with https://github.com/scalacenter/scalafix/pull/2034 and https://github.com/scalacenter/scalafix/pull/2023, so it's probably time for a little refresh of the JVM options.