### PR TITLE
TokenListSuite: use parse before tokens

### DIFF
--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/util/TokenListSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/util/TokenListSuite.scala
@@ -14,7 +14,7 @@ class TokenListSuite extends AnyFunSuite {
       |
       |object Bar {
       | val baz   =   10
-      |}""".stripMargin.tokenize.get
+      |}""".stripMargin.parse[Source].get.tokens
   val tokenList: TokenList = TokenList(tokens)
 
   val unknownToken = new Token.EOF(Input.None, Scala212)


### PR DESCRIPTION
In scalameta v4.16.0, one must provide an implicit Tokenize instance if not parsing.