### PR TITLE
Revert scalafix-properties PRs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -382,18 +382,13 @@ lazy val integration = projectMatrix
       )
       .value,
     // Mimic sbt-scalafix usage of interfaces (without properties per default)
-    // to exercise dynamic loading of scalafix-properties artifact
+    // to exercise dynamic loading of latest scalafix-properties artifact
     Test / internalDependencyClasspath := {
       val prev = (Test / internalDependencyClasspath).value
       val propertiesClassDirectory =
         (properties / Compile / classDirectory).value
       prev.filter(_.data != propertiesClassDirectory)
-    },
-    // Since tests may depend on new values, we use a system property to ScalafixCoursier
-    // to whitelist a specific SNAPSHOT version from the list of available ones
-    Test / javaOptions += s"-Dscalafix-properties.version=${version.value}",
-    Test / fork := true,
-    Test / baseDirectory := (ThisBuild / baseDirectory).value
+    }
   )
   .defaultAxes(VirtualAxis.jvm)
   .jvmPlatform(CrossVersion.full, cliScalaVersions)

--- a/build.sbt
+++ b/build.sbt
@@ -22,8 +22,8 @@ def inferJavaHome() = {
   Some(actualHome)
 }
 
-lazy val properties = project
-  .in(file("scalafix-properties"))
+lazy val interfaces = project
+  .in(file("scalafix-interfaces"))
   .settings(
     Compile / resourceGenerators += Def.task {
       val props = new java.util.Properties()
@@ -43,16 +43,6 @@ lazy val properties = project
       IO.write(props, "Scalafix version constants", out)
       List(out)
     },
-    moduleName := "scalafix-properties",
-    mimaPreviousArtifacts := Set.empty,
-    crossPaths := false,
-    autoScalaLibrary := false
-  )
-  .disablePlugins(ScalafixPlugin)
-
-lazy val interfaces = project
-  .in(file("scalafix-interfaces"))
-  .settings(
     (Compile / javacOptions) ++= List(
       "-Xlint:all",
       "-Werror"
@@ -66,7 +56,6 @@ lazy val interfaces = project
     autoScalaLibrary := false
   )
   .disablePlugins(ScalafixPlugin)
-  .dependsOn(properties)
 
 // Scala 3 macros vendored separately (i.e. without runtime classes), to
 // shadow Scala 2.13 macros in the Scala 3 compiler classpath, while producing

--- a/build.sbt
+++ b/build.sbt
@@ -380,15 +380,7 @@ lazy val integration = projectMatrix
           .collect { case p @ LocalProject(n) if n.startsWith("cli3") => p }
           .map(_ / publishLocalTransitive)): _*
       )
-      .value,
-    // Mimic sbt-scalafix usage of interfaces (without properties per default)
-    // to exercise dynamic loading of latest scalafix-properties artifact
-    Test / internalDependencyClasspath := {
-      val prev = (Test / internalDependencyClasspath).value
-      val propertiesClassDirectory =
-        (properties / Compile / classDirectory).value
-      prev.filter(_.data != propertiesClassDirectory)
-    }
+      .value
   )
   .defaultAxes(VirtualAxis.jvm)
   .jvmPlatform(CrossVersion.full, cliScalaVersions)

