### PR TITLE
spin off properties to a separate artifact

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,8 +22,8 @@ def inferJavaHome() = {
   Some(actualHome)
 }
 
-lazy val interfaces = project
-  .in(file("scalafix-interfaces"))
+lazy val properties = project
+  .in(file("scalafix-properties"))
   .settings(
     Compile / resourceGenerators += Def.task {
       val props = new java.util.Properties()
@@ -43,6 +43,16 @@ lazy val interfaces = project
       IO.write(props, "Scalafix version constants", out)
       List(out)
     },
+    moduleName := "scalafix-properties",
+    mimaPreviousArtifacts := Set.empty,
+    crossPaths := false,
+    autoScalaLibrary := false
+  )
+  .disablePlugins(ScalafixPlugin)
+
+lazy val interfaces = project
+  .in(file("scalafix-interfaces"))
+  .settings(
     (Compile / javacOptions) ++= List(
       "-Xlint:all",
       "-Werror"
@@ -56,6 +66,7 @@ lazy val interfaces = project
     autoScalaLibrary := false
   )
   .disablePlugins(ScalafixPlugin)
+  .dependsOn(properties)
 
 // Scala 3 macros vendored separately (i.e. without runtime classes), to
 // shadow Scala 2.13 macros in the Scala 3 compiler classpath, while producing


### PR DESCRIPTION
sbt-scalafix will exclude that new artifact by blocking transitive dependency of interfaces, forcing users to explicitly pick a version for runtime.

Helps for https://github.com/scalacenter/sbt-scalafix/pull/482
Towards https://github.com/scalacenter/scalafix/issues/1146