### PR TITLE
align param name with javadoc

### DIFF
--- a/scalafix-interfaces/src/main/java/scalafix/interfaces/Scalafix.java
+++ b/scalafix-interfaces/src/main/java/scalafix/interfaces/Scalafix.java
@@ -112,8 +112,8 @@ public interface Scalafix {
      * @return An implementation of the {@link Scalafix} interface.
      * @throws ScalafixException in case of errors during artifact resolution/fetching.
      */
-    static Scalafix fetchAndClassloadInstance(String scalaBinaryVersion) throws ScalafixException {
-        return fetchAndClassloadInstance(scalaBinaryVersion, Repository.defaults());
+    static Scalafix fetchAndClassloadInstance(String requestedScalaVersion) throws ScalafixException {
+        return fetchAndClassloadInstance(requestedScalaVersion, Repository.defaults());
     }
 
     /**


### PR DESCRIPTION
Fix drift introduced in https://github.com/scalacenter/scalafix/pull/2034