### PR TITLE
CompilerTypePrinter: rewrite writing Defn.Def

### DIFF
--- a/scalafix-rules/src/main/scala-2/scalafix/internal/rule/CompilerTypePrinter.scala
+++ b/scalafix-rules/src/main/scala-2/scalafix/internal/rule/CompilerTypePrinter.scala
@@ -241,6 +241,20 @@ class CompilerTypePrinter(g: ScalafixGlobal, config: ExplicitResultTypesConfig)(
         case t: m.Defn.Def => Some(t.body)
         case _ => None
       }
+      def appendParams(
+          sb: StringBuilder,
+          lp: Char,
+          rp: Char,
+          params: List[m.Member]
+      ): Unit = {
+        sb.append(lp)
+        val sblen = sb.length
+        params.foreach { p =>
+          if (sb.length > sblen) sb.append(", ")
+          sb.append(p.name.syntax)
+        }
+        sb.append(rp)
+      }
       body match {
         case Some(body @ m.Term.NewAnonymous(_))
             if body.tokens.head.syntax == "new" =>
@@ -254,38 +268,40 @@ class CompilerTypePrinter(g: ScalafixGlobal, config: ExplicitResultTypesConfig)(
             }
             .get
           isInsertedClass += name
-          val paramDefnSuffix = defn match {
-            case d: m.Defn.Def =>
-              d.paramss
-                .map(_.map(_.syntax).mkString(", "))
-                .mkString("(", ")(", ")")
-            case _ => ""
+          val defnOpt = defn match {
+            case d: m.Defn.Def => Some(d)
+            case _ => None
           }
-          val tparamDefn = defn match {
-            case d: m.Defn.Def if d.tparams.nonEmpty =>
-              d.tparams.map(_.syntax).mkString("[", ", ", "]")
-            case _ => ""
+          val nameWithType = defnOpt match {
+            case Some(d)
+                if d.paramClauseGroups.exists(_.tparamClause.values.nonEmpty) =>
+              val sbCall = new StringBuilder
+              sbCall.append(name)
+              d.paramClauseGroups.foreach { pcg =>
+                val tps = pcg.tparamClause.values
+                if (tps.nonEmpty) appendParams(sbCall, '[', ']', tps)
+              }
+              sbCall.toString()
+            case _ => name
           }
-          val tparamCall = defn match {
-            case d: m.Defn.Def if d.tparams.nonEmpty =>
-              d.tparams.map(_.name.syntax).mkString("[", ", ", "]")
-            case _ => ""
-          }
-          val paramCallSuffix = defn match {
-            case d: m.Defn.Def =>
-              d.paramss
-                .map(_.map(_.name.syntax).mkString(", "))
-                .mkString("(", ")(", ")")
-            case _ => ""
-          }
-          val indent = " " * defn.pos.startColumn
+          val sb = new StringBuilder
+          sb.append(' ')
+          sb.append(nameWithType)
+          defnOpt.foreach(_.paramClauseGroups.foreach(_.paramClauses.foreach {
+            pc => appendParams(sb, '(', ')', pc.values)
+          }))
+          sb.append('\n')
+            .append(" " * defn.pos.startColumn)
+            .append("class ")
+            .append(name)
+          defnOpt.foreach(_.paramClauseGroups.foreach { pcg =>
+            sb.append(pcg.syntax)
+          })
+          sb.append(" extends")
           Some(
             (
-              new PrettyType(name + tparamCall),
-              v1.Patch.addRight(
-                body.tokens.head,
-                s" ${name}${tparamCall}${paramCallSuffix}\n${indent}class ${name}${tparamDefn}${paramDefnSuffix} extends"
-              )
+              new PrettyType(nameWithType),
+              v1.Patch.addRight(body.tokens.head, sb.toString())
             )
           )
         case _ =>

--- a/scalafix-tests/output/src/main/scala/test/explicitResultTypes/ExplicitResultTypesOutline.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitResultTypes/ExplicitResultTypesOutline.scala
@@ -2,8 +2,8 @@
 package test.explicitResultTypes
 
 object ExplicitResultTypesOutline {
-  def foo: foo = new foo()
-  class foo() extends java.io.Serializable {
+  def foo: foo = new foo
+  class foo extends java.io.Serializable {
     def format = 24
   }
 }


### PR DESCRIPTION
Supports multiple parameter clauses -- and none as well. Also avoids using deprecated methods when accessing params.