### PR TITLE
Docs/improve cli website

### DIFF
--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -436,7 +436,6 @@ cs launch ch.epfl.scala::scalafix-cli:latest.release \
   -M scalafix.cli.Cli \
   --scala-version 2.11
 
-````
 
 > If you plan to use advanced semantic rules like `ExplicitResultTypes`, you
 > must use the version of Scalafix built with a Scala version matching your


### PR DESCRIPTION
This PR improves the command-line documentation by adding a concrete example
and explanation for running scalafix-cli with a specific Scala binary version
(e.g. Scala 2.11), as requested in issue #1175.

Fixes #1175
