### PR TITLE
Patching: use Tokens own traversal methods

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/internal/patch/ImportPatchOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/patch/ImportPatchOps.scala
@@ -14,7 +14,6 @@ import scalafix.patch.Patch
 import scalafix.patch.Patch.internal._
 import scalafix.rule.RuleCtx
 import scalafix.syntax._
-import scalafix.util.Newline
 import scalafix.util.SemanticdbIndex
 import scalafix.v0.Signature
 import scalafix.v0.Symbol
@@ -46,11 +45,12 @@ object ImportPatchOps {
       case _: Source => tree.tokens.head
       case Pkg.Initial(_, stat :: _) => loop(stat)
       case els =>
-        ctx.tokenList.prev(ctx.tokenList.prev(els.tokens.head)) match {
-          case comment @ Token.Comment(_) =>
-            ctx.tokenList.prev(ctx.tokenList.prev(comment))
-          case other => other
-        }
+        val tokens = els.begComment.getOrElse(els).tokens
+        val eolidx = tokens.rskipWideIf(_.is[Token.HTrivia], -1)
+        (tokens.getWideOpt(eolidx) match {
+          case Some(_: Token.AtEOL) => tokens.getWideOpt(eolidx - 1)
+          case x => x
+        }).getOrElse(tokens.head)
     }
     loop(ctx.tree)
   }
@@ -78,7 +78,7 @@ object ImportPatchOps {
       case Importee.Name(n) if index.symbol(n).isDefined =>
         n.symbol
       // TODO(olafur) handle rename.
-    }
+    }.flatten
     lazy val allImporteeSymbols = allImportees.flatMap(importee =>
       importee.symbol.map(_.normalized -> importee)
     )
