### PR TITLE
OrganizeImportsConfig: use Conf{Codec,Decoder}Ex

### DIFF
--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -8,11 +8,7 @@ import scala.util.Try
 import scala.meta._
 
 import metaconfig.Conf
-import metaconfig.ConfDecoder
-import metaconfig.ConfEncoder
-import metaconfig.ConfOps
 import metaconfig.Configured
-import metaconfig.internal.ConfGet
 import scalafix.internal.config.ScalaVersion
 import scalafix.internal.rule.ImportMatcher._
 import scalafix.lint.Diagnostic
@@ -43,7 +39,7 @@ class OrganizeImports(
 
   private val wildcardGroupIndex: Int = matchers indexOf *
 
-  def this() = this(OrganizeImportsConfig())
+  def this() = this(OrganizeImportsConfig.default)
 
   override def description: String = "Organize import statements"
 
@@ -51,12 +47,13 @@ class OrganizeImports(
 
   override def isRewrite: Boolean = true
 
-  override def withConfiguration(config: Configuration): Configured[Rule] =
-    config.conf
-      .getOrElse("OrganizeImports")(OrganizeImportsConfig())
-      .andThen(patchPreset(_, config.conf))
-      .andThen(checkRemoveUnusedConflict(_, config.conf))
-      .andThen(checkScalacOptions(_, config.scalacOptions, config.scalaVersion))
+  override def withConfiguration(cfg: Configuration): Configured[Rule] =
+    (cfg.conf match {
+      case c: Conf.Obj => c.field("OrganizeImports").map(config.merge)
+      case _ => None
+    }).getOrElse(Configured.Ok(config))
+      .andThen(checkRemoveUnusedConflict(_, cfg.conf))
+      .andThen(checkScalacOptions(_, cfg.scalacOptions, cfg.scalaVersion))
 
   override def fix(implicit doc: SemanticDocument): Patch = {
     val that = (doc.input, scala3DialectForScala3Paths) match {
@@ -815,19 +812,6 @@ class OrganizeImports(
 
 object OrganizeImports {
   private case class ImportGroup(index: Int, imports: Seq[Importer])
-
-  private def patchPreset(
-      ruleConf: OrganizeImportsConfig,
-      conf: Conf
-  ): Configured[OrganizeImportsConfig] = {
-    val preset = OrganizeImportsConfig.presets(ruleConf.preset)
-    val presetConf = ConfEncoder[OrganizeImportsConfig].write(preset)
-    val userConf = ConfGet
-      .getOrOK(conf, "OrganizeImports" :: Nil, Configured.ok, Conf.Obj.empty)
-      .getOrElse(Conf.Obj.empty)
-    val mergedConf = ConfOps.merge(presetConf, userConf)
-    ConfDecoder[OrganizeImportsConfig].read(mergedConf)
-  }
 
   private def checkRemoveUnusedConflict(
       ruleConf: OrganizeImportsConfig,

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImportsConfig.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImportsConfig.scala
@@ -1,13 +1,6 @@
 package scalafix.internal.rule
 
-import metaconfig.Conf
-import metaconfig.ConfDecoder
-import metaconfig.ConfEncoder
-import metaconfig.generic.Surface
-import metaconfig.generic.deriveDecoder
-import metaconfig.generic.deriveEncoder
-import metaconfig.generic.deriveSurface
-import scalafix.internal.config.ReaderUtil
+import metaconfig._
 
 sealed trait ImportsOrder
 
@@ -17,14 +10,8 @@ object ImportsOrder {
   case object SymbolsFirst extends ImportsOrder
   case object Keep extends ImportsOrder
 
-  def all: List[ImportsOrder] =
-    List(Ascii, AsciiCaseInsensitive, SymbolsFirst, Keep)
-
-  implicit def reader: ConfDecoder[ImportsOrder] =
-    ReaderUtil.fromMap(all.map(x => x.toString -> x).toMap)
-
-  implicit def writer: ConfEncoder[ImportsOrder] =
-    ConfEncoder.instance(v => Conf.Str(v.toString))
+  implicit val codec: ConfCodecEx[ImportsOrder] = OrganizeImportsConfig
+    .getCodecFrom(Ascii, AsciiCaseInsensitive, SymbolsFirst, Keep)
 }
 
 sealed trait ImportSelectorsOrder
@@ -34,14 +21,8 @@ object ImportSelectorsOrder {
   case object SymbolsFirst extends ImportSelectorsOrder
   case object Keep extends ImportSelectorsOrder
 
-  def all: List[ImportSelectorsOrder] =
-    List(Ascii, SymbolsFirst, Keep)
-
-  implicit def reader: ConfDecoder[ImportSelectorsOrder] =
-    ReaderUtil.fromMap(all.map(x => x.toString -> x).toMap)
-
-  implicit def writer: ConfEncoder[ImportSelectorsOrder] =
-    ConfEncoder.instance(v => Conf.Str(v.toString))
+  implicit val codec: ConfCodecEx[ImportSelectorsOrder] = OrganizeImportsConfig
+    .getCodecFrom(Ascii, SymbolsFirst, Keep)
 }
 
 sealed trait GroupedImports
@@ -52,14 +33,8 @@ object GroupedImports {
   case object Explode extends GroupedImports
   case object Keep extends GroupedImports
 
-  def all: List[GroupedImports] =
-    List(AggressiveMerge, Merge, Explode, Keep)
-
-  implicit def reader: ConfDecoder[GroupedImports] =
-    ReaderUtil.fromMap(all.map(x => x.toString -> x).toMap)
-
-  implicit def writer: ConfEncoder[GroupedImports] =
-    ConfEncoder.instance(v => Conf.Str(v.toString))
+  implicit val codec: ConfCodecEx[GroupedImports] = OrganizeImportsConfig
+    .getCodecFrom(AggressiveMerge, Merge, Explode, Keep)
 }
 
 sealed trait BlankLines
@@ -68,30 +43,8 @@ object BlankLines {
   case object Auto extends BlankLines
   case object Manual extends BlankLines
 
-  def all: List[BlankLines] =
-    List(Auto, Manual)
-
-  implicit def reader: ConfDecoder[BlankLines] =
-    ReaderUtil.fromMap(all.map(x => x.toString -> x).toMap)
-
-  implicit def writer: ConfEncoder[BlankLines] =
-    ConfEncoder.instance(v => Conf.Str(v.toString))
-}
-
-sealed trait Preset
-
-object Preset {
-  case object DEFAULT extends Preset
-  case object INTELLIJ_2020_3 extends Preset
-
-  def all: List[Preset] =
-    List(DEFAULT, INTELLIJ_2020_3)
-
-  implicit def reader: ConfDecoder[Preset] =
-    ReaderUtil.fromMap(all.map(x => x.toString -> x).toMap)
-
-  implicit def writer: ConfEncoder[Preset] =
-    ConfEncoder.instance(v => Conf.Str(v.toString))
+  implicit val codec: ConfCodecEx[BlankLines] = OrganizeImportsConfig
+    .getCodecFrom(Auto, Manual)
 }
 
 sealed trait TargetDialect
@@ -101,14 +54,8 @@ object TargetDialect {
   case object Scala3 extends TargetDialect
   case object StandardLayout extends TargetDialect
 
-  def all: List[TargetDialect] =
-    List(Auto, Scala2, Scala3, StandardLayout)
-
-  implicit def reader: ConfDecoder[TargetDialect] =
-    ReaderUtil.fromMap(all.map(x => x.toString -> x).toMap)
-
-  implicit def writer: ConfEncoder[TargetDialect] =
-    ConfEncoder.instance(v => Conf.Str(v.toString))
+  implicit val codec: ConfCodecEx[TargetDialect] = OrganizeImportsConfig
+    .getCodecFrom(Auto, Scala2, Scala3, StandardLayout)
 }
 
 final case class OrganizeImportsConfig(
@@ -123,26 +70,41 @@ final case class OrganizeImportsConfig(
     ),
     importSelectorsOrder: ImportSelectorsOrder = ImportSelectorsOrder.Ascii,
     importsOrder: ImportsOrder = ImportsOrder.Ascii,
-    preset: Preset = Preset.DEFAULT,
     removeUnused: Boolean = true,
     targetDialect: TargetDialect = TargetDialect.StandardLayout
-)
+) {
+
+  def merge(conf: Conf): Configured[OrganizeImportsConfig] = {
+    val (state, confRest) = (conf match {
+      case conf: Conf.Obj =>
+        val remapped = conf.removeMapIf {
+          case ("preset", Conf.Str("DEFAULT")) =>
+            OrganizeImportsConfig.default
+          case ("preset", Conf.Str("INTELLIJ_2020_3")) =>
+            OrganizeImportsConfig(
+              coalesceToWildcardImportThreshold = Some(5),
+              groupedImports = GroupedImports.Merge
+            )
+        }
+        remapped.map { case (state, elems) => state -> Conf.Obj(elems) }
+      case _ => None
+    }).getOrElse(this -> conf)
+    OrganizeImportsConfig.decoder.read(Some(state), confRest)
+  }
+
+}
 
 object OrganizeImportsConfig {
   val default: OrganizeImportsConfig = OrganizeImportsConfig()
 
-  implicit val surface: Surface[OrganizeImportsConfig] =
-    deriveSurface
+  implicit val surface: generic.Surface[OrganizeImportsConfig] =
+    generic.deriveSurface
   implicit val encoder: ConfEncoder[OrganizeImportsConfig] =
-    deriveEncoder
-  implicit val decoder: ConfDecoder[OrganizeImportsConfig] =
-    deriveDecoder(default)
+    generic.deriveEncoder[OrganizeImportsConfig]
+  implicit val decoder: ConfDecoderEx[OrganizeImportsConfig] =
+    generic.deriveDecoderEx(default).noTypos
 
-  val presets: Map[Preset, OrganizeImportsConfig] = Map(
-    Preset.DEFAULT -> OrganizeImportsConfig(),
-    Preset.INTELLIJ_2020_3 -> OrganizeImportsConfig(
-      coalesceToWildcardImportThreshold = Some(5),
-      groupedImports = GroupedImports.Merge
-    )
-  )
+  def getCodecFrom[T](values: T*): ConfCodecEx[T] =
+    ConfCodecEx.oneOf(values.map(x => sourcecode.Text(x, x.toString)): _*)
+
 }


### PR DESCRIPTION
Allows handling presets by passing the right initial state, rather than via encoding, merge and decoding.

Don't need to use:
- custom ReaderUtil as ConfCodecEx defines it already
- presets as a separate step as we can transform Conf.

The only nuance is that for scala3 the build uses sourcecode_2.13, so we can't use the macro syntax.

Blocks #2449. This will allow modifying `groupExplicitlyImportedImplicitsSeparately` parameter to allow additional options.