### PR TITLE
allow usage of scalafix-interfaces without scalafix-properties

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -380,7 +380,15 @@ lazy val integration = projectMatrix
           .collect { case p @ LocalProject(n) if n.startsWith("cli3") => p }
           .map(_ / publishLocalTransitive)): _*
       )
-      .value
+      .value,
+    // Mimic sbt-scalafix usage of interfaces (without properties per default)
+    // to exercise dynamic loading of latest scalafix-properties artifact
+    Test / internalDependencyClasspath := {
+      val prev = (Test / internalDependencyClasspath).value
+      val propertiesClassDirectory =
+        (properties / Compile / classDirectory).value
+      prev.filter(_.data != propertiesClassDirectory)
+    }
   )
   .defaultAxes(VirtualAxis.jvm)
   .jvmPlatformFull(cliScalaVersions)

--- a/scalafix-interfaces/src/main/java/scalafix/internal/interfaces/ScalafixCoursier.java
+++ b/scalafix-interfaces/src/main/java/scalafix/internal/interfaces/ScalafixCoursier.java
@@ -15,6 +15,21 @@ import java.util.stream.Collectors;
 
 public class ScalafixCoursier {
 
+    private static VersionListing versions(
+            List<Repository> repositories,
+            coursierapi.Module module
+    ) throws ScalafixException {
+        try {
+            return Versions.create()
+                    .withModule(module)
+                    .withRepositories(repositories.stream().toArray(Repository[]::new))
+                    .versions()
+                    .getMergedListings();
+        } catch (CoursierError e) {
+            throw new ScalafixException("Failed to list versions for " + module + " from " + repositories, e);
+        }
+    }
+
     private static FetchResult fetch(
             List<Repository> repositories,
             List<Dependency> dependencies,
@@ -42,6 +57,22 @@ public class ScalafixCoursier {
             }
         }
         return urls;
+    }
+
+    public static List<URL> latestScalafixPropertiesJars(
+            List<Repository> repositories
+    ) throws ScalafixException {
+        Module module = Module.of("ch.epfl.scala", "scalafix-properties");
+        String version = versions(repositories, module)
+                .getAvailable()
+                .stream()
+                // Ignore RC & SNAPSHOT versions
+                .filter(v -> !v.contains("-"))
+                .reduce((older, newer) -> newer)
+                .orElseThrow(() -> new ScalafixException("Could not find any stable version for " + module)); 
+
+        Dependency scalafixProperties = Dependency.of(module, version);
+        return toURLs(fetch(repositories, Collections.singletonList(scalafixProperties), ResolutionParams.create()));
     }
 
     public static List<URL> scalafixCliJars(

--- a/scalafix-interfaces/src/main/java/scalafix/internal/interfaces/ScalafixCoursier.java
+++ b/scalafix-interfaces/src/main/java/scalafix/internal/interfaces/ScalafixCoursier.java
@@ -67,7 +67,7 @@ public class ScalafixCoursier {
                 .getAvailable()
                 .stream()
                 // Ignore RC & SNAPSHOT versions
-                .filter(v -> !v.contains("-"))
+                .filter(v -> v.startsWith("0.14.2+") || !v.contains("-"))
                 .reduce((older, newer) -> newer)
                 .orElseThrow(() -> new ScalafixException("Could not find any stable version for " + module)); 
 


### PR DESCRIPTION
Helps for https://github.com/scalacenter/sbt-scalafix/pull/482
Towards https://github.com/scalacenter/scalafix/issues/1146
Follows https://github.com/scalacenter/scalafix/pull/2226

This non-deterministic fallback will allow scalafixEnable to work in sbt-scalafix even though no scalafix-interfaces was explicitly provided.