### PR TITLE
OrganizeImports: preserve comments, too

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/patch/Patch.scala
+++ b/scalafix-core/src/main/scala/scalafix/patch/Patch.scala
@@ -82,6 +82,10 @@ object Patch {
 
   /** Remove all of the these tokens from the source file. */
   def removeTokens(tokens: Iterable[Token]): Patch =
+    removeTokens(tokens.iterator)
+
+  /** Remove all of the these tokens from the source file. */
+  def removeTokens(tokens: Iterator[Token]): Patch =
     tokens.foldLeft(Patch.empty)(_ + Remove(_))
 
   /** Remove this single token from the source file. */

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -715,7 +715,59 @@ class OrganizeImports(
   private def prettyPrintImportGroups(
       groups: Seq[ImportGroup]
   ): Seq[(Int, Seq[String])] = {
-    groups.map(g => g.index -> g.imports.map("import " + treeSyntax(_)))
+    groups.map { group =>
+      val res = Seq.newBuilder[String]
+
+      group.imports.foreach { i =>
+        val sb = new StringBuilder
+
+        val single =
+          if (i.importees.lengthCompare(1) == 0) i.importees.head else null
+
+        sb.append("import ").append(treeSyntax(i.ref)).append('.')
+        if (single != null) {
+          val isCurly = single.isCurlyBraced
+          val useOuterSpace = isCurly && single
+            .originalPrototype()
+            .parent
+            .exists(_.hasSpaceInCurly)
+          if (isCurly) {
+            sb.append('{')
+            if (useOuterSpace) sb.append(' ')
+          }
+          sb.append(treeSyntax(single))
+          if (isCurly) {
+            if (useOuterSpace) sb.append(' ')
+            sb.append('}')
+          }
+        } else {
+          val lines = i.importees.iterator.map(_.pos.startLine).filter(_ >= 0)
+          val isMultiline = lines.hasNext && {
+            val line = lines.next()
+            lines.exists(_ != line)
+          }
+          val useOuterSpace = !isMultiline && i.importees
+            .flatMap(_.originalPrototype().parent)
+            .distinct
+            .exists(_.hasSpaceInCurly)
+          sb.append('{')
+          val sep = if (isMultiline) "\n  " else " "
+          if (isMultiline) sb.append(sep)
+          else if (useOuterSpace) sb.append(' ')
+          val sblen = sb.length
+          i.importees.foreach { i2 =>
+            if (sb.length > sblen) sb.append(',').append(sep)
+            sb.append(treeSyntax(i2))
+          }
+          if (isMultiline) sb.append('\n')
+          else if (useOuterSpace) sb.append(' ')
+          sb.append('}')
+        }
+        res += sb.toString()
+      }
+
+      group.index -> res.result()
+    }
   }
 
 }
@@ -1090,6 +1142,30 @@ object OrganizeImports {
     def hasGivenAll: Boolean =
       importer.importees.exists(_.is[Importee.GivenAll]) &&
         !importer.importees.exists(_.is[Importee.Unimport])
+
+    def hasSpaceInCurly: Boolean = {
+      def lspace: Boolean = {
+        val tokens = importer.importees.head.tokens
+        val idx = tokens.rskipWideIf(_.is[Token.HTrivia], -1)
+        idx < -1 &&
+        tokens.getWideOpt(idx).exists(_.is[Token.LeftBrace])
+      }
+      def rspace: Boolean = {
+        val tokens = importer.importees.last.tokens
+        val idx = tokens.skipWideIf(_.is[Token.HTrivia], tokens.length)
+        idx > tokens.length &&
+        tokens.getWideOpt(idx).exists(_.is[Token.RightBrace])
+      }
+      lspace || rspace
+    }
+
+  }
+
+  implicit private class TreeExtension(val tree: Tree) extends AnyVal {
+    def hasSpaceInCurly: Boolean = tree match {
+      case i: Importer => i.hasSpaceInCurly
+      case _ => false
+    }
   }
 
 }

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -141,12 +141,15 @@ class OrganizeImports(
     )
 
     // Builds a patch that removes all the tokens forming the original imports.
