### PR TITLE
build with and test against Scala 3.6.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,8 +30,11 @@ lazy val interfaces = project
       props.put("scalafixVersion", version.value)
       props.put("scalafixStableVersion", stableVersion.value)
       props.put("scalametaVersion", scalametaV)
-      props.put("scala213", scala213)
       props.put("scala212", scala212)
+      props.put("scala213", scala213)
+      props.put("scala33", scala33)
+      props.put("scala35", scala35)
+      props.put("scala36", scala36)
       props.put("scala3LTS", scala3LTS)
       props.put("scala3Next", scala3Next)
       val out =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,11 @@ import sbt._
 object Dependencies {
   val scala212 = sys.props.getOrElse("scala212.nightly", "2.12.20")
   val scala213 = sys.props.getOrElse("scala213.nightly", "2.13.15")
-  val scala3Next = sys.props.getOrElse("scala3.nightly", "3.5.2")
-  val scala3LTS = "3.3.4"
+  val scala33 = "3.3.4"
+  val scala35 = "3.5.2"
+  val scala36 = "3.6.2"
+  val scala3LTS = scala33
+  val scala3Next = sys.props.getOrElse("scala3.nightly", scala36)
 
   val bijectionCoreV = "0.9.8"
   val collectionCompatV = "2.12.0"

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -9,7 +9,10 @@ object Mima {
       ProblemFilters.exclude[Problem]("scalafix.internal.*"),
       ProblemFilters.exclude[Problem]("scala.meta.internal.*"),
       // Exceptions
-      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.v0.Signature#Self.syntax")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("scalafix.v0.Signature#Self.syntax"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("scalafix.interfaces.Scalafix.scala33"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("scalafix.interfaces.Scalafix.scala35"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("scalafix.interfaces.Scalafix.scala36")
     )
   }
 }

