### PR TITLE
remove obsolete filter

### DIFF
--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -54,10 +54,6 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
                 .getOrElse(Nil)
             previousPatchVersions
               .map { patch => s"$binaryVersion.$patch" }
-              .filterNot { v =>
-                System.getProperty("java.version").startsWith("22") &&
-                Seq("2.12.18").contains(v)
-              }
           }
 
           val prevVersions = previousVersions(sv).map(prev => TargetAxis(prev))


### PR DESCRIPTION
JDK22 is [no longer built](https://github.com/scalacenter/scalafix/pull/2075), and it seems that we can compile 2.12.18 on JDK23