### PR TITLE
use latest scalameta for better SIP-64 support

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
   val metaconfigV = "0.14.0"
   val nailgunV = "0.9.1"
   val scalaXmlV = "2.2.0"
-  val scalametaV = "4.12.2"
+  val scalametaV = "4.12.3"
   val scalatagsV = "0.13.1"
   val scalatestV = "3.2.19"
   val munitV = "1.0.3"

--- a/scalafix-tests/input/src/main/scala-3next/test/explicitResultTypes/Scala3_6OrGreater.scala
+++ b/scalafix-tests/input/src/main/scala-3next/test/explicitResultTypes/Scala3_6OrGreater.scala
@@ -8,6 +8,9 @@ trait Order[T]:
   extension (values: Seq[T]) def toSorted: Seq[T] = ???
   def compare(x: T, y: T): Int
 
+given List[Int] => Object = new:
+  def foo() = 1
+
 given Order[Int]:
   def compare(x: Int, y: Int) = ???
 

--- a/scalafix-tests/output/src/main/scala-3next/test/explicitResultTypes/Scala3_6OrGreater.scala
+++ b/scalafix-tests/output/src/main/scala-3next/test/explicitResultTypes/Scala3_6OrGreater.scala
@@ -4,6 +4,9 @@ trait Order[T]:
   extension (values: Seq[T]) def toSorted: Seq[T] = ???
   def compare(x: T, y: T): Int
 
+given List[Int] => Object = new:
+  def foo(): Int = 1
+
 given Order[Int]:
   def compare(x: Int, y: Int): Int = ???
 


### PR DESCRIPTION
Brings in https://github.com/scalameta/scalameta/pull/4092
Fixes https://github.com/scalacenter/scalafix/issues/2138