### PR TITLE
fix save-expect again

### DIFF
--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -206,7 +206,9 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
         .map { sv =>
           s"integration${asProjectSuffix(sv)} / Test / runMain scalafix.tests.util.SaveExpect"
         }
-        .mkString("all ", " ", "") :: state
+        .foldLeft(state) { (state, command) =>
+          command :: state
+        }
     },
     commands += Command.command("ci-docs") { state =>
       "docs2_13/run" :: // reduce risk of errors on deploy-website.yml


### PR DESCRIPTION
Since 3f644e7, save-expect would only run for Scala 2 despite saying it was running only for Scala 3. Better stay away from using "all" with input tasks.