### PR TITLE
Add `dialectOverride` to `.scalafix.conf`

### DIFF
--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ScalafixConfigSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ScalafixConfigSuite.scala
@@ -18,4 +18,24 @@ class ScalafixConfigSuite extends munit.FunSuite {
     "groupImportsByPrefix = true",
     ScalafixConfig(groupImportsByPrefix = true)
   )
+
+  test("dialectOverride allowCaptureChecking") {
+    val config = "dialectOverride.allowCaptureChecking = true"
+    val obtained = Conf.parseString(config).get.as[ScalafixConfig].get
+    assert(obtained.dialect.allowCaptureChecking)
+  }
+
+  test("dialectOverride invalid key") {
+    val config = "dialectOverride.invalidKey = true"
+    val obtained = Conf.parseString(config).get.as[ScalafixConfig].get
+    assertEquals(obtained.dialect, scala.meta.dialects.Scala213)
+  }
+
+  test("dialectOverride invalid value") {
+    val config = "dialectOverride.allowCaptureChecking = foo"
+    val error = intercept[NoSuchElementException] {
+      Conf.parseString(config).get.as[ScalafixConfig].get
+    }
+    assert(error.getMessage.contains("error: Type mismatch"))
+  }
 }


### PR DESCRIPTION
same as scalafmt

https://github.com/scalameta/scalafmt/blob/563f4ae766f65dd49a0610fdbbbf326ddd7ae592/docs/configuration.md#runnerdialectoverride