### PR TITLE
Update JVM versions in contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,23 +29,23 @@ sbt shell.
 
 ```sh
 # Fast unit tests for core, rules, reflect, cli & testkit.
-> unit3_3_4 / test
+> unit3_3_6 / test
 
 # Integration tests for core, rules, reflect, cli & testkit.
 # Contains a lot of different test suites, so it's recommended
 # to use testOnly and/or testQuick.
-> integration3_3_4 / test
+> integration3_3_6 / test
 
 # Use testWindows to exclude tests that are not expected to succeed
 # on that OS.
-> unit3_3_4 / testWindows
-> integration3_3_4 / testWindows
+> unit3_3_6 / testWindows
+> integration3_3_6 / testWindows
 
 # Only run tests for built-in rules, using scalafix-testkit.
-> expect3_3_4Target2_13_14 / test
+> expect3_3_6Target3_3_6 / test
 
 # Only run ProcedureSyntax unit tests.
-> expect3_3_4Target2_13_14 / testOnly -- -z ProcedureSyntax
+> expect3_3_6Target3_3_6 / testOnly -- -z ProcedureSyntax
 ```
 
 [sbt-projectmatrix](https://github.com/sbt/sbt-projectmatrix) is used to


### PR DESCRIPTION
Tests such as
```bash
> unit3_3_4 / test
```
as mentioned in `CONTRIBUTING.md` don't readily run.
```bash
sbt:scalafix> unit3_3_4 / test
[error] Expected ID character
[error] Not a valid command: unit3_3_4
[error] Expected project ID
[error] Expected configuration
[error] Expected ':'
[error] Expected key
[error] Not a valid key: unit3_3_4
[error] unit3_3_4 / test
[error]     
```
Version `3.3.4` is no longer available in the jvm versions.
![image](https://github.com/user-attachments/assets/0d22ea07-6a69-4a3a-8ded-948b0ea3de72)