--- a/scalafix-interfaces/src/main/java/scalafix/interfaces/Scalafix.java
+++ b/scalafix-interfaces/src/main/java/scalafix/interfaces/Scalafix.java
@@ -163,26 +163,11 @@ public interface Scalafix {
 
         Properties properties = new Properties();
         String propertiesPath = "scalafix-interfaces.properties";
+        InputStream stream = Scalafix.class.getClassLoader().getResourceAsStream(propertiesPath);
         try {
-            InputStream stream = Scalafix.class.getClassLoader().getResourceAsStream(propertiesPath);
             properties.load(stream);
-        } catch (Exception e) {
-            System.err.println(
-                "Failed to load '" + propertiesPath +  "' from local artifact, " +
-                "falling back to fetching the latest scalafix version...");
-
-            try {
-                List<URL> jars = ScalafixCoursier.latestScalafixPropertiesJars(repositories);
-                URLClassLoader classLoader =
-                    new URLClassLoader(jars.stream().toArray(URL[]::new), null);
-                
-                InputStream stream = classLoader.getResourceAsStream(propertiesPath);
-                properties.load(stream);
-            } catch (Exception ee) {
-                throw new ScalafixException(
-                    "Failed to load '" + propertiesPath + "' from local & remote artifacts",
-                    ee);
-            }
+        } catch (IOException | NullPointerException e) {
+            throw new ScalafixException("Failed to load '" + propertiesPath + "' to lookup versions", e);
         }
 
         String scalafixVersion = properties.getProperty("scalafixVersion");

--- a/scalafix-interfaces/src/main/java/scalafix/internal/interfaces/ScalafixCoursier.java
+++ b/scalafix-interfaces/src/main/java/scalafix/internal/interfaces/ScalafixCoursier.java
@@ -63,12 +63,11 @@ public class ScalafixCoursier {
             List<Repository> repositories
     ) throws ScalafixException {
         Module module = Module.of("ch.epfl.scala", "scalafix-properties");
-        String allowedVersion = System.getProperty("scalafix-properties.version");
         String version = versions(repositories, module)
                 .getAvailable()
                 .stream()
-                // Ignore RC & SNAPSHOT versions, except if explicitly requested
-                .filter(v -> !v.contains("-") || v.equals(allowedVersion))
+                // Ignore RC & SNAPSHOT versions
+                .filter(v -> v.startsWith("0.14.2+") || !v.contains("-"))
                 .reduce((older, newer) -> newer)
                 .orElseThrow(() -> new ScalafixException("Could not find any stable version for " + module)); 
 

--- a/scalafix-interfaces/src/main/java/scalafix/internal/interfaces/ScalafixCoursier.java
+++ b/scalafix-interfaces/src/main/java/scalafix/internal/interfaces/ScalafixCoursier.java
@@ -15,21 +15,6 @@ import java.util.stream.Collectors;
 
 public class ScalafixCoursier {
 
-    private static VersionListing versions(
-            List<Repository> repositories,
-            coursierapi.Module module
-    ) throws ScalafixException {
-        try {
-            return Versions.create()
-                    .withModule(module)
-                    .withRepositories(repositories.stream().toArray(Repository[]::new))
-                    .versions()
-                    .getMergedListings();
-        } catch (CoursierError e) {
-            throw new ScalafixException("Failed to list versions for " + module + " from " + repositories, e);
-        }
-    }
-
     private static FetchResult fetch(
             List<Repository> repositories,
             List<Dependency> dependencies,
@@ -57,22 +42,6 @@ public class ScalafixCoursier {
             }
         }
         return urls;
-    }
-
-    public static List<URL> latestScalafixPropertiesJars(
-            List<Repository> repositories
-    ) throws ScalafixException {
-        Module module = Module.of("ch.epfl.scala", "scalafix-properties");
-        String version = versions(repositories, module)
-                .getAvailable()
-                .stream()
-                // Ignore RC & SNAPSHOT versions
-                .filter(v -> !v.contains("-"))
-                .reduce((older, newer) -> newer)
-                .orElseThrow(() -> new ScalafixException("Could not find any stable version for " + module)); 
-
-        Dependency scalafixProperties = Dependency.of(module, version);
-        return toURLs(fetch(repositories, Collections.singletonList(scalafixProperties), ResolutionParams.create()));
     }
 
     public static List<URL> scalafixCliJars(

--- a/scalafix-interfaces/src/main/java/scalafix/internal/interfaces/ScalafixCoursier.java
+++ b/scalafix-interfaces/src/main/java/scalafix/internal/interfaces/ScalafixCoursier.java
@@ -67,7 +67,7 @@ public class ScalafixCoursier {
                 .getAvailable()
                 .stream()
                 // Ignore RC & SNAPSHOT versions
-                .filter(v -> v.startsWith("0.14.2+") || !v.contains("-"))
+                .filter(v -> !v.contains("-"))
                 .reduce((older, newer) -> newer)
                 .orElseThrow(() -> new ScalafixException("Could not find any stable version for " + module)); 
 


### PR DESCRIPTION
The initial approach for https://github.com/scalacenter/scalafix/issues/1146 started in https://github.com/scalacenter/scalafix/pull/2226, https://github.com/scalacenter/scalafix/pull/2231 & https://github.com/scalacenter/scalafix/pull/2233 [is being revised](https://github.com/scalacenter/sbt-scalafix/pull/482#issuecomment-2817172495) in https://github.com/scalacenter/scalafix/pull/2236.

However, that PR is not ready and we want to cut a release [for 3.7.0](https://github.com/scalacenter/scalafix/pull/2211) ASAP, so this reverts the corresponding PRs since they introduced the artifact scalafix-properties that is likely to be removed and superseeded by scalafix-versions (and is not used as it was never published as a stable release). 