### PR TITLE
SemanticRuleSuite: optionally strip config comment

### DIFF
--- a/scalafix-testkit/src/main/scala/scalafix/testkit/AbstractSemanticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/AbstractSemanticRuleSuite.scala
@@ -3,7 +3,6 @@ package scalafix.testkit
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
-import scala.meta._
 import scala.meta.internal.io.FileIO
 
 import org.scalatest.BeforeAndAfterAll
@@ -52,8 +51,7 @@ abstract class AbstractSemanticRuleSuite(
       res.fixed,
       "fixed from tokenPatchApply differs from fixed2 from rule.semanticPatch"
     )
-    val tokens = fixed.tokenize.get
-    val obtained = SemanticRuleSuite.stripTestkitComments(tokens)
+    val obtained = SemanticRuleSuite.stripTestkitComments(fixed)
     val expected = diffTest.path.resolveOutput(props) match {
       case Right(file) =>
         FileIO.slurp(file, StandardCharsets.UTF_8)

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/RuleTest.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/RuleTest.scala
@@ -28,7 +28,11 @@ object RuleTest {
       val dialect = args.scalaVersion.dialect(args.sourceScalaVersion)
       val tree = dialect(input).parse[Source].get
       val (_, conf, rulesConf, scalafixConfig) =
-        SemanticRuleSuite.parseTestkitComment(tree.tokens)
+        SemanticRuleSuite.parseTestkitCommentOpt(tree.tokens).getOrElse {
+          throw new IllegalArgumentException(
+            s"Missing /* */ comment with rules attribute in $input"
+          )
+        }
       val doc = v1.SyntacticDocument(
         tree.pos.input,
         LazyValue.now(tree),

--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
@@ -28,7 +28,7 @@ object SemanticRuleSuite {
     stripTestkitComments(input.tokenize.get)
 
   def stripTestkitComments(tokens: Tokens): String = {
-    val configComment = findTestkitComment(tokens)
+    val configComment = parseTestkitCommentOpt(tokens).fold(null: Token)(_._1)
     tokens.filter {
       case `configComment` => false
       case EndOfLineAssertExtractor(_) => false
@@ -43,34 +43,44 @@ object SemanticRuleSuite {
   def parseTestkitComment(
       tokens: Tokens
   ): (Token, Conf, Conf, ScalafixConfig) = {
-    def extractTestkitHints(comment: Token) = {
-      val syntax = comment.syntax.stripPrefix("/*").stripSuffix("*/")
-      for {
-        conf <- Try(Conf.parseString("comment", syntax)).toOption
-          .flatMap(_.toEither.toOption)
-        rulesConf <-
-          ConfGet
-            .getOrElse(
-              Configured.ok,
-              ConfError.message("").notOk
-            )(conf, "rules" :: "rule" :: Nil)
-            .toEither
-            .toOption
-        scalafixConfig <- conf.as[ScalafixConfig].toEither.toOption
-      } yield (comment, conf, rulesConf, scalafixConfig)
+    parseTestkitCommentOpt(tokens).getOrElse {
+      val input = tokens.headOption.fold("the file")(_.input.syntax)
+      throw new IllegalArgumentException(
+        s"Missing /* */ comment with rules attribute in $input"
+      )
+    }
+  }
+
+  private[scalafix] def parseTestkitCommentOpt(
+      tokens: Tokens
+  ): Option[(Token.Comment, Conf, Conf, ScalafixConfig)] = {
+    def extractTestkitHints(token: Token) = token match {
+      case comment: Token.Comment =>
+        val origSyntax = comment.syntax
+        val syntaxNoPrefix = origSyntax.stripPrefix("/*")
+        if (origSyntax eq syntaxNoPrefix) None
+        else {
+          val syntax = syntaxNoPrefix.stripSuffix("*/")
+          for {
+            conf <- Try(Conf.parseString("comment", syntax)).toOption
+              .flatMap(_.toEither.toOption)
+            rulesConf <- ConfGet
+              .getOrElse(
+                Configured.ok,
+                ConfError.empty.notOk
+              )(conf, "rules" :: "rule" :: Nil)
+              .toEither
+              .toOption
+            scalafixConfig <- conf.as[ScalafixConfig].toEither.toOption
+          } yield (comment, conf, rulesConf, scalafixConfig)
+        }
+      case _ => None
     }
 
     // It is possible to have comments which are not valid HOCON with
     // rules (i.e. license headers), so lets parse until we find one
-    tokens
-      .filter(token => token.is[Token.Comment] && token.syntax.startsWith("/*"))
-      .collectFirst(Function.unlift(extractTestkitHints))
-      .getOrElse {
-        val input = tokens.headOption.fold("the file")(_.input.syntax)
-        throw new IllegalArgumentException(
-          s"Missing /* */ comment with rules attribute in $input"
-        )
-      }
+    val iter = tokens.iterator.flatMap(extractTestkitHints)
+    if (iter.hasNext) Some(iter.next()) else None
   }
 
 }


### PR DESCRIPTION
Some rules might have already stripped it if this is called after they had been applied.