### PR TITLE
support target files built with nightly Scala 3 compiler version

### DIFF
--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ScalaVersionSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ScalaVersionSuite.scala
@@ -22,12 +22,28 @@ class ScalaVersionSuite extends munit.FunSuite {
 
   test("parse: 2.13.16-bin-ce78754") {
     val scala2 = ScalaVersion.from("2.13.16-bin-ce78754")
-    assert(scala2.get == Nightly(Major.Scala2, 13, 16, "ce78754"))
+    assert(scala2.get == Nightly(Major.Scala2, 13, 16, None, None, "ce78754"))
+    assert(scala2.get.value == "2.13.16-bin-ce78754")
   }
 
   test("parse: 3.0.0-RC3") {
     val scala3 = ScalaVersion.from("3.0.0-RC3")
     assert(scala3.get == RC(Major.Scala3, 0, 0, 3))
+  }
+
+  test("parse: 3.6.0-RC1-bin-20241008-3408ed7-NIGHTLY") {
+    val scala3 = ScalaVersion.from("3.6.0-RC1-bin-20241008-3408ed7-NIGHTLY")
+    assert(
+      scala3.get == Nightly(
+        Major.Scala3,
+        6,
+        0,
+        Some(1),
+        Some(java.time.LocalDate.parse("2024-10-08")),
+        "3408ed7"
+      )
+    )
+    assert(scala3.get.value == "3.6.0-RC1-bin-20241008-3408ed7-NIGHTLY")
   }
 
   test("parse failure: 3.0.0RC3") {


### PR DESCRIPTION
Fixes #2112

Successfully tested locally with
```
$ sbt -Dscala3.nightly=3.6.4-RC1-bin-20241223-4d3f757-NIGHTLY expect3_6_4_RC1_bin_20241223_4d3f757_NIGHTLYTarget3_6_4-RC1-bin-20241223-4d3f757-NIGHTLY/test
...
[info] Run completed in 8 seconds, 698 milliseconds.
[info] Total number of tests run: 135
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 135, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 46 s, completed Dec 29, 2024, 9:53:37 PM
```