--- a/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixImpl.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixImpl.scala
@@ -34,6 +34,12 @@ final class ScalafixImpl extends Scalafix {
     Versions.scala212
   override def scala213(): String =
     Versions.scala213
+  override def scala33(): String =
+    Versions.scala33
+  override def scala35(): String =
+    Versions.scala35
+  override def scala36(): String =
+    Versions.scala36
   override def scala3LTS(): String =
     Versions.scala3LTS
   override def scala3Next(): String =

--- a/scalafix-interfaces/src/main/java/scalafix/interfaces/Scalafix.java
+++ b/scalafix-interfaces/src/main/java/scalafix/interfaces/Scalafix.java
@@ -71,6 +71,21 @@ public interface Scalafix {
     String scala213();
 
     /**
+     * The Scala 3.3 version in {@link #supportedScalaVersions()}
+     */
+    String scala33();
+
+    /**
+     * The Scala 3.5 version in {@link #supportedScalaVersions()}
+     */
+    String scala35();
+
+    /**
+     * The Scala 3.6 version in {@link #supportedScalaVersions()}
+     */
+    String scala36();
+
+    /**
      * The Scala 3 LTS version in {@link #supportedScalaVersions()}
      */
     String scala3LTS();
@@ -135,7 +150,11 @@ public interface Scalafix {
             requestedScalaMajorMinorOrMajorVersion.equals("3.1") ||
             requestedScalaMajorMinorOrMajorVersion.equals("3.2") ||
             requestedScalaMajorMinorOrMajorVersion.equals("3.3")) {
-            scalaVersionKey = "scala3LTS";
+            scalaVersionKey = "scala33";
+        } else if (requestedScalaMajorMinorOrMajorVersion.equals("3.5")) {
+            scalaVersionKey = "scala35";
+        } else if (requestedScalaMajorMinorOrMajorVersion.equals("3.6")) {
+            scalaVersionKey = "scala36";
         } else if (requestedScalaMajorMinorOrMajorVersion.startsWith("3")) {
             scalaVersionKey = "scala3Next";
         } else {

--- a/scalafix-tests/input/src/main/scala-3next/test/explicitResultTypes/Scala3_6OrGreater.scala
+++ b/scalafix-tests/input/src/main/scala-3next/test/explicitResultTypes/Scala3_6OrGreater.scala
@@ -1,0 +1,15 @@
+/*
+rules = ExplicitResultTypes
+ExplicitResultTypes.skipSimpleDefinitions = false
+*/
+package test.explicitResultTypes
+
+trait Order[T]:
+  extension (values: Seq[T]) def toSorted: Seq[T] = ???
+  def compare(x: T, y: T): Int
+
+given Order[Int]:
+  def compare(x: Int, y: Int) = ???
+
+given listOrdering: [T: Order as elementOrder] => Order[List[T]]:
+  def compare(x: List[T], y: List[T]) = elementOrder.compare(x.head, y.head)

--- a/scalafix-tests/integration/src/test/scala/scalafix/tests/interfaces/ScalafixSuite.scala
+++ b/scalafix-tests/integration/src/test/scala/scalafix/tests/interfaces/ScalafixSuite.scala
@@ -43,6 +43,9 @@ class ScalafixSuite extends AnyFunSuite {
     assert(api.scalametaVersion() == Versions.scalameta)
     assert(api.scala212() == Versions.scala212)
     assert(api.scala213() == Versions.scala213)
+    assert(api.scala33() == Versions.scala33)
+    assert(api.scala35() == Versions.scala35)
+    assert(api.scala36() == Versions.scala36)
     assert(api.scala3LTS() == Versions.scala3LTS)
     assert(api.scala3Next() == Versions.scala3Next)
     assert(
@@ -113,13 +116,23 @@ class ScalafixSuite extends AnyFunSuite {
     assert(scalafixAPI.scalaVersion() == Versions.scala3LTS)
   }
 
-  test("classload Scala 3 Next with full post-LTS version") {
-    val scalafixAPI = Scalafix.fetchAndClassloadInstance("3.4.0", repositories)
+  test("classload Scala 3.5 with full version") {
+    val scalafixAPI = Scalafix.fetchAndClassloadInstance("3.5.2", repositories)
+    assert(scalafixAPI.scalaVersion() == Versions.scala35)
+  }
+
+  test("classload Scala 3.5 with major.minor version") {
+    val scalafixAPI = Scalafix.fetchAndClassloadInstance("3.5", repositories)
+    assert(scalafixAPI.scalaVersion() == Versions.scala35)
+  }
+
+  test("classload Scala 3 Next with full version") {
+    val scalafixAPI = Scalafix.fetchAndClassloadInstance("3.6.2", repositories)
     assert(scalafixAPI.scalaVersion() == Versions.scala3Next)
   }
 
-  test("classload Scala 3 Next with major.minor post-LTS version") {
-    val scalafixAPI = Scalafix.fetchAndClassloadInstance("3.5", repositories)
+  test("classload Scala 3 Next with major.minor version") {
+    val scalafixAPI = Scalafix.fetchAndClassloadInstance("3.6", repositories)
     assert(scalafixAPI.scalaVersion() == Versions.scala3Next)
   }
 

--- a/scalafix-tests/output/src/main/scala-3next/test/explicitResultTypes/Scala3_6OrGreater.scala
+++ b/scalafix-tests/output/src/main/scala-3next/test/explicitResultTypes/Scala3_6OrGreater.scala
@@ -1,0 +1,11 @@
+package test.explicitResultTypes
+
+trait Order[T]:
+  extension (values: Seq[T]) def toSorted: Seq[T] = ???
+  def compare(x: T, y: T): Int
+
+given Order[Int]:
+  def compare(x: Int, y: Int): Int = ???
+
+given listOrdering: [T: Order as elementOrder] => Order[List[T]]:
+  def compare(x: List[T], y: List[T]): Int = elementOrder.compare(x.head, y.head)

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/InterfacesPropertiesSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/InterfacesPropertiesSuite.scala
@@ -25,6 +25,9 @@ class InterfacesPropertiesSuite extends AnyFunSuite with BeforeAndAfterAll {
   check("scalametaVersion", Versions.scalameta)
   check("scala212", Versions.scala212)
   check("scala213", Versions.scala213)
+  check("scala33", Versions.scala33)
+  check("scala35", Versions.scala35)
+  check("scala36", Versions.scala36)
   check("scala3LTS", Versions.scala3LTS)
   check("scala3Next", Versions.scala3Next)
 


### PR DESCRIPTION
Keep building for Scala 3.5 until the next minor version for backward compatibility.

- [ ] prepare PR to remove Scala 3.5 support ahead of scalafix 0.14.0

⚠️ at least https://github.com/scalacenter/scalafix/issues/2138 remains a problem