### PR TITLE
OrganizeImports: optionally move `given` imports to end

### DIFF
--- a/docs/rules/OrganizeImports.md
+++ b/docs/rules/OrganizeImports.md
@@ -58,7 +58,7 @@ Known limitations:
     may result in incorrect imports.
 
 2.  The
-    [`groupExplicitlyImportedImplicitsSeparately`](OrganizeImports.md#groupexplicitlyimportedimplicitsseparately)
+    [`groupSeparately=ByNameImplicits`](#bynameimplicits)
     option has no effect.
 
 Configuration
@@ -374,130 +374,6 @@ import scala.util.control.NonFatal
 import sun.misc.BASE64Encoder
 ```
 
-`groupExplicitlyImportedImplicitsSeparately`
---------------------------------------------
-
-This option provides a workaround to a subtle and rarely seen
-correctness issue related to explicitly imported implicit names.
-
-The following snippet helps illustrate the problem:
-
-```scala
-package a
-
-import c._
-import b.i
-
-object b { implicit def i: Int = 1 }
-object c { implicit def i: Int = 2 }
-
-object Imports {
-  def f()(implicit i: Int) = println(1)
-  def main() = f()
-}
-```
-
-The above snippet compiles successfully and outputs `1`, because the
-explicitly imported implicit value `b.i` overrides `c.i`, which is made
-available via a wildcard import. However, if we reorder the two imports
-into:
-
-```scala
-import b.i
-import c._
-```
-
-The Scala compiler starts complaining:
-
-```
-error: could not find implicit value for parameter i: Int
-  def main() = f()
-                ^
-```
-
-This behavior could be due to a Scala compiler bug since [the Scala
-language
-specification](https://scala-lang.org/files/archive/spec/2.13/02-identifiers-names-and-scopes.html)
-requires that explicitly imported names should have higher precedence
-than names made available via a wildcard.
-
-Unfortunately, Scalafix is not able to surgically identify conflicting
-implicit values behind a wildcard import. In order to guarantee
-correctness in all cases, when the
-`groupExplicitlyImportedImplicitsSeparately` option is set to `true`,
-all explicitly imported implicit names are moved into the trailing
-order-preserving import group together with relative imports, if any
-(see the [trailing order-preserving import
-group](OrganizeImports.md#groups) section for more
-details).
-
-> In general, order-sensitive imports are fragile, and can easily be
-> broken by either human collaborators or tools (e.g., the IntelliJ IDEA
-> Scala import optimizer does not handle this case correctly). They should
-> be eliminated whenever possible. This option is mostly useful when you
-> are dealing with a large trunk of legacy codebase, and you want to
-> minimize manual intervention and guarantee correctness in all cases.
-
-> The `groupExplicitlyImportedImplicitsSeparately` option has currently no
-> effect on source files compiled with Scala 3, as the [compiler does not
-> expose full signature
-> information](https://github.com/scala/scala3/issues/12766), preventing
-> the rule to identify imported implicits.
-
-### Value type
-
-Boolean
-
-### Default value
-
-`false`
-
-Rationale:
-
-1.  Although setting it to `true` avoids the aforementioned correctness
-    issue, the result is unintuitive and confusing for many users since
-    it looks like the `groups` option is not respected.
-
-    E.g., why my `scala.concurrent.ExecutionContext.Implicits.global`
-    import is moved to a separate group even if I have a `scala.` group
-    defined in the `groups` option?
-
-2.  The concerned correctness issue is rarely seen in real life. When it
-    really happens, it is usually a sign of bad coding style, and you
-    may want to tweak your imports to eliminate the root cause.
-
-### Examples
-
-```conf
-OrganizeImports {
-  groups = ["scala.", "*"]
-  groupExplicitlyImportedImplicitsSeparately = true // not supported in Scala 3
-}
-```
-
-Before:
-
-```scala
-import org.apache.spark.SparkContext
-import org.apache.spark.RDD
-import scala.collection.mutable.ArrayBuffer
-import scala.collection.mutable.Buffer
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.sys.process.stringToProcess
-```
-
-After:
-```scala
-import scala.collection.mutable.ArrayBuffer
-import scala.collection.mutable.Buffer
-
-import org.apache.spark.RDD
-import org.apache.spark.SparkContext
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.sys.process.stringToProcess
-```
-
 `groupedImports`
 ----------------
 
@@ -755,8 +631,8 @@ same group and sorted by the order defined by the
 > 1.  The `expandRelative` option is set to `false` and there are relative
 >     imports.
 > 
-> 2.  The `groupExplicitlyImportedImplicitsSeparately` option is set to
->     `true` and there are implicit names explicitly imported.
+> 2.  The `groupSeparately` parameter is set, and there are
+>     [matching imports](#groupseparately).
 > 
 > This special import group is necessary because the above two kinds of
 > imports are order sensitive:
@@ -770,9 +646,9 @@ same group and sorted by the order defined by the
 > import util.control
 > import control.NonFatal
 > ```
-> #### Explicitly imported implicit names  
+> #### Explicitly imported implicit names
 > Please refer to the
-> [`groupExplicitlyImportedImplicitsSeparately`](OrganizeImports.md#groupexplicitlyimportedimplicitsseparately)
+> [`groupSeparately=ByNameImplicits`](#bynameimplicits)
 > option for more details.
 
 ### Value type
@@ -930,7 +806,7 @@ import control.NonFatal
 ```conf
 OrganizeImports {
   groups = ["re:javax?\\.", "scala.", "*"]
-  groupExplicitlyImportedImplicitsSeparately = true
+  groupSeparately = [ByNameImplicits]
 }
 ```
 
@@ -1039,6 +915,141 @@ import java.time.Clock
 import javax.annotation.Generated
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
+```
+
+`groupSeparately`
+-----------------
+
+This parameter places matching imports in a trailing order-preserving import
+group, together with relative imports, if any (see the [trailing
+order-preserving import group](OrganizeImports.md#groups) section for more
+details).
+
+### Value type
+
+This parameter accepts a list of zero or more values
+described below.
+
+#### `ByNameImplicits`
+
+This option provides a workaround to a subtle and rarely seen
+correctness issue related to explicitly imported implicit names.
+
+(Prior to v0.14.7, the same behaviour was accomplished by setting
+`groupExplicitlyImportedImplicitsSeparately = true`.)
+
+The following snippet helps illustrate the problem:
+
+```scala
+package a
+
+import c._
+import b.i
+
+object b { implicit def i: Int = 1 }
+object c { implicit def i: Int = 2 }
+
+object Imports {
+  def f()(implicit i: Int) = println(1)
+  def main() = f()
+}
+```
+
+The above snippet compiles successfully and outputs `1`, because the
+explicitly imported implicit value `b.i` overrides `c.i`, which is made
+available via a wildcard import. However, if we reorder the two imports
+into:
+
+```scala
+import b.i
+import c._
+```
+
+The Scala compiler starts complaining:
+
+```
+error: could not find implicit value for parameter i: Int
+  def main() = f()
+                ^
+```
+
+This behavior could be due to a Scala compiler bug since [the Scala
+language
+specification](https://scala-lang.org/files/archive/spec/2.13/02-identifiers-names-and-scopes.html)
+requires that explicitly imported names should have higher precedence
+than names made available via a wildcard.
+
+Unfortunately, Scalafix is not able to surgically identify conflicting
+implicit values behind a wildcard import. In order to guarantee
+correctness in all cases, when the
+`groupSeparately` parameter contains `ByNameImplicits`,
+all explicitly imported implicit names are moved into the trailing
+order-preserving import group.
+
+> In general, order-sensitive imports are fragile, and can easily be
+> broken by either human collaborators or tools (e.g., the IntelliJ IDEA
+> Scala import optimizer does not handle this case correctly). They should
+> be eliminated whenever possible. This option is mostly useful when you
+> are dealing with a large trunk of legacy codebase, and you want to
+> minimize manual intervention and guarantee correctness in all cases.
+
+> This option has currently no
+> effect on source files compiled with Scala 3, as the [compiler does not
+> expose full signature
+> information](https://github.com/scala/scala3/issues/12766), preventing
+> the rule to identify imported implicits.
+
+Rationale for not including it by default:
+
+1.  Although doing so avoids the aforementioned correctness
+    issue, the result is unintuitive and confusing for many users since
+    it looks like the `groups` option is not respected.
+
+    E.g., why my `scala.concurrent.ExecutionContext.Implicits.global`
+    import is moved to a separate group even if I have a `scala.` group
+    defined in the `groups` option?
+
+2.  The concerned correctness issue is rarely seen in real life. When it
+    really happens, it is usually a sign of bad coding style, and you
+    may want to tweak your imports to eliminate the root cause.
+
+### Default value
+
+`[]`
+
+### Examples
+
+#### `ByNameImplicits`
+
+```conf
+OrganizeImports {
+  groups = ["scala.", "*"]
+  groupSeparately = [ByNameImplicits] // not supported in Scala 3
+}
+```
+
+Before:
+
+```scala
+import org.apache.spark.SparkContext
+import org.apache.spark.RDD
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.Buffer
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.sys.process.stringToProcess
+```
+
+After:
+
+```scala
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.Buffer
+
+import org.apache.spark.RDD
+import org.apache.spark.SparkContext
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.sys.process.stringToProcess
 ```
 
 `importSelectorsOrder`
@@ -1223,7 +1234,7 @@ OrganizeImports {
   blankLines = Auto
   coalesceToWildcardImportThreshold = null
   expandRelative = false
-  groupExplicitlyImportedImplicitsSeparately = false
+  groupSeparately = []
   groupedImports = Explode
   groups = [
     "*"
@@ -1252,7 +1263,7 @@ OrganizeImports {
   blankLines = Auto
   coalesceToWildcardImportThreshold = 5
   expandRelative = false
-  groupExplicitlyImportedImplicitsSeparately = false
+  groupSeparately = []
   groupedImports = Merge
   groups = [
     "*"

--- a/docs/rules/OrganizeImports.md
+++ b/docs/rules/OrganizeImports.md
@@ -1013,9 +1013,26 @@ Rationale for not including it by default:
     really happens, it is usually a sign of bad coding style, and you
     may want to tweak your imports to eliminate the root cause.
 
+#### `ByTypeGivens`
+
+If this option is specified, any explicit
+[by-type](https://docs.scala-lang.org/scala3/reference/contextual/given-imports.html#importing-by-type)
+`given` imports will be put in the trailing order-preserving import group.
+Obviously, it is only applicable to Scala 3 source files.
+
+The reason is that a `given` import refers to a type `T`, and that type can
+come from any package `P` that must be imported earlier. This matters because:
+
+- Our grouping and sorting logic could otherwise move `import P.T` later.
+- Scala 3 SemanticDB does not currently provide symbol information for `T`.
+
 ### Default value
 
-`[]`
+`[ByTypeGivens]`
+
+This value is enabled by default because by-type given imports are more likely
+to produce invalid code when reorganized. When no such imports are present, the
+option has no effect.
 
 ### Examples
 
@@ -1050,6 +1067,58 @@ import org.apache.spark.SparkContext
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.sys.process.stringToProcess
+```
+
+#### `ByTypeGivens`
+
+```conf
+OrganizeImports {
+  groups = ["scala.", "*"]
+  groupSeparately = [ByTypeGivens] // Only applicable for this Scala 3 feature
+}
+```
+
+```scala
+object ZGivens {
+  trait AA[T]
+}
+
+object Givens {
+  trait A
+  given aa_a: ZGivens.AA[A] = ???
+}
+
+object AGivens {
+  given a: Givens.A = ???
+}
+```
+
+Before:
+
+```scala
+import Givens.A
+import ZGivens.AA
+import AGivens.given A
+import Givens.given AA[A]
+```
+
+After:
+
+```scala
+import Givens.A
+import ZGivens.AA
+
+import AGivens.given A
+import Givens.given AA[A]
+```
+
+Without `ByTypeGivens`:
+
+```scala
+import AGivens.given A // incorrect: A is not imported yet
+import Givens.A
+import Givens.given AA[A] // incorrect: AA is not imported yet
+import ZGivens.AA
 ```
 
 `importSelectorsOrder`

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -234,7 +234,8 @@ class OrganizeImports(
       implicitImporters: ArrayBuffer[Importer]
   )(implicit doc: SemanticDocument): Seq[Importer] = {
     val noImplicitImporters = Seq.newBuilder[Importer]
-    val separateImplicits = config.groupExplicitlyImportedImplicitsSeparately
+    val separateImplicits = config.groupSeparately
+      .contains(GroupSeparately.ByNameImplicits)
     if (separateImplicits) importers.foreach { importer =>
       val (implicits, noImplicits) = importer.importees.partition {
         case i: Importee.Name =>

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -236,10 +236,13 @@ class OrganizeImports(
     val noImplicitImporters = Seq.newBuilder[Importer]
     val separateImplicits = config.groupSeparately
       .contains(GroupSeparately.ByNameImplicits)
-    if (separateImplicits) importers.foreach { importer =>
+    val separateGivens = targetDialect.allowGivenUsing &&
+      config.groupSeparately.contains(GroupSeparately.ByTypeGivens)
+    if (separateImplicits || separateGivens) importers.foreach { importer =>
       val (implicits, noImplicits) = importer.importees.partition {
         case i: Importee.Name =>
-          i.symbol.infoNoThrow.exists(_.isImplicit)
+          separateImplicits && i.symbol.infoNoThrow.exists(_.isImplicit)
+        case _: Importee.Given => separateGivens
         case _ => false
       }
       if (implicits.isEmpty) noImplicitImporters += importer

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImportsConfig.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImportsConfig.scala
@@ -61,9 +61,10 @@ object TargetDialect {
 sealed trait GroupSeparately
 object GroupSeparately {
   case object ByNameImplicits extends GroupSeparately
+  case object ByTypeGivens extends GroupSeparately
 
   implicit val codec: ConfCodecEx[GroupSeparately] = OrganizeImportsConfig
-    .getCodecFrom(ByNameImplicits)
+    .getCodecFrom(ByNameImplicits, ByTypeGivens)
 }
 
 final case class OrganizeImportsConfig(

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImportsConfig.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImportsConfig.scala
@@ -71,7 +71,7 @@ final case class OrganizeImportsConfig(
     blankLines: BlankLines = BlankLines.Auto,
     coalesceToWildcardImportThreshold: Option[Int] = None,
     expandRelative: Boolean = false,
-    groupSeparately: Seq[GroupSeparately] = Nil,
+    groupSeparately: Seq[GroupSeparately] = Seq(GroupSeparately.ByTypeGivens),
     groupedImports: GroupedImports = GroupedImports.Explode,
     groups: Seq[String] = Seq(
       "*",

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImportsConfig.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImportsConfig.scala
@@ -58,11 +58,19 @@ object TargetDialect {
     .getCodecFrom(Auto, Scala2, Scala3, StandardLayout)
 }
 
+sealed trait GroupSeparately
+object GroupSeparately {
+  case object ByNameImplicits extends GroupSeparately
+
+  implicit val codec: ConfCodecEx[GroupSeparately] = OrganizeImportsConfig
+    .getCodecFrom(ByNameImplicits)
+}
+
 final case class OrganizeImportsConfig(
     blankLines: BlankLines = BlankLines.Auto,
     coalesceToWildcardImportThreshold: Option[Int] = None,
     expandRelative: Boolean = false,
-    groupExplicitlyImportedImplicitsSeparately: Boolean = false,
+    groupSeparately: Seq[GroupSeparately] = Nil,
     groupedImports: GroupedImports = GroupedImports.Explode,
     groups: Seq[String] = Seq(
       "*",
@@ -101,8 +109,14 @@ object OrganizeImportsConfig {
     generic.deriveSurface
   implicit val encoder: ConfEncoder[OrganizeImportsConfig] =
     generic.deriveEncoder[OrganizeImportsConfig]
-  implicit val decoder: ConfDecoderEx[OrganizeImportsConfig] =
-    generic.deriveDecoderEx(default).noTypos
+  implicit val decoder: ConfDecoderEx[OrganizeImportsConfig] = {
+    val baseDecoder = generic.deriveDecoderEx(default).noTypos
+    baseDecoder.withSectionRenames(
+      annotation.SectionRename { case Conf.Bool(flag) =>
+        if (flag) Conf.Lst(Conf.Str("ByNameImplicits")) else Conf.Lst()
+      }("groupExplicitlyImportedImplicitsSeparately", "groupSeparately")
+    )
+  }
 
   def getCodecFrom[T](values: T*): ConfCodecEx[T] =
     ConfCodecEx.oneOf(values.map(x => sourcecode.Text(x, x.toString)): _*)

--- a/scalafix-tests/input/src/main/scala-3/test/organizeImports/PreserveDependentGivens.scala
+++ b/scalafix-tests/input/src/main/scala-3/test/organizeImports/PreserveDependentGivens.scala
@@ -1,0 +1,14 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupSeparately = [ByTypeGivens]
+  groupedImports = AggressiveMerge
+  removeUnused = false
+}
+ */
+package test.organizeImports
+
+import test.organizeImports.Givens.{A, B}
+import test.organizeImports.AGivens.{given A, given B}
+
+object PreserveDependentGivens

--- a/scalafix-tests/input/src/main/scala-3/test/organizeImports/RelativeGenericGivens.scala
+++ b/scalafix-tests/input/src/main/scala-3/test/organizeImports/RelativeGenericGivens.scala
@@ -1,0 +1,16 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupSeparately = [ByTypeGivens]
+  groupedImports = AggressiveMerge
+  removeUnused = false
+}
+ */
+package test.organizeImports
+
+import ZGivens.AA
+import test.organizeImports.ZGivens.EE
+import test.organizeImports.Givens.{A, B}
+import test.organizeImports.Givens.{given A, given B, given AA[A], given EE[B]}
+
+object RelativeGenericGivens

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/CurlyBracedSingleImportee.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/CurlyBracedSingleImportee.scala
@@ -1,7 +1,6 @@
 package test.organizeImports
 
 import test.organizeImports.GivenImports.given
-import test.organizeImports.GivenImports.given GivenImports.Alpha
 import test.organizeImports.PackageObject.a
 import test.organizeImports.PackageObject.a as A
 
@@ -10,5 +9,7 @@ import scala.collection.Map
 import scala.collection.Seq as _
 import scala.collection.Set as ImmutableSet
 import scala.util.*
+
+import test.organizeImports.GivenImports.given GivenImports.Alpha
 
 object CurlyBracedSingleImportee

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/DeduplicateGivenImportees.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/DeduplicateGivenImportees.scala
@@ -1,6 +1,7 @@
 package test.organizeImports
 
 import test.organizeImports.Givens.*
+
 import test.organizeImports.Givens.given A
 import test.organizeImports.Givens.given B
 import test.organizeImports.Givens.given C

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/ExpandGiven.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/ExpandGiven.scala
@@ -2,10 +2,11 @@ package test.organizeImports
 
 import test.organizeImports.GivenImports.Alpha
 import test.organizeImports.GivenImports.Beta
-import test.organizeImports.GivenImports.given Alpha
-import test.organizeImports.GivenImports.given Beta
-import test.organizeImports.GivenImports.given test.organizeImports.GivenImports.Gamma
 
 import scala.util.Either
+
+import test.organizeImports.GivenImports.given Beta
+import test.organizeImports.GivenImports.given test.organizeImports.GivenImports.Gamma
+import test.organizeImports.GivenImports.given Alpha
 
 object ExpandGiven

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/ExpandUnimportGiven.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/ExpandUnimportGiven.scala
@@ -3,9 +3,10 @@ package test.organizeImports
 import test.organizeImports.GivenImports.Alpha
 import test.organizeImports.GivenImports.Beta
 import test.organizeImports.GivenImports.alpha as _
-import test.organizeImports.GivenImports.given Alpha
 import test.organizeImports.GivenImports.{beta as _, given}
 
 import scala.util.Either
+
+import test.organizeImports.GivenImports.given Alpha
 
 object ExpandUnimportGiven

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/GroupedGivenImportsMergeUnimports.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/GroupedGivenImportsMergeUnimports.scala
@@ -1,15 +1,15 @@
 package test.organizeImports
 
 import test.organizeImports.GivenImports.*
-import test.organizeImports.GivenImports.{
-  gamma as _,
-  given Beta,
-  given Zeta,
-  given
-}
+import test.organizeImports.GivenImports.{gamma as _, given}
 import test.organizeImports.GivenImports2.{
   alpha as _,
   beta as _
+}
+
+import test.organizeImports.GivenImports.{
+  given Beta,
+  given Zeta
 }
 import test.organizeImports.GivenImports2.{
   given Gamma,

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/MergeGiven.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/MergeGiven.scala
@@ -4,12 +4,13 @@ import test.organizeImports.GivenImports.{
   Alpha,
   Beta
 }
+
+import scala.util.Either
+
 import test.organizeImports.GivenImports.{
   given Alpha,
   given Beta,
   given test.organizeImports.GivenImports.Gamma
 }
-
-import scala.util.Either
 
 object MergeGiven

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/MergeImportsFormatPreservingGiven.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/MergeImportsFormatPreservingGiven.scala
@@ -1,6 +1,7 @@
 package test.organizeImports
 
 import test.organizeImports.GivenImports.*
+
 import test.organizeImports.GivenImports.{ given Alpha, given Beta }
 
 object MergeImportsFormatPreservingGiven

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/PreserveDependentGivens.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/PreserveDependentGivens.scala
@@ -1,8 +1,7 @@
 package test.organizeImports
 
-/*
-import test.organizeImports.AGivens.{given A, given B}
 import test.organizeImports.Givens.{A, B}
-*/
+
+import test.organizeImports.AGivens.{given A, given B}
 
 object PreserveDependentGivens

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/PreserveDependentGivens.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/PreserveDependentGivens.scala
@@ -1,0 +1,8 @@
+package test.organizeImports
+
+/*
+import test.organizeImports.AGivens.{given A, given B}
+import test.organizeImports.Givens.{A, B}
+*/
+
+object PreserveDependentGivens

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/RelativeGenericGivens.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/RelativeGenericGivens.scala
@@ -1,0 +1,11 @@
+package test.organizeImports
+
+/*
+import test.organizeImports.Givens.{A, B}
+import test.organizeImports.Givens.{given A, given AA[A], given B, given EE[B]}
+import test.organizeImports.ZGivens.EE
+
+import ZGivens.AA
+*/
+
+object RelativeGenericGivens

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/RelativeGenericGivens.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/RelativeGenericGivens.scala
@@ -1,11 +1,9 @@
 package test.organizeImports
 
-/*
 import test.organizeImports.Givens.{A, B}
-import test.organizeImports.Givens.{given A, given AA[A], given B, given EE[B]}
 import test.organizeImports.ZGivens.EE
 
 import ZGivens.AA
-*/
+import test.organizeImports.Givens.{given A, given AA[A], given B, given EE[B]}
 
 object RelativeGenericGivens

--- a/scalafix-tests/shared/src/main/scala-3/test/organizeImports/Givens.scala
+++ b/scalafix-tests/shared/src/main/scala-3/test/organizeImports/Givens.scala
@@ -1,5 +1,10 @@
 package test.organizeImports
 
+object ZGivens { // sorted after Givens
+  trait AA[T]
+  trait EE[T]
+}
+
 object Givens {
   trait A
   trait B
@@ -12,4 +17,11 @@ object Givens {
   given c: C = ???
   given d: D = ???
   given e: E = ???
+  given aa_a: ZGivens.AA[A] = ???
+  given ee_b: ZGivens.EE[B] = ???
+}
+
+object AGivens { // sorted before Givens
+  given a: Givens.A = ???
+  given b: Givens.B = ???
 }


### PR DESCRIPTION
Fixes #2255.