### PR TITLE
Bump jgit version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
   val coursierInterfaceV = "1.0.28"
   val commontTextV = "1.15.0"
   val googleDiffV = "1.3.0"
-  val jgitV = "5.13.5.202508271544-r"
+  val jgitV = "7.6.0.202603022253-r"
   val metaconfigV = "0.18.4"
   val nailgunV = "0.9.1"
   val scalaXmlV = "2.4.0"


### PR DESCRIPTION
In 7.0.0, jgit started supporting git work trees.  I've been using this workflow a lot lately and am used to relying on `scalafix --diff` but that doesn't work when you're in a worktree.  It doesn't think you're in a git repo.