### PR TITLE
bump scalameta for SIP-58 & better SIP-64 syntax

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
   val metaconfigV = "0.14.0"
   val nailgunV = "0.9.1"
   val scalaXmlV = "2.2.0"
-  val scalametaV = "4.12.3"
+  val scalametaV = "4.12.4"
   val scalatagsV = "0.13.1"
   val scalatestV = "3.2.19"
   val munitV = "1.0.3"


### PR DESCRIPTION
Many bugfixes, but highlight for Scala 3.6.2 is
- https://github.com/scalameta/scalameta/pull/4105
- https://github.com/scalameta/scalameta/issues/4093