### PR TITLE
Update Maven Central badge link in installation.md

### DIFF
--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -40,7 +40,7 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "@VERSION@")
 > dependencyOverrides += "ch.epfl.scala" % "scalafix-interfaces" % "@VERSION@"
 > ```
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/ch.epfl.scala/sbt-scalafix/badge.svg)](https://maven-badges.herokuapp.com/maven-central/ch.epfl.scala/sbt-scalafix)
+[![Maven Central](https://maven-badges.sml.io/maven-central/ch.epfl.scala/sbt-scalafix/badge.svg)](https://maven-badges.sml.io/maven-central/ch.epfl.scala/sbt-scalafix)
 
 From the sbt shell, let's run the rule `ProcedureSyntax`:
 


### PR DESCRIPTION
The badge link/image is currently broken. According to [this](https://github.com/softwaremill/maven-badges#a-new-dns-address), `https://maven-badges.herokuapp.com` has been deprecated.

<img width="834" height="189" alt="image" src="https://github.com/user-attachments/assets/95cfe70b-3cf4-4e1e-b902-64879db1af56" />
