### PR TITLE
OrganizeImports: refactor partitionImplicits

### DIFF
--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -102,13 +102,10 @@ class OrganizeImports(
   )(
       imports: Seq[Import]
   )(implicit doc: SemanticDocument): Patch = {
-    val noUnused = imports flatMap (_.importers) flatMap (
-      removeUnusedImporters(unusedImporteePositions)(_).toSeq
-    )
-
-    val (implicits, noImplicits) =
-      if (!config.groupExplicitlyImportedImplicitsSeparately) (Nil, noUnused)
-      else partitionImplicits(noUnused)
+    val noUnusedIterator = imports.iterator
+      .flatMap(_.importers)
+      .flatMap(removeUnusedImporters(unusedImporteePositions))
+    val (implicits, noImplicits) = partitionImplicits(noUnusedIterator)
 
     val (fullyQualifiedImporters, relativeImporters) =
       noImplicits partition isFullyQualified(diagnostics)
@@ -224,23 +221,26 @@ class OrganizeImports(
     }
 
   private def partitionImplicits(
-      importers: Seq[Importer]
+      importers: Iterator[Importer]
   )(implicit doc: SemanticDocument): (Seq[Importer], Seq[Importer]) = {
-    val (implicits, implicitPositions) = importers.flatMap {
-      case importer @ Importer(_, importees) =>
-        importees collect {
-          case i: Importee.Name if i.symbol.infoNoThrow exists (_.isImplicit) =>
-            importer.copy(importees = i :: Nil) -> i.pos
-        }
-    }.unzip
-
-    val noImplicits = importers.flatMap {
-      _.filterImportees { importee =>
-        !implicitPositions.contains(importee.pos)
-      }.toSeq
+    val implicitImporters = Seq.newBuilder[Importer]
+    val noImplicitImporters = Seq.newBuilder[Importer]
+    val separateImplicits = config.groupExplicitlyImportedImplicitsSeparately
+    if (separateImplicits) importers.foreach { importer =>
+      val (implicits, noImplicits) = importer.importees.partition {
+        case i: Importee.Name =>
+          i.symbol.infoNoThrow.exists(_.isImplicit)
+        case _ => false
+      }
+      if (implicits.isEmpty) noImplicitImporters += importer
+      else if (noImplicits.isEmpty) implicitImporters += importer
+      else {
+        implicitImporters += importer.copy(importees = implicits)
+        noImplicitImporters += importer.copy(importees = noImplicits)
+      }
     }
-
-    (implicits, noImplicits)
+    else importers.foreach(noImplicitImporters += _)
+    (implicitImporters.result(), noImplicitImporters.result())
   }
 
   private def isFullyQualified(

--- a/scalafix-tests/input/src/main/scala-2/test/organizeImports/ExplicitlyImportedImplicits.scala
+++ b/scalafix-tests/input/src/main/scala-2/test/organizeImports/ExplicitlyImportedImplicits.scala
@@ -6,6 +6,8 @@ OrganizeImports.groupExplicitlyImportedImplicitsSeparately = true
 package test.organizeImports
 
 import scala.concurrent.ExecutionContext
+import test.organizeImports.Implicits.c.longImplicit
+import test.organizeImports.Implicits.c.floatImplicit
 import test.organizeImports.Implicits.b._
 import ExecutionContext.Implicits.global
 import test.organizeImports.Implicits.a.{nonImplicit, intImplicit, stringImplicit}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/ExplicitlyImportedImplicits.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/ExplicitlyImportedImplicits.scala
@@ -5,6 +5,8 @@ import test.organizeImports.Implicits.b._
 
 import scala.concurrent.ExecutionContext
 
+import test.organizeImports.Implicits.c.longImplicit
+import test.organizeImports.Implicits.c.floatImplicit
 import ExecutionContext.Implicits.global
 import test.organizeImports.Implicits.a.intImplicit
 import test.organizeImports.Implicits.a.stringImplicit

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/ExplicitlyImportedImplicits.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/ExplicitlyImportedImplicits.scala
@@ -8,8 +8,7 @@ import scala.concurrent.ExecutionContext
 import test.organizeImports.Implicits.c.longImplicit
 import test.organizeImports.Implicits.c.floatImplicit
 import ExecutionContext.Implicits.global
-import test.organizeImports.Implicits.a.intImplicit
-import test.organizeImports.Implicits.a.stringImplicit
+import test.organizeImports.Implicits.a.{intImplicit, stringImplicit}
 
 // Unsupported on Scala 3
 // https://github.com/scala/scala3/issues/12766

--- a/scalafix-tests/shared/src/main/scala/test/organizeImports/Implicits.scala
+++ b/scalafix-tests/shared/src/main/scala/test/organizeImports/Implicits.scala
@@ -11,4 +11,9 @@ object Implicits {
     implicit def intImplicit: Int = ???
     implicit def stringImplicit: String = ???
   }
+
+  object c {
+    implicit def longImplicit: Long = ???
+    implicit def floatImplicit: Float = ???
+  }
 }


### PR DESCRIPTION
- don't "explode" them automatically, ignoring `groupedImports`
- use one pass, don't use positions
Helps with #2255.