### PR TITLE
docs: document how to pass multiple values for CLI flags (e.g. --scalac-options)

### DIFF
--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -443,6 +443,23 @@ cs launch scalafix:0.13.0 -- --version # Should say 0.13.0
 
 ```
 
+### Multiple values for CLI flags
+
+Some Scalafix CLI flags accept more than one value (for example `--rules`,
+`--files`, or compiler options). Pass each value by repeating the flag instead
+of trying to comma-separate or space-separate them. For instance, when you need
+to forward several scalac options you would write:
+
+```
+scalafix \
+  --rules RemoveUnused \
+  --scalac-options -Wunused:imports \
+  --scalac-options -Wvalue-discard
+```
+
+The CLI treats those repeated occurrences as a list, so both compiler options
+are forwarded to each Scalafix invocation.
+
 ## Support in other build tools
 
 Scalafix is supported in other build tools via externally maintained plugins:


### PR DESCRIPTION
Fixes #970

This PR updates the installation documentation to explain how to pass multiple
values to a single CLI parameter (e.g. using repeated flags like:
--scalac-options A --scalac-options B).

This helps users avoid common mistakes such as comma-separated or quoted lists.
