### PR TITLE
ExplicitResultTypes: annotate members with symbolic names on Scala 2

### DIFF
--- a/scalafix-rules/src/main/scala-2/scalafix/internal/pc/ScalafixGlobal.scala
+++ b/scalafix-rules/src/main/scala-2/scalafix/internal/pc/ScalafixGlobal.scala
@@ -5,6 +5,7 @@ import java.{util => ju}
 
 import scala.collection.compat._
 import scala.collection.mutable
+import scala.reflect.NameTransformer
 import scala.reflect.internal.{Flags => gf}
 import scala.reflect.io.VirtualDirectory
 import scala.tools.nsc.Settings
@@ -17,7 +18,6 @@ import scala.{meta => m}
 
 import scala.meta.internal.semanticdb.scalac.SemanticdbOps
 import scala.meta.io.AbsolutePath
-import scala.reflect.NameTransformer
 
 object ScalafixGlobal {
   def newCompiler(

--- a/scalafix-rules/src/main/scala-2/scalafix/internal/pc/ScalafixGlobal.scala
+++ b/scalafix-rules/src/main/scala-2/scalafix/internal/pc/ScalafixGlobal.scala
@@ -17,6 +17,7 @@ import scala.{meta => m}
 
 import scala.meta.internal.semanticdb.scalac.SemanticdbOps
 import scala.meta.io.AbsolutePath
+import scala.reflect.NameTransformer
 
 object ScalafixGlobal {
   def newCompiler(
@@ -72,6 +73,9 @@ class ScalafixGlobal(
     import scala.meta.internal.semanticdb.Scala._
     if (!symbol.isGlobal) return Nil
 
+    def EncodedTermName(str: String): TermName = TermName(NameTransformer.encode(str))
+    def EncodedTypeName(str: String): TypeName = TypeName(NameTransformer.encode(str))
+
     def loop(s: String): List[Symbol] = {
       if (s.isNone || s.isRootPackage) rootMirror.RootPackage :: Nil
       else if (s.isEmptyPackage) rootMirror.EmptyPackage :: Nil
@@ -95,20 +99,20 @@ class ScalafixGlobal(
                 case Descriptor.None =>
                   Nil
                 case Descriptor.Type(value) =>
-                  val member = owner.info.decl(TypeName(value)) :: Nil
-                  if (sym.isJava) owner.info.decl(TermName(value)) :: member
+                  val member = owner.info.decl(EncodedTypeName(value)) :: Nil
+                  if (sym.isJava) owner.info.decl(EncodedTermName(value)) :: member
                   else member
                 case Descriptor.Term(value) =>
-                  owner.info.decl(TermName(value)) :: Nil
+                  owner.info.decl(EncodedTermName(value)) :: Nil
                 case Descriptor.Package(value) =>
-                  owner.info.decl(TermName(value)) :: Nil
+                  owner.info.decl(EncodedTermName(value)) :: Nil
                 case Descriptor.Parameter(value) =>
-                  owner.paramss.flatten.filter(_.name.containsName(value))
+                  owner.paramss.flatten.filter(_.name.containsName(EncodedTermName(value)))
                 case Descriptor.TypeParameter(value) =>
-                  owner.typeParams.filter(_.name.containsName(value))
+                  owner.typeParams.filter(_.name.containsName(EncodedTypeName(value)))
                 case Descriptor.Method(value, _) =>
                   owner.info
-                    .decl(TermName(value))
+                    .decl(EncodedTermName(value))
                     .alternatives
                     .iterator
                     .filter(sym => semanticdbSymbol(sym) == s)

--- a/scalafix-rules/src/main/scala-2/scalafix/internal/pc/ScalafixGlobal.scala
+++ b/scalafix-rules/src/main/scala-2/scalafix/internal/pc/ScalafixGlobal.scala
@@ -73,8 +73,12 @@ class ScalafixGlobal(
     import scala.meta.internal.semanticdb.Scala._
     if (!symbol.isGlobal) return Nil
 
-    def EncodedTermName(str: String): TermName = TermName(NameTransformer.encode(str))
-    def EncodedTypeName(str: String): TypeName = TypeName(NameTransformer.encode(str))
+    def EncodedTermName(str: String): TermName = TermName(
+      NameTransformer.encode(str)
+    )
+    def EncodedTypeName(str: String): TypeName = TypeName(
+      NameTransformer.encode(str)
+    )
 
     def loop(s: String): List[Symbol] = {
       if (s.isNone || s.isRootPackage) rootMirror.RootPackage :: Nil
@@ -100,16 +104,21 @@ class ScalafixGlobal(
                   Nil
                 case Descriptor.Type(value) =>
                   val member = owner.info.decl(EncodedTypeName(value)) :: Nil
-                  if (sym.isJava) owner.info.decl(EncodedTermName(value)) :: member
+                  if (sym.isJava)
+                    owner.info.decl(EncodedTermName(value)) :: member
                   else member
                 case Descriptor.Term(value) =>
                   owner.info.decl(EncodedTermName(value)) :: Nil
                 case Descriptor.Package(value) =>
                   owner.info.decl(EncodedTermName(value)) :: Nil
                 case Descriptor.Parameter(value) =>
-                  owner.paramss.flatten.filter(_.name.containsName(EncodedTermName(value)))
+                  owner.paramss.flatten.filter(
+                    _.name.containsName(EncodedTermName(value))
+                  )
                 case Descriptor.TypeParameter(value) =>
-                  owner.typeParams.filter(_.name.containsName(EncodedTypeName(value)))
+                  owner.typeParams.filter(
+                    _.name.containsName(EncodedTypeName(value))
+                  )
                 case Descriptor.Method(value, _) =>
                   owner.info
                     .decl(EncodedTermName(value))

--- a/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBase.scala
+++ b/scalafix-tests/input/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBase.scala
@@ -36,6 +36,7 @@ object ExplicitResultTypesBase {
     x + 2
   object ExtraSpace {
     def * = "abc".length
+    def ! = "abc".length
     def foo_ = "abc".length
     def `x` = "abc".length
     def `x ` = "abc".length

--- a/scalafix-tests/output/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBase.scala
+++ b/scalafix-tests/output/src/main/scala-2/test/explicitResultTypes/ExplicitResultTypesBase.scala
@@ -31,7 +31,8 @@ object ExplicitResultTypesBase {
     // comment
     x + 2
   object ExtraSpace {
-    def * = "abc".length
+    def * : Int = "abc".length
+    def ! : Int = "abc".length
     def foo_ : Int = "abc".length
     def `x`: Int = "abc".length
     def `x ` = "abc".length


### PR DESCRIPTION
TypeName / TermName constructor does not run NameTransformer. The issue was that the type had encoded names while we used plain: Ours `TermName(-)` vs `TermName($minus)`