@@ -161,9 +161,7 @@ object ImportPatchOps {
     def removeSpaces(tokens: Iterable[Token]): Patch = {
       tokens
         .takeWhile {
-          case Token.Space() => true
-          case Newline() => true
-          case Token.Comma() => true
+          case _: Token.Whitespace | _: Token.Comma => true
           case _ => false
         }
         .map(ctx.removeToken)
@@ -238,46 +236,34 @@ object ImportPatchOps {
       Patch.removeTokens(toRemove.tokens) ++ leadingComma ++ trailingComma
     }
 
-    val leadingNewlines = isRemovedImport.map { i =>
-      var newline = false
-      ctx.tokenList
-        .leading(i.tokens.head)
-        .takeWhile(x =>
-          !newline && {
-            x.is[Token.Space] || {
-              val isNewline = x.is[Newline]
-              if (isNewline) {
-                newline = true
-              }
-              isNewline
-            }
-          }
-        )
-        .map(tok => ctx.removeToken(tok))
-        .asPatch
+    val importsRemoves = isRemovedImport.map { i =>
+      val tokens = i.tokens
+      val eolidx = tokens.rskipWideIf(_.is[Token.HSpace], -1)
+      val begidx = tokens.getWideOpt(eolidx) match {
+        case Some(_: Token.AtEOL) => eolidx
+        case _ => eolidx + 1
+      }
+      ctx.removeTokens(tokens.sliceWide(begidx, tokens.length))
     }
 
-    leadingNewlines ++
-      curlyBraceRemoves ++
+    curlyBraceRemoves ++
       extraPatches ++
       isRemovedImportee.map(remove) ++
       isRemovedImporter.map(remove) ++
-      isRemovedImport.map(i => Patch.removeTokens(i.tokens))
+      importsRemoves
   }
 
   private def removeUpToFirstComma(tokens: Iterable[Token]): List[Patch] = {
     var foundComma = false
     val patch = tokens
       .takeWhile {
-        case _: Token.Space | Newline() => true
+        case _: Token.Whitespace => true
         case _: Token.Comma if !foundComma =>
           foundComma = true
           true
         case _ => false
       }
-      .map { token =>
-        Patch.removeToken(token)
-      }
+      .map(Patch.removeToken)
       .toList
     if (foundComma) patch
     else Nil

--- a/scalafix-core/src/main/scala/scalafix/internal/patch/PatchInternals.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/patch/PatchInternals.scala
@@ -129,13 +129,18 @@ object PatchInternals {
     importTokenPatches ++ tokenPatches
   }
 
+  private def buildPatchMap(
+      patches: Iterable[TokenPatch]
+  ): Map[TokenOps.TokenHash, String] =
+    patches
+      .groupBy(x => TokenOps.hash(x.tok))
+      .map { case (k, v) => k -> v.reduce(merge).newTok }
+
   private def tokenPatchApply(
       ctx: v0.RuleCtx,
       patches: Iterable[TokenPatch]
   ): String = {
-    val patchMap = patches
-      .groupBy(x => TokenOps.hash(x.tok))
-      .mapValues(_.reduce(merge).newTok)
+    val patchMap = buildPatchMap(patches)
     ctx.tokens.iterator
       .map(tok => patchMap.getOrElse(TokenOps.hash(tok), tok.syntax))
       .mkString
@@ -147,10 +152,7 @@ object PatchInternals {
       v0Patches: Iterable[v0.Patch]
   ): String = {
     val idx = index.getOrElse(v0.SemanticdbIndex.empty)
-    val patches = treePatchApply(v0Patches.asPatch)(ctx, idx)
-    val patchMap = patches
-      .groupBy(x => TokenOps.hash(x.tok))
-      .mapValues(_.reduce(merge).newTok)
+    val patchMap = buildPatchMap(treePatchApply(v0Patches.asPatch)(ctx, idx))
     ctx.tokens.iterator
       .map(tok => patchMap.getOrElse(TokenOps.hash(tok), tok.syntax))
       .mkString

--- a/scalafix-core/src/main/scala/scalafix/util/TokenClasses.scala
+++ b/scalafix-core/src/main/scala/scalafix/util/TokenClasses.scala
@@ -3,12 +3,10 @@ package scalafix.util
 import scala.meta.classifiers.Classifier
 import scala.meta.classifiers.XtensionClassifiable
 import scala.meta.tokens.Token
-import scala.meta.tokens.Token._
 
 trait Whitespace
 object Whitespace {
-  def unapply(token: Token): Boolean =
-    token.is[Space] || token.is[Tab] || token.is[Newline] || token.is[FF]
+  def unapply(token: Token): Boolean = token.is[Token.Whitespace]
   implicit def classifier[T <: Token]: Classifier[T, Whitespace] =
     new Classifier[T, Whitespace] {
       override def apply(token: T): Boolean = unapply(token)
@@ -17,8 +15,7 @@ object Whitespace {
 
 trait Trivia
 object Trivia {
-  def unapply(token: Token): Boolean =
-    token.is[Whitespace] || token.is[Comment]
+  def unapply(token: Token): Boolean = token.is[Token.Trivia]
   implicit def classifier[T <: Token]: Classifier[T, Trivia] =
     new Classifier[T, Trivia] {
       override def apply(token: T): Boolean = unapply(token)
@@ -27,8 +24,7 @@ object Trivia {
 
 trait Newline
 object Newline {
-  def unapply(token: Token): Boolean =
-    token.is[LF] || token.is[CR]
+  def unapply(token: Token): Boolean = token.is[Token.AtEOL]
   implicit def classifier[T <: Token]: Classifier[T, Newline] =
     new Classifier[T, Newline] {
       override def apply(token: T): Boolean = unapply(token)

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/ExplicitResultTypesBase.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/ExplicitResultTypesBase.scala
@@ -145,7 +145,7 @@ abstract class ExplicitResultTypesBase[P <: Printer]
       // Example: `val x = ` from `val x = rhs.banana`
       lhsTokens = slice(start, end)
       replace <- lhsTokens.reverseIterator.find(x =>
-        !x.is[Token.Equals] && !x.is[Trivia]
+        !x.isAny[Token.Equals, Token.Trivia]
       )
       space = {
         if (TokenOps.needsLeadingSpaceBeforeColon(replace)) " "

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/NoValInForComprehension.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/NoValInForComprehension.scala
@@ -1,7 +1,6 @@
 package scalafix.internal.rule
 
 import scala.meta._
-import scala.meta.contrib._
 
 import scalafix.v1._
 
@@ -13,8 +12,7 @@ class NoValInForComprehension extends SyntacticRule("NoValInForComprehension") {
 
   override def fix(implicit doc: SyntacticDocument): Patch = {
     doc.tree.collect { case v: Enumerator.Val =>
-      val valTokens =
-        v.tokens.takeWhile(t => t.syntax == "val" || t.is[Whitespace])
+      val valTokens = v.tokens.takeWhile(_.isAny[Token.KwVal, Token.Whitespace])
       valTokens.map(Patch.removeToken).asPatch.atomic
     }.asPatch
   }

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/ProcedureSyntax.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/ProcedureSyntax.scala
@@ -1,11 +1,7 @@
 package scalafix.internal.rule
 
 import scala.meta._
-import scala.meta.tokens.Token
-import scala.meta.tokens.Token.Equals
-import scala.meta.tokens.Token.RightParen
 
-import scalafix.util.Trivia
 import scalafix.v1._
 
 class ProcedureSyntax extends SyntacticRule("ProcedureSyntax") {
@@ -24,7 +20,7 @@ class ProcedureSyntax extends SyntacticRule("ProcedureSyntax") {
             t.body.tokens.head.is[Token.LeftBrace] =>
         val fixed = for {
           bodyStart <- t.body.tokens.headOption
-          toAdd <- doc.tokenList.leading(bodyStart).find(!_.is[Trivia])
+          toAdd <- doc.tokenList.leading(bodyStart).find(!_.is[Token.Trivia])
         } yield Patch.addRight(toAdd, s": Unit =").atomic
         fixed.getOrElse(Patch.empty)
 
@@ -33,18 +29,10 @@ class ProcedureSyntax extends SyntacticRule("ProcedureSyntax") {
        *   [[https://github.com/ohze/scala-rewrites/blob/dotty/rewrites/src/main/scala/fix/scala213/ConstructorProcedureSyntax.scala ConstructorProcedureSyntax.scala]]
        */
       case t: Ctor.Secondary =>
-        val tokens = t.tokens
-        val beforeInitIdx = tokens.indexOf(t.init.tokens.head) - 1
-        // last RightParen before init
-        val lastRightParenIdx =
-          tokens.lastIndexWhere(_.is[RightParen], beforeInitIdx)
-        // if slicedTokens don't have Equals token => need patching
-        val slicedTokens = tokens.slice(lastRightParenIdx, beforeInitIdx)
-        slicedTokens.find(_.is[Equals]) match {
-          case Some(_) => Patch.empty
-          case None => Patch.addRight(tokens(lastRightParenIdx), " =")
+        t.body.tokens.rfindWideNot(_.is[Token.Trivia], -1).get match {
+          case _: Token.Equals => Patch.empty
+          case tok => Patch.addRight(tok, " =")
         }
-
     }.asPatch
   }
 }

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/RedundantSyntax.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/RedundantSyntax.scala
@@ -1,10 +1,8 @@
 package scalafix.internal.rule
 
 import scala.meta._
-import scala.meta.tokens.Token
 
 import metaconfig.Configured
-import scalafix.util.TokenList
 import scalafix.v1._
 
 class RedundantSyntax(config: RedundantSyntaxConfig)
@@ -24,12 +22,11 @@ class RedundantSyntax(config: RedundantSyntaxConfig)
   override def fix(implicit doc: SyntacticDocument): Patch =
     doc.tree
       .collect {
-        case o: Defn.Object
-            if config.finalObject && o.mods.exists(_.is[Mod.Final]) =>
-          Patch.removeTokens {
-            o.tokens.find(_.is[Token.KwFinal]).toIterable.flatMap { finalTok =>
-              finalTok :: TokenList(o.tokens).trailingSpaces(finalTok).toList
-            }
+        case o: Defn.Object if config.finalObject =>
+          o.mods.find(_.is[Mod.Final]).fold(Patch.empty) { modf =>
+            val tokens = modf.tokens
+            val end = tokens.skipWideIf(_.is[Token.Whitespace], tokens.length)
+            Patch.removeTokens(tokens.sliceWide(0, end))
           }
         case Term.Interpolate(
               interpolator,

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
@@ -6,7 +6,6 @@ import scala.meta._
 import scala.meta.tokens.Token
 
 import metaconfig.Configured
-import scalafix.util.Trivia
 import scalafix.v1._
 
 class RemoveUnused(config: RemoveUnusedConfig)
@@ -259,7 +258,8 @@ class RemoveUnused(config: RemoveUnusedConfig)
         case Some(locally) =>
           // Preserve comments between the LHS and the RHS, as well as
           // newlines & whitespaces for significant indentation
-          val tokensNoTrailingTrivia = heading.dropRightWhile(_.is[Trivia])
+          val tokensNoTrailingTrivia =
+            heading.dropRightWhile(_.is[Token.Trivia])
 
           Patch.removeTokens(tokensNoTrailingTrivia) +
             tokensNoTrailingTrivia.lastOption.map(Patch.addRight(_, locally))
@@ -271,14 +271,13 @@ class RemoveUnused(config: RemoveUnusedConfig)
     }
 
   private def posExclParens(tree: Tree): Position = {
-    val leftTokenCount =
-      tree.tokens.takeWhile(tk => tk.is[Token.LeftParen] || tk.is[Trivia]).size
-    val rightTokenCount = tree.tokens
-      .takeRightWhile(tk => tk.is[Token.RightParen] || tk.is[Trivia])
-      .size
     tree.pos match {
       case Position.Range(input, start, end) =>
-        Position.Range(input, start + leftTokenCount, end - rightTokenCount)
+        val tokens = tree.tokens
+        val leftCount = tokens.skipIf(_.isAny[Token.LeftParen, Token.Trivia])
+        val rightCount = tokens.length - 1 -
+          tokens.rskipIf(_.isAny[Token.RightParen, Token.Trivia])
+        Position.Range(input, start + leftCount, end - rightCount)
       case other => other
     }
   }


### PR DESCRIPTION
Avoids deprecated methods as well.