### PR TITLE
Scalameta: upgrade to v4.14.7

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val metaconfigV = "0.18.2"
   val nailgunV = "0.9.1"
   val scalaXmlV = "2.4.0"
-  val scalametaV = "4.14.5"
+  val scalametaV = "4.14.7"
   val scalatagsV = "0.13.1"
   val scalatestV = "3.2.19"
   val munitV = "1.2.2"


### PR DESCRIPTION
Supercedes #2362 after rebasing.

Closes #2362.