-    val removalPatch = Patch.removeTokens(
-      doc.tree.tokens.slice(
-        imports.head.tokens.start,
-        imports.last.tokens.end
-      )
-    )
+    val removalPatch = Patch.removeTokens {
+      val importsWithComments = Seq.newBuilder[Tokens]
+      imports.foreach { x =>
+        importsWithComments += x.tokens
+        x.begComment.foreach(importsWithComments += _.tokens)
+        x.endComment.foreach(importsWithComments += _.tokens)
+      }
+      Tokens.merge(importsWithComments.result(): _*).iterator.flatten
+    }
 
     (insertionPatch + removalPatch).atomic
   }
@@ -715,15 +718,42 @@ class OrganizeImports(
   private def prettyPrintImportGroups(
       groups: Seq[ImportGroup]
   ): Seq[(Int, Seq[String])] = {
-    groups.map { group =>
+    // within each group, for each Importer, get a list of Imports its Importees come from
+    // after re-assembly, an Importer might contain Importees from different Imports
+    // NB: to find Imports, need to trace parents of the original parsed tree
+    val groupsWithImports = groups.map { ig =>
+      ig.index -> ig.imports.map { i1 =>
+        val i1o = i1.originalPrototype()
+        val i1p = i1o.parent.filter(_.hasComments)
+        val i2ps = i1.importees.flatMap { i2 =>
+          val i2p = i2.originalPrototype().parent.getOrElse(i1o)
+          if (i2p eq i1o) None else i2p.parent.filter(_.hasComments)
+        }
+        (i1, i1p.fold(i2ps)(_ :: i2ps).distinct)
+      }
+    }
+
+    // make sure to print each comment only once
+    val commentsPrinted = mutable.Set.empty[Tree.Comments]
+    groupsWithImports.map { case (index, ig) =>
       val res = Seq.newBuilder[String]
 
-      group.imports.foreach { i =>
+      def appendBegComment(pc: Tree.Comments): Unit =
+        if (commentsPrinted.add(pc))
+          pc.values.foreach(x => res += x.syntax)
+
+      ig.foreach { case (i, ps) =>
         val sb = new StringBuilder
+        def appendEndComment(pc: Tree.Comments): Unit =
+          if (commentsPrinted.add(pc))
+            pc.values.foreach(x => sb.append(' ').append(x.syntax))
 
         val single =
           if (i.importees.lengthCompare(1) == 0) i.importees.head else null
 
+        ps.foreach(_.begComment.foreach(appendBegComment))
+        i.begComment.foreach(appendBegComment)
+        if (single != null) single.begComment.foreach(appendBegComment)
         sb.append("import ").append(treeSyntax(i.ref)).append('.')
         if (single != null) {
           val isCurly = single.isCurlyBraced
@@ -740,6 +770,7 @@ class OrganizeImports(
             if (useOuterSpace) sb.append(' ')
             sb.append('}')
           }
+          single.endComment.foreach(appendEndComment)
         } else {
           val lines = i.importees.iterator.map(_.pos.startLine).filter(_ >= 0)
           val isMultiline = lines.hasNext && {
@@ -757,16 +788,21 @@ class OrganizeImports(
           val sblen = sb.length
           i.importees.foreach { i2 =>
             if (sb.length > sblen) sb.append(',').append(sep)
+            val proto = i2.originalPrototype()
+            proto.begComment.foreach(appendBegComment)
             sb.append(treeSyntax(i2))
+            proto.endComment.foreach(appendEndComment)
           }
           if (isMultiline) sb.append('\n')
           else if (useOuterSpace) sb.append(' ')
           sb.append('}')
         }
+        i.endComment.foreach(appendEndComment)
+        ps.foreach(_.endComment.foreach(appendEndComment))
         res += sb.toString()
       }
 
-      group.index -> res.result()
+      index -> res.result()
     }
   }
 

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -718,45 +718,6 @@ class OrganizeImports(
     groups.map(g => g.index -> g.imports.map("import " + treeSyntax(_)))
   }
 
-  implicit private class ImporterExtension(importer: Importer) {
-
-    /**
-     * Checks whether the `Importer` should be curly-braced when pretty-printed.
-     */
-    def isCurlyBraced: Boolean = {
-      val importees @ Importees(_, renames, unimports, _, _, _) =
-        importer.importees
-
-      importees.length > 1 ||
-      ((renames.length == 1 || unimports.length == 1) && !targetDialect.allowAsForImportRename)
-    }
-
-    /**
-     * Returns an `Importer` with all the `Importee`s that are selected from the
-     * input `Importer` and satisfy a predicate. If all the `Importee`s are
-     * selected, the input `Importer` instance is returned to preserve the
-     * original source level formatting. If none of the `Importee`s are
-     * selected, returns a `None`.
-     */
-    def filterImportees(f: Importee => Boolean): Option[Importer] = {
-      val filtered = importer.importees filter f
-      if (filtered.length == importer.importees.length) Some(importer)
-      else if (filtered.isEmpty) None
-      else Some(importer.copy(importees = filtered))
-    }
-
-    /** Returns true if the `Importer` contains a standalone wildcard. */
-    def hasWildcard: Boolean = {
-      val Importees(_, _, unimports, _, _, wildcard) = importer.importees
-      unimports.isEmpty && wildcard.nonEmpty
-    }
-
-    /** Returns true if the `Importer` contains a standalone given wildcard. */
-    def hasGivenAll: Boolean = {
-      val Importees(_, _, unimports, _, givenAll, _) = importer.importees
-      unimports.isEmpty && givenAll.nonEmpty
-    }
-  }
 }
 
 object OrganizeImports {
@@ -1084,5 +1045,51 @@ object OrganizeImports {
   @inline
   private def treeSyntax(tree: Tree)(implicit dialect: Dialect): String =
     tree.reprint()
+
+  implicit private class ImporteeExtension(val importee: Importee)
+      extends AnyVal {
+
+    /**
+     * Checks whether the `Importee` should be curly-braced when pretty-printed.
+     */
+    def isCurlyBraced(implicit dialect: Dialect): Boolean =
+      !dialect.allowAsForImportRename &&
+        importee.isAny[Importee.Rename, Importee.Unimport]
+  }
+
+  implicit private class ImporterExtension(val importer: Importer)
+      extends AnyVal {
+
+    /**
+     * Checks whether the `Importer` should be curly-braced when pretty-printed.
+     */
+    def isCurlyBraced(implicit dialect: Dialect): Boolean =
+      importer.importees.lengthCompare(1) != 0 ||
+        importer.importees.head.isCurlyBraced
+
+    /**
+     * Returns an `Importer` with all the `Importee`s that are selected from the
+     * input `Importer` and satisfy a predicate. If all the `Importee`s are
+     * selected, the input `Importer` instance is returned to preserve the
+     * original source level formatting. If none of the `Importee`s are
+     * selected, returns a `None`.
+     */
+    def filterImportees(f: Importee => Boolean): Option[Importer] = {
+      val filtered = importer.importees filter f
+      if (filtered.length == importer.importees.length) Some(importer)
+      else if (filtered.isEmpty) None
+      else Some(importer.copy(importees = filtered))
+    }
+
+    /** Returns true if the `Importer` contains a standalone wildcard. */
+    def hasWildcard: Boolean =
+      importer.importees.exists(_.is[Importee.Wildcard]) &&
+        !importer.importees.exists(_.is[Importee.Unimport])
+
+    /** Returns true if the `Importer` contains a standalone given wildcard. */
+    def hasGivenAll: Boolean =
+      importer.importees.exists(_.is[Importee.GivenAll]) &&
+        !importer.importees.exists(_.is[Importee.Unimport])
+  }
 
 }

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/InlineCommentBlockStyle.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/InlineCommentBlockStyle.scala
@@ -1,0 +1,32 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports.removeUnused = false
+ */
+
+package test.organizeImports
+
+import z.Z /* block comment for Z */
+
+import a.A /* block comment for A */
+
+import b.B
+
+/* XYP */
+import
+  /* Xbeg */ x.X, /* Xend */
+  /* Ybeg */ y.Y, /* Yend */
+  /* Pbeg */ other.P /* Pend */
+
+/* zbeg */
+import z.{
+  /* Z1beg */
+  Z1 => Z_1, /* Z1end */
+  /* Z2beg */
+  Z2 => Z_2, /* Z2end */
+  /* Z3beg */
+  Z3 => Z_3 /* Z3end */
+} /* zend */
+
+object InlineCommentBlockStyle {
+  val keep = 1
+}

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/InlineCommentLeading.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/InlineCommentLeading.scala
@@ -1,0 +1,18 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports.removeUnused = false
+ */
+
+package test.organizeImports
+
+// Leading comment for Z
+import z.Z
+
+// Leading comment for A
+import a.A
+
+import b.B
+
+object InlineCommentLeading {
+  val keep = 1
+}

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/InlineCommentMixed.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/InlineCommentMixed.scala
@@ -1,0 +1,14 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports.removeUnused = false
+ */
+
+package test.organizeImports
+
+import z.Z // trailing line comment
+import b.B /* trailing block comment */
+import a.A
+
+object InlineCommentMixed {
+  val keep = 1
+}

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/InlineCommentMoves.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/InlineCommentMoves.scala
@@ -1,0 +1,15 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports.removeUnused = false
+ */
+
+package test.organizeImports
+
+import z.Z // commentZ
+
+import a.A
+
+object InlineCommentMoves {
+  val keep = (null: AnyRef)
+}
+

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/InlineCommentMultiple.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/InlineCommentMultiple.scala
@@ -1,0 +1,17 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports.removeUnused = false
+ */
+
+package test.organizeImports
+
+import b.B // bnote
+
+import a.A // anote
+
+import c.C
+
+object InlineCommentMultiple {
+  val keep = 1
+}
+

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/InlineCommentRemoved.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/InlineCommentRemoved.scala
@@ -1,0 +1,15 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports.removeUnused = true
+ */
+
+package test.organizeImports
+
+import my.pkg.K // noteK
+
+import other.P
+
+object InlineCommentRemoved {
+  val keep: P = null.asInstanceOf[P]
+}
+

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/InlineCommentRemovedBlock.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/InlineCommentRemovedBlock.scala
@@ -1,0 +1,12 @@
+/*
+rules = [OrganizeImports]
+ */
+
+package test.organizeImports
+
+import my.pkg.K /* this unused import and comment should be removed */
+import other.P // this used import and comment should stay
+
+object InlineCommentRemovedBlock {
+  val keep: P = null.asInstanceOf[P]
+}

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/InlineCommentSlcStyle.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/InlineCommentSlcStyle.scala
@@ -1,0 +1,35 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports.removeUnused = false
+ */
+
+package test.organizeImports
+
+import z.Z // Z
+
+import a.A // A
+
+import b.B
+
+// XYP
+import
+  // Xbeg
+  x.X, // Xend
+  // Ybeg
+  y.Y, // Yend
+  // Pbeg
+  other.P // Pend
+
+// zbeg
+import z.{
+  // Z1beg
+  Z1 => Z_1, // Z1end
+  // Z2beg
+  Z2 => Z_2, // Z2end
+  // Z3beg
+  Z3 => Z_3 // Z3end
+} // zend
+
+object InlineCommentSlcStyle {
+  val keep = 1
+}

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/StandaloneComment.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/StandaloneComment.scala
@@ -1,0 +1,15 @@
+/*
+rules = [OrganizeImports]
+ */
+
+package test.organizeImports
+
+// This comment is ambiguous and not linked to a specific import
+import y.Y
+import x.X
+
+object StandaloneComment {
+  val keep = new X
+  val alsoKeep = new Y
+}
+

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/MultiLineImportsWithAliasesAndWildcard.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/MultiLineImportsWithAliasesAndWildcard.scala
@@ -2,6 +2,7 @@ package test.organizeImports
 
 // Line 14 equivalent: wildcard import from same package as multi-line renames
 import scala.collection.immutable.*
+// Multi-line renames from same package: already sorted, should preserve format
 import scala.collection.immutable.{
   ArraySeq as ASeq,
   HashMap as HMap,

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentBlockStyle.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentBlockStyle.scala
@@ -1,0 +1,15 @@
+package test.organizeImports
+
+import a.A
+import b.B
+import other.P
+import x.X
+import y.Y
+import z.Z
+import z.{ Z1 => Z_1 }
+import z.{Z2 => Z_2}
+import z.{ Z3 => Z_3 } /* zend */
+
+object InlineCommentBlockStyle {
+  val keep = 1
+}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentBlockStyle.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentBlockStyle.scala
@@ -6,9 +6,9 @@ import other.P
 import x.X
 import y.Y
 import z.Z
-import z.{ Z1 => Z_1 }
+import z.{Z1 => Z_1}
 import z.{Z2 => Z_2}
-import z.{ Z3 => Z_3 } /* zend */
+import z.{Z3 => Z_3} /* zend */
 
 object InlineCommentBlockStyle {
   val keep = 1

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentBlockStyle.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentBlockStyle.scala
@@ -1,14 +1,22 @@
 package test.organizeImports
 
-import a.A
+import a.A /* block comment for A */
 import b.B
-import other.P
-import x.X
-import y.Y
-import z.Z
-import z.{Z1 => Z_1}
-import z.{Z2 => Z_2}
-import z.{Z3 => Z_3} /* zend */
+/* XYP */
+/* Pbeg */
+import other.P /* Pend */
+/* Xbeg */
+import x.X /* Xend */
+/* Ybeg */
+import y.Y /* Yend */
+import z.Z /* block comment for Z */
+/* zbeg */
+/* Z1beg */
+import z.{Z1 => Z_1} /* Z1end */ /* zend */
+/* Z2beg */
+import z.{Z2 => Z_2} /* Z2end */
+/* Z3beg */
+import z.{Z3 => Z_3} /* Z3end */
 
 object InlineCommentBlockStyle {
   val keep = 1

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentLeading.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentLeading.scala
@@ -1,0 +1,10 @@
+package test.organizeImports
+
+// Leading comment for Z
+import a.A
+import b.B
+import z.Z
+
+object InlineCommentLeading {
+  val keep = 1
+}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentLeading.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentLeading.scala
@@ -1,8 +1,9 @@
 package test.organizeImports
 
-// Leading comment for Z
+// Leading comment for A
 import a.A
 import b.B
+// Leading comment for Z
 import z.Z
 
 object InlineCommentLeading {

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentMixed.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentMixed.scala
@@ -1,8 +1,8 @@
 package test.organizeImports
 
 import a.A
-import b.B
-import z.Z
+import b.B /* trailing block comment */
+import z.Z // trailing line comment
 
 object InlineCommentMixed {
   val keep = 1

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentMixed.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentMixed.scala
@@ -1,0 +1,9 @@
+package test.organizeImports
+
+import a.A
+import b.B
+import z.Z
+
+object InlineCommentMixed {
+  val keep = 1
+}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentMoves.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentMoves.scala
@@ -1,0 +1,9 @@
+package test.organizeImports
+
+import a.A
+import z.Z
+
+object InlineCommentMoves {
+  val keep = (null: AnyRef)
+}
+

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentMoves.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentMoves.scala
@@ -1,7 +1,7 @@
 package test.organizeImports
 
 import a.A
-import z.Z
+import z.Z // commentZ
 
 object InlineCommentMoves {
   val keep = (null: AnyRef)

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentMultiple.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentMultiple.scala
@@ -1,7 +1,7 @@
 package test.organizeImports
 
-import a.A
-import b.B
+import a.A // anote
+import b.B // bnote
 import c.C
 
 object InlineCommentMultiple {

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentMultiple.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentMultiple.scala
@@ -1,0 +1,10 @@
+package test.organizeImports
+
+import a.A
+import b.B
+import c.C
+
+object InlineCommentMultiple {
+  val keep = 1
+}
+

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentRemoved.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentRemoved.scala
@@ -1,0 +1,8 @@
+package test.organizeImports
+
+import other.P
+
+object InlineCommentRemoved {
+  val keep: P = null.asInstanceOf[P]
+}
+

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentRemovedBlock.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentRemovedBlock.scala
@@ -1,0 +1,7 @@
+package test.organizeImports
+
+import other.P // this used import and comment should stay
+
+object InlineCommentRemovedBlock {
+  val keep: P = null.asInstanceOf[P]
+}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentSlcStyle.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentSlcStyle.scala
@@ -1,14 +1,22 @@
 package test.organizeImports
 
-import a.A
+import a.A // A
 import b.B
-import other.P
-import x.X
-import y.Y
-import z.Z
-import z.{Z1 => Z_1}
-import z.{Z2 => Z_2}
-import z.{Z3 => Z_3} // zend
+// XYP
+// Pbeg
+import other.P // Pend
+// Xbeg
+import x.X // Xend
+// Ybeg
+import y.Y // Yend
+import z.Z // Z
+// zbeg
+// Z1beg
+import z.{Z1 => Z_1} // Z1end // zend
+// Z2beg
+import z.{Z2 => Z_2} // Z2end
+// Z3beg
+import z.{Z3 => Z_3} // Z3end
 
 object InlineCommentSlcStyle {
   val keep = 1

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentSlcStyle.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentSlcStyle.scala
@@ -6,9 +6,9 @@ import other.P
 import x.X
 import y.Y
 import z.Z
-import z.{ Z1 => Z_1 }
+import z.{Z1 => Z_1}
 import z.{Z2 => Z_2}
-import z.{ Z3 => Z_3 } // zend
+import z.{Z3 => Z_3} // zend
 
 object InlineCommentSlcStyle {
   val keep = 1

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentSlcStyle.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentSlcStyle.scala
@@ -1,0 +1,15 @@
+package test.organizeImports
+
+import a.A
+import b.B
+import other.P
+import x.X
+import y.Y
+import z.Z
+import z.{ Z1 => Z_1 }
+import z.{Z2 => Z_2}
+import z.{ Z3 => Z_3 } // zend
+
+object InlineCommentSlcStyle {
+  val keep = 1
+}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/StandaloneComment.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/StandaloneComment.scala
@@ -1,0 +1,11 @@
+package test.organizeImports
+
+// This comment is ambiguous and not linked to a specific import
+import x.X
+import y.Y
+
+object StandaloneComment {
+  val keep = new X
+  val alsoKeep = new Y
+}
+

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/StandaloneComment.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/StandaloneComment.scala
@@ -1,7 +1,7 @@
 package test.organizeImports
 
-// This comment is ambiguous and not linked to a specific import
 import x.X
+// This comment is ambiguous and not linked to a specific import
 import y.Y
 
 object StandaloneComment {

--- a/scalafix-tests/shared/src/main/scala/test/organizeImports/InlineCommentFixtures.scala
+++ b/scalafix-tests/shared/src/main/scala/test/organizeImports/InlineCommentFixtures.scala
@@ -1,0 +1,34 @@
+package a {
+  class A
+}
+
+package b {
+  class B
+}
+
+package c {
+  class C
+}
+
+package z {
+  class Z
+  class Z1
+  class Z2
+  class Z3
+}
+
+package my.pkg {
+  class K
+}
+
+package other {
+  class P
+}
+
+package x {
+  class X
+}
+
+package y {
+  class Y
+}


### PR DESCRIPTION
For that, we need to access the `.originalPrototype()` tree that was parsed out from input, before we generated partial copies with various combinations of importees and importers (each such copy also creates a copy of the fields with the new parent set).

That original prototype is what can be used to access the parent import statement and its attached comments.

Fixes #2267. Borrowed tests from #2324.