### PR TITLE
make test resilient to scala upgrades beyond 0.14.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -382,13 +382,18 @@ lazy val integration = projectMatrix
       )
       .value,
     // Mimic sbt-scalafix usage of interfaces (without properties per default)
-    // to exercise dynamic loading of latest scalafix-properties artifact
+    // to exercise dynamic loading of scalafix-properties artifact
     Test / internalDependencyClasspath := {
       val prev = (Test / internalDependencyClasspath).value
       val propertiesClassDirectory =
         (properties / Compile / classDirectory).value
       prev.filter(_.data != propertiesClassDirectory)
-    }
+    },
+    // Since tests may depend on new values, we use a system property to ScalafixCoursier
+    // to whitelist a specific SNAPSHOT version from the list of available ones
+    Test / javaOptions += s"-Dscalafix-properties.version=${version.value}",
+    Test / fork := true,
+    Test / baseDirectory := (ThisBuild / baseDirectory).value
   )
   .defaultAxes(VirtualAxis.jvm)
   .jvmPlatformFull(cliScalaVersions)

--- a/scalafix-interfaces/src/main/java/scalafix/internal/interfaces/ScalafixCoursier.java
+++ b/scalafix-interfaces/src/main/java/scalafix/internal/interfaces/ScalafixCoursier.java
@@ -63,11 +63,12 @@ public class ScalafixCoursier {
             List<Repository> repositories
     ) throws ScalafixException {
         Module module = Module.of("ch.epfl.scala", "scalafix-properties");
+        String allowedVersion = System.getProperty("scalafix-properties.version");
         String version = versions(repositories, module)
                 .getAvailable()
                 .stream()
-                // Ignore RC & SNAPSHOT versions
-                .filter(v -> v.startsWith("0.14.2+") || !v.contains("-"))
+                // Ignore RC & SNAPSHOT versions, except if explicitly requested
+                .filter(v -> !v.contains("-") || v.equals(allowedVersion))
                 .reduce((older, newer) -> newer)
                 .orElseThrow(() -> new ScalafixException("Could not find any stable version for " + module)); 
 


### PR DESCRIPTION
Follows https://github.com/scalacenter/scalafix/pull/2231
Helps for https://github.com/scalacenter/scalafix/pull/2223 & https://github.com/scalacenter/scalafix/pull/2211