### PR TITLE
Fix compilation breaking due to collisions in Scalafix symbol replacements

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
@@ -30,7 +30,7 @@ object ReplaceSymbolOps {
   private def extractImports(stats: Seq[Stat]): Seq[Import] = {
     stats.collect { case i: Import => i }
   }
-  
+
   private def extractImportInfo(tree: Tree)(implicit index: SemanticdbIndex): ImportInfo = {
     @tailrec
     def getTopLevelImports(ast: Tree): Seq[Import] = ast match {
@@ -62,7 +62,7 @@ object ReplaceSymbolOps {
       moveSymbols: Seq[ReplaceSymbol]
   )(implicit ctx: RuleCtx, index: SemanticdbIndex): Patch = {
     if (moveSymbols.isEmpty) return Patch.empty
-    
+
     val importInfo = extractImportInfo(ctx.tree)(index)
 
     val moves: Map[String, Symbol.Global] =
@@ -172,7 +172,7 @@ object ReplaceSymbolOps {
             if (n.isDefinition || causesCollision) Patch.empty
             else ctx.addGlobalImport(to)
           if (causesCollision)
-            addImport + ctx.replaceTree(n, s"${to.owner.syntax}.${to.signature.name}")
+            addImport + ctx.replaceTree(n, to.owner.syntax + to.signature.name)
           else
             addImport + ctx.replaceTree(n, to.signature.name)
         case _ =>

--- a/scalafix-core/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
@@ -16,7 +16,7 @@ import scalafix.v0._
 object ReplaceSymbolOps {
   private case class ImportInfo(
       globalImports: Seq[Import],
-      globalImportedSymbols: Map[String, Symbol] = Map.empty
+      globalImportedSymbols: Map[String, Symbol]
   )
 
   private object Select {

--- a/scalafix-core/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
@@ -31,7 +31,7 @@ object ReplaceSymbolOps {
     stats.collect { case i: Import => i }
   }
 
-  private def getGranularImports(tree: Tree): ImportInfo = {
+  private def getGranularImports(tree: Tree)(implicit doc: SemanticDocument): ImportInfo = {
     @tailrec
     def getTopLevelImports(ast: Tree): Seq[Import] = ast match {
       case Pkg(_, Seq(pkg: Pkg)) => getTopLevelImports(pkg)
@@ -63,7 +63,7 @@ object ReplaceSymbolOps {
   )(implicit ctx: RuleCtx, index: SemanticdbIndex): Patch = {
     if (moveSymbols.isEmpty) return Patch.empty
 
-    val importInfo = getGranularImports(ctx.tree)
+    val importInfo = getGranularImports(ctx.tree)(ctx.doc)
 
     val moves: Map[String, Symbol.Global] =
       moveSymbols.iterator.flatMap {

--- a/scalafix-core/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
@@ -31,7 +31,7 @@ object ReplaceSymbolOps {
     stats.collect { case i: Import => i }
   }
   
-  private def getGranularImports(tree: Tree)(implicit index: SemanticdbIndex): ImportInfo = {
+  private def extractImportInfo(tree: Tree)(implicit index: SemanticdbIndex): ImportInfo = {
     @tailrec
     def getTopLevelImports(ast: Tree): Seq[Import] = ast match {
       case Pkg(_, Seq(pkg: Pkg)) => getTopLevelImports(pkg)
@@ -63,7 +63,7 @@ object ReplaceSymbolOps {
   )(implicit ctx: RuleCtx, index: SemanticdbIndex): Patch = {
     if (moveSymbols.isEmpty) return Patch.empty
     
-    val importInfo = getGranularImports(ctx.tree)(index)
+    val importInfo = extractImportInfo(ctx.tree)(index)
 
     val moves: Map[String, Symbol.Global] =
       moveSymbols.iterator.flatMap {

--- a/scalafix-core/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
@@ -1,5 +1,7 @@
 package scalafix.internal.patch
 
+import scala.annotation.tailrec
+
 import scala.meta._
 import scala.meta.internal.trees._
 
@@ -10,7 +12,6 @@ import scalafix.patch.Patch
 import scalafix.patch.Patch.internal.ReplaceSymbol
 import scalafix.syntax._
 import scalafix.v0._
-import scala.annotation.tailrec
 
 object ReplaceSymbolOps {
   private case class ImportInfo(

--- a/scalafix-core/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
@@ -35,15 +35,15 @@ object ReplaceSymbolOps {
       tree: Tree
   )(implicit index: SemanticdbIndex): ImportInfo = {
     @tailrec
-    def getTopLevelImports(ast: Tree): Seq[Import] = ast match {
-      case Pkg(_, Seq(pkg: Pkg)) => getTopLevelImports(pkg)
-      case Source(Seq(pkg: Pkg)) => getTopLevelImports(pkg)
+    def getGlobalImports(ast: Tree): Seq[Import] = ast match {
+      case Pkg(_, Seq(pkg: Pkg)) => getGlobalImports(pkg)
+      case Source(Seq(pkg: Pkg)) => getGlobalImports(pkg)
       case Pkg(_, stats) => extractImports(stats)
       case Source(stats) => extractImports(stats)
       case _ => Nil
     }
 
-    val globalImports = getTopLevelImports(tree)
+    val globalImports = getGlobalImports(tree)
 
     // pre-compute global imported symbols for O(1) collision detection
     // since ctx.addGlobalImport adds imports at global scope

--- a/scalafix-core/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
@@ -14,10 +14,10 @@ import scala.annotation.tailrec
 
 object ReplaceSymbolOps {
   private case class ImportInfo(
-                                 globalImports: Seq[Import],
-                                 allImports: Seq[Import] = Seq.empty,
-                                 importedSymbols: Map[String, Symbol] = Map.empty
-                               )
+      globalImports: Seq[Import],
+      allImports: Seq[Import] = Seq.empty,
+      importedSymbols: Map[String, Symbol] = Map.empty
+  )
 
   private object Select {
     def unapply(arg: Ref): Option[(Ref, Name)] = arg match {
@@ -31,7 +31,9 @@ object ReplaceSymbolOps {
     stats.collect { case i: Import => i }
   }
 
-  private def extractImportInfo(tree: Tree)(implicit index: SemanticdbIndex): ImportInfo = {
+  private def extractImportInfo(
+      tree: Tree
+  )(implicit index: SemanticdbIndex): ImportInfo = {
     @tailrec
     def getTopLevelImports(ast: Tree): Seq[Import] = ast match {
       case Pkg(_, Seq(pkg: Pkg)) => getTopLevelImports(pkg)
@@ -49,8 +51,10 @@ object ReplaceSymbolOps {
     val importedSymbols = allImports.flatMap { importStat =>
       importStat.importers.flatMap { importer =>
         importer.importees.collect {
-          case Importee.Name(name) => name.value -> name.symbol.getOrElse(Symbol.None)
-          case Importee.Rename(_, rename) => rename.value -> rename.symbol.getOrElse(Symbol.None)
+          case Importee.Name(name) =>
+            name.value -> name.symbol.getOrElse(Symbol.None)
+          case Importee.Rename(_, rename) =>
+            rename.value -> rename.symbol.getOrElse(Symbol.None)
         }
       }
     }.toMap
@@ -167,7 +171,8 @@ object ReplaceSymbolOps {
             if sig.name != parent.value =>
           Patch.empty // do nothing because it was a renamed symbol
         case Some(_) =>
-          val causesCollision = importInfo.importedSymbols.contains(to.signature.name)
+          val causesCollision =
+            importInfo.importedSymbols.contains(to.signature.name)
           val addImport =
             if (n.isDefinition || causesCollision) Patch.empty
             else ctx.addGlobalImport(to)

--- a/scalafix-tests/input/src/main/scala/test/ReplaceSymbol.scala
+++ b/scalafix-tests/input/src/main/scala/test/ReplaceSymbol.scala
@@ -31,7 +31,7 @@ patches.replaceSymbols = [
  */
 package fix
 
-import scala.collection.immutable.{SortedMap, TreeMap}
+import scala.collection.immutable.{ SortedMap, TreeMap }
 import scala.collection.mutable.HashMap
 import scala.collection.mutable.ListBuffer
 import scala.collection.mutable

--- a/scalafix-tests/input/src/main/scala/test/ReplaceSymbol.scala
+++ b/scalafix-tests/input/src/main/scala/test/ReplaceSymbol.scala
@@ -12,6 +12,8 @@ patches.replaceSymbols = [
     to = "com.geirsson.mutable.CoolBuffer" }
   { from = "scala.collection.mutable.HashMap"
     to = "com.geirsson.mutable.unsafe.CoolMap" }
+  { from = "scala.collection.immutable.TreeMap"
+    to = "com.geirsson.immutable.SortedMap" }
   { from = "scala.math.sqrt"
     to = "com.geirsson.fastmath.sqrt" }
   // normalized symbol renames all overloaded methods
@@ -29,6 +31,7 @@ patches.replaceSymbols = [
  */
 package fix
 
+import scala.collection.immutable.{SortedMap, TreeMap}
 import scala.collection.mutable.HashMap
 import scala.collection.mutable.ListBuffer
 import scala.collection.mutable
@@ -42,6 +45,7 @@ object ReplaceSymbol {
   "blah".substring(1)
   "blah".substring(1, 2)
   val u: mutable.HashMap[Int, Int] = HashMap.empty[Int, Int]
+  val v: SortedMap[Int, Int] = TreeMap.empty[Int, Int]
   val x: ListBuffer[Int] = ListBuffer.empty[Int]
   val y: mutable.ListBuffer[Int] = mutable.ListBuffer.empty[Int]
   val z: scala.collection.mutable.ListBuffer[Int] =

--- a/scalafix-tests/output/src/main/scala/com/geirsson/immutable.scala
+++ b/scalafix-tests/output/src/main/scala/com/geirsson/immutable.scala
@@ -1,0 +1,11 @@
+package com.geirsson
+
+import scala.collection.immutable.TreeMap
+
+object immutable {
+  type SortedMap[A, B] = TreeMap[A, B]
+
+  object SortedMap {
+    def empty[A : Ordering, B]: SortedMap[A, B] = TreeMap.empty[A, B]
+  }
+}

--- a/scalafix-tests/output/src/main/scala/test/ReplaceSymbol.scala
+++ b/scalafix-tests/output/src/main/scala/test/ReplaceSymbol.scala
@@ -1,11 +1,11 @@
 package fix
 
+import scala.collection.immutable.SortedMap
 import com.geirsson.Future
 import com.geirsson.{ fastmath, mutable }
 import com.geirsson.mutable.{ CoolBuffer, unsafe }
 import com.geirsson.mutable.unsafe.CoolMap
 
-import scala.collection.immutable.SortedMap
 object ReplaceSymbol {
   Future.successful(1 + 2)
   fastmath.sqrt(9)

--- a/scalafix-tests/output/src/main/scala/test/ReplaceSymbol.scala
+++ b/scalafix-tests/output/src/main/scala/test/ReplaceSymbol.scala
@@ -1,10 +1,10 @@
 package fix
-
 import com.geirsson.Future
-import com.geirsson.{ fastmath, mutable }
-import com.geirsson.mutable.{ CoolBuffer, unsafe }
+import com.geirsson.{fastmath, mutable}
+import com.geirsson.mutable.{CoolBuffer, unsafe}
 import com.geirsson.mutable.unsafe.CoolMap
 
+import scala.collection.immutable.SortedMap
 object ReplaceSymbol {
   Future.successful(1 + 2)
   fastmath.sqrt(9)
@@ -13,6 +13,7 @@ object ReplaceSymbol {
   "blah".substringFrom(1)
   "blah".substringBetween(1, 2)
   val u: unsafe.CoolMap[Int, Int] = CoolMap.empty[Int, Int]
+  val v: SortedMap[Int, Int] = com.geirsson.immutable.SortedMap.empty[Int, Int]
   val x: CoolBuffer[Int] = CoolBuffer.empty[Int]
   val y: mutable.CoolBuffer[Int] = mutable.CoolBuffer.empty[Int]
   val z: com.geirsson.mutable.CoolBuffer[Int] =

--- a/scalafix-tests/output/src/main/scala/test/ReplaceSymbol.scala
+++ b/scalafix-tests/output/src/main/scala/test/ReplaceSymbol.scala
@@ -1,7 +1,7 @@
 package fix
 import com.geirsson.Future
-import com.geirsson.{fastmath, mutable}
-import com.geirsson.mutable.{CoolBuffer, unsafe}
+import com.geirsson.{ fastmath, mutable }
+import com.geirsson.mutable.{ CoolBuffer, unsafe }
 import com.geirsson.mutable.unsafe.CoolMap
 
 import scala.collection.immutable.SortedMap

--- a/scalafix-tests/output/src/main/scala/test/ReplaceSymbol.scala
+++ b/scalafix-tests/output/src/main/scala/test/ReplaceSymbol.scala
@@ -1,4 +1,5 @@
 package fix
+
 import com.geirsson.Future
 import com.geirsson.{ fastmath, mutable }
 import com.geirsson.mutable.{ CoolBuffer, unsafe }


### PR DESCRIPTION
Fixes https://github.com/scalacenter/scalafix/issues/1305
Supersedes https://github.com/scalacenter/scalafix/pull/1695

I attempted to finish the PR. It is not perfect, but I tried taking into account reviews that were "simple" to tackle such as https://github.com/scalacenter/scalafix/pull/1695#discussion_r997448965, https://github.com/scalacenter/scalafix/pull/1695#discussion_r997430821 and https://github.com/scalacenter/scalafix/pull/1695#discussion_r997446650, and also implementing the collision detection in O(1) by pre-computing the map for global imported symbols, instead of O(n) lookup for each symbol replacement during collision checking.