### PR TITLE
SBT: add -Werror and -deprecation, with exceptions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,7 @@ lazy val interfaces = project
 // Scala 3 macros vendored separately (i.e. without runtime classes), to
 // shadow Scala 2.13 macros in the Scala 3 compiler classpath, while producing
 // code valid against Scala 2.13 bytecode
+// TODO: after replacing with metaconfig_3, remove -Wconf filter in ScalafixBuild
 lazy val `compat-metaconfig-macros` = projectMatrix
   .settings(
     libraryDependencies += metaconfig cross CrossVersion.for3Use2_13
@@ -246,6 +247,7 @@ lazy val input = projectMatrix
     scalacOptions ~= (_.filterNot(_ == "-Yno-adapted-args")),
     scalacOptions ++= warnAdaptedArgs.value, // For NoAutoTupling
     logLevel := Level.Error, // avoid flood of compiler warnings
+    scalacOptions --= ScalafixBuild.werrorOptions,
     libraryDependencies ++= testsDependencies.value,
     coverageEnabled := false,
     allowUnsafeScalaLibUpgrade := true,
@@ -270,6 +272,7 @@ lazy val output = projectMatrix
   .settings(
     noPublishAndNoMima,
     logLevel := Level.Error, // avoid flood of compiler warnings
+    scalacOptions --= ScalafixBuild.werrorOptions,
     libraryDependencies ++= testsDependencies.value,
     coverageEnabled := false,
     // mimic dependsOn(shared) but allowing binary Scala version matching
@@ -319,6 +322,7 @@ lazy val integration = projectMatrix
   .settings(
     noPublishAndNoMima,
     Test / parallelExecution := false,
+    Compile / scalacOptions --= ScalafixBuild.werrorOptions,
     libraryDependencies ++= {
       if (!isScala3.value) {
         Seq(

--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -282,6 +282,14 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
       }
     },
     versionPolicyIntention := Compatibility.BinaryCompatible,
+    scalacOptions ++= werrorOptions,
+    scalacOptions ++= Seq( // exclusions
+      "-Wconf:cat=deprecation&msg=Rule:s",
+      "-Wconf:cat=deprecation&msg=JavaConverters:s",
+      "-Wconf:cat=deprecation&msg=AssociatedComments:s",
+      // TODO: remove after replacing compat-metaconfig-macros with proper metaconfig
+      "-Wconf:msg=.*Toplevel definition .* is defined in.*:s"
+    ),
     scalacOptions += "-Wconf:origin=scala.collection.compat.*:s",
     scalacOptions ++= compilerOptions.value,
     scalacOptions ++= {
@@ -374,4 +382,11 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
 
   private def asProjectSuffix(scalaVersion: String) =
     scalaVersion.replaceAll("[\\.-]", "_")
+
+  val werrorOptions = Seq(
+    "-Werror",
+    "-deprecation",
+    "-Wconf:cat=deprecation:error"
+  )
+
 }

--- a/scalafix-core/src/main/scala/scalafix/internal/util/FileOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/util/FileOps.scala
@@ -4,6 +4,7 @@ import java.io.BufferedReader
 import java.io.File
 import java.io.FileReader
 import java.io.PrintWriter
+import java.net.URI
 import java.net.URL
 
 import scala.meta.io.AbsolutePath
@@ -44,7 +45,7 @@ object FileOps {
    */
   def readFile(filename: String): String = {
     if (filename matches "https?://.*") {
-      readURL(new URL(filename))
+      readURL(new URI(filename).toURL)
     } else {
       readFile(new File(filename))
     }

--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/GitHubUrlRule.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/GitHubUrlRule.scala
@@ -1,6 +1,7 @@
 package scalafix.internal.reflect
 
 import java.io.FileNotFoundException
+import java.net.URI
 import java.net.URL
 
 import scala.util.Try
@@ -82,8 +83,8 @@ object GitHubUrlRule {
       repo: String,
       file: String,
       sha: String
-  ): URL = new URL(
+  ): URL = new URI(
     s"https://raw.githubusercontent.com/$org/$repo/$sha/scalafix/rules/src/main/scala/$file"
-  )
+  ).toURL
 
 }


### PR DESCRIPTION
Scalafix apparently depends on warnings to operate (although it would be ideal to separate generation of diagnostics from printing them out), so these stricter options cannot be applied to input, output, integration.

Depends on #2437, #2436, #2435, #2434, #2433, #2432, #2431, #2430.