### PR TITLE
Replace: unimport replaced symbol from nested wildcard imports (#376)

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
@@ -28,21 +28,36 @@ object ReplaceSymbolOps {
     case _ => stats.collect { case i: Import => i }
   }
 
+  private def globalImports(tree: Tree): Seq[Import] = tree match {
+    case t: Pkg => extractImports(t.body.stats)
+    case t: Source => extractImports(t.stats)
+    case _ => Nil
+  }
+
+  // The rightmost `Name` of an importer ref, e.g. `mutable` in
+  // `import scala.collection.mutable._`, used to resolve the importer's owner.
+  private def refTerminalName(ref: Term.Ref): Option[Name] = ref match {
+    case Term.Select(_, name) => Some(name)
+    case name: Term.Name => Some(name)
+    case _ => None
+  }
+
+  @tailrec
+  private def isAncestor(ancestor: Tree, tree: Tree): Boolean =
+    tree.parent match {
+      case Some(p) => (p eq ancestor) || isAncestor(ancestor, p)
+      case None => false
+    }
+
   private def getNamesOfExplicitlyImportedSymbols(
       tree: Tree,
       isMoved: Name => Boolean
   ): Set[String] = {
-    val globalImports = tree match {
-      case t: Pkg => extractImports(t.body.stats)
-      case t: Source => extractImports(t.stats)
-      case _ => Nil
-    }
-
     // pre-compute global imported symbols for O(1) collision detection
     // since ctx.addGlobalImport adds imports at global scope
     // exclude names whose symbols are being moved, as those imports
     // will be removed and should not count as collisions
-    globalImports.flatMap { importStat =>
+    globalImports(tree).flatMap { importStat =>
       importStat.importers.flatMap { importer =>
         importer.importees.collect {
           case Importee.Name(name) if !isMoved(name) => name.value
@@ -76,6 +91,27 @@ object ReplaceSymbolOps {
 
     lazy val globalImportedNames =
       getNamesOfExplicitlyImportedSymbols(ctx.tree, Move.unapply(_).isDefined)
+
+    // Wildcard imports nested below the top level (inside a class/object/def
+    // body), paired with the normalized symbol of their owner. A top-level
+    // wildcard shares the scope of the global import we add for the replacement,
+    // where a named import already takes precedence over a wildcard; only a
+    // wildcard in an inner scope can clash with that named import and produce the
+    // ambiguous import reported in scalacenter/scalafix#376.
+    lazy val nestedWildcardImports: List[(Import, Importer, String)] = {
+      val topLevel = globalImports(ctx.tree)
+      ctx.tree
+        .collect { case i: Import => i }
+        .filterNot(i => topLevel.exists(_ eq i))
+        .flatMap { importStat =>
+          for {
+            importer <- importStat.importers
+            if importer.importees.exists(_.is[Importee.Wildcard])
+            ownerName <- refTerminalName(importer.ref).toList
+            ownerSym <- ownerName.symbol.toList
+          } yield (importStat, importer, SymbolOps.normalize(ownerSym).syntax)
+        }
+    }
     @annotation.nowarn("msg=Exhaustivity|match may not be exhaustive")
     def loop(ref: Ref, sym: Symbol, isImport: Boolean): (Patch, Symbol) = {
       (ref, sym) match {
@@ -111,16 +147,16 @@ object ReplaceSymbolOps {
       }
     }
     object Move {
-      def unapply(name: Name): Option[Symbol.Global] = {
-        val result = name.symbol.iterator
+      def unapply(name: Name): Option[(Symbol.Global, Symbol.Global)] = {
+        name.symbol.iterator
           .flatMap {
             case Symbol.Multi(syms) => syms
             case els => els :: Nil
           }
-          .collectFirst { case Moved(out) =>
-            out
-          }
-        result
+          .collectFirst(Function.unlift {
+            case from: Symbol.Global => Moved.unapply(from).map(from -> _)
+            case _ => None
+          })
       }
     }
     object Identifier {
@@ -130,15 +166,72 @@ object ReplaceSymbolOps {
         case _ => None
       }
     }
-    val patches = ctx.tree.collect { case n @ Move(to) =>
+    // The short name of an import selector that renames-or-names a replaced
+    // symbol whose replacement keeps the same short name (the only case that
+    // can clash with the top-level named import we add). `None` otherwise.
+    def sameNameMoved(nm: Name): Option[String] =
+      Move.unapply(nm).collect {
+        case (from, to) if from.signature.name == to.signature.name => nm.value
+      }
+
+    // Nested wildcard importers that must be rewritten to unimport a replaced
+    // name, mapped to those names. Without this, the wildcard keeps bringing the
+    // old binding into an inner scope where it clashes with the top-level named
+    // import added for the replacement, producing the ambiguous import reported
+    // in scalacenter/scalafix#376. A name needs unimporting when it is:
+    //   - selected explicitly alongside the wildcard (`{Future, _}`), or renamed
+    //     alongside it (`{Future => F, _}`) -- removing/renaming the selector
+    //     would otherwise let the wildcard re-introduce the old binding; or
+    //   - referenced by its own (unrenamed) short name and brought in only by
+    //     the wildcard (`import p._; Future...`).
+    // Top-level wildcards are excluded (see `nestedWildcardImports`): there a
+    // named import already takes precedence over the wildcard.
+    val wildcardRewrites: Map[Importer, Set[String]] = {
+      val selectorPairs = nestedWildcardImports.flatMap {
+        case (_, importer, _) =>
+          importer.importees.flatMap {
+            case Importee.Name(nm) => sameNameMoved(nm).map(importer -> _)
+            case Importee.Rename(nm, _) => sameNameMoved(nm).map(importer -> _)
+            case _ => None
+          }
+      }
+      val usagePairs = ctx.tree.collect {
+        case n @ Move((from, to))
+            if from.signature.name == to.signature.name &&
+              n.value == from.signature.name &&
+              !n.parent.exists(_.is[Importee]) =>
+          val ownerKey = SymbolOps.normalize(from.owner).syntax
+          nestedWildcardImports.collect {
+            case (importStat, importer, owner)
+                if owner == ownerKey &&
+                  importStat.parent.exists(isAncestor(_, n)) =>
+              importer -> from.signature.name
+          }
+      }.flatten
+      (selectorPairs ++ usagePairs).groupBy(_._1).map { case (importer, ps) =>
+        importer -> ps.map(_._2).toSet
+      }
+    }
+
+    val patches = ctx.tree.collect { case n @ Move((_, to)) =>
       // was this written as `to = "blah"` instead of `to = _root_.blah`
       val isSelected = to match {
         case Root(_) => false
         case _ => true
       }
+      // A nested wildcard rewrite (below) replaces the whole importer, dropping
+      // every moved selector itself, so the per-importee branches must not also
+      // edit selectors of such an importer or the patches would overlap.
+      def rewrittenByWildcard(importee: Importee): Boolean =
+        importee.parent.exists {
+          case importer: Importer => wildcardRewrites.contains(importer)
+          case _ => false
+        }
       n.parent match {
         case Some(i @ Importee.Name(_)) =>
-          ctx.removeImportee(i)
+          if (rewrittenByWildcard(i)) Patch.empty else ctx.removeImportee(i)
+        case Some(i @ Importee.Rename(_, _)) if rewrittenByWildcard(i) =>
+          Patch.empty
         case Some(i @ Importee.Rename(name, rename)) =>
           i.parent match {
             case Some(Importer(ref, `i` :: Nil)) =>
@@ -177,6 +270,40 @@ object ReplaceSymbolOps {
           Patch.empty
       }
     }
-    patches.asPatch
+
+    // Rewrite each affected wildcard import in place so that it unimports the
+    // replaced names while keeping the rest, e.g.
+    // `import scala.collection.mutable._`,
+    // `import scala.collection.mutable.{ListBuffer, _}` and
+    // `import scala.collection.mutable.{ListBuffer => LB, _}` all become
+    // `import scala.collection.mutable.{ListBuffer => _, _}`. Every moved
+    // selector is dropped (its replacement is imported at the use site); the
+    // unimport then keeps the wildcard from re-introducing the old binding.
+    // Rewriting in place (rather than adding a global import) preserves the
+    // wildcard's lexical scope, which is what makes this work.
+    val unimportPatches = wildcardRewrites.toList.flatMap {
+      case (importer, names) =>
+        val remaining = importer.importees.filterNot {
+          case Importee.Name(nm) => Move.unapply(nm).isDefined
+          case Importee.Rename(nm, _) => Move.unapply(nm).isDefined
+          case _ => false
+        }
+        val unimports: List[Importee] = names.toList
+          .filterNot(name =>
+            importer.importees.exists {
+              case Importee.Unimport(n) => n.value == name
+              case _ => false
+            }
+          )
+          .map(name => Importee.Unimport(Name.Indeterminate(name)))
+        if (unimports.isEmpty && remaining.length == importer.importees.length)
+          Nil
+        else {
+          val rewritten = importer.copy(importees = unimports ++ remaining)
+          List(Patch.replaceTree(importer, rewritten.syntax))
+        }
+    }
+
+    (patches ++ unimportPatches).asPatch
   }
 }

--- a/scalafix-core/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/patch/ReplaceSymbolOps.scala
@@ -186,7 +186,7 @@ object ReplaceSymbolOps {
     //     the wildcard (`import p._; Future...`).
     // Top-level wildcards are excluded (see `nestedWildcardImports`): there a
     // named import already takes precedence over the wildcard.
-    val wildcardRewrites: Map[Importer, Set[String]] = {
+    val wildcardRewrites: Map[Importer, List[String]] = {
       val selectorPairs = nestedWildcardImports.flatMap {
         case (_, importer, _) =>
           importer.importees.flatMap {
@@ -208,9 +208,26 @@ object ReplaceSymbolOps {
               importer -> from.signature.name
           }
       }.flatten
+      // `distinct` keeps source order, so the rewritten selectors are stable
       (selectorPairs ++ usagePairs).groupBy(_._1).map { case (importer, ps) =>
-        importer -> ps.map(_._2).toSet
+        importer -> ps.map(_._2).distinct
       }
+    }
+
+    // Aliases whose `Importee.Rename` is dropped by a wildcard rewrite below:
+    // in-scope uses of such an alias must be rewritten to the replacement,
+    // since the alias binding no longer exists after the rewrite.
+    val droppedAliases: List[(String, Import)] = nestedWildcardImports.collect {
+      case (importStat, importer, _) if wildcardRewrites.contains(importer) =>
+        importer.importees.collect {
+          case Importee.Rename(nm, rename) if Move.unapply(nm).isDefined =>
+            rename.value -> importStat
+        }
+    }.flatten
+
+    def aliasDropped(alias: Name): Boolean = droppedAliases.exists {
+      case (name, importStat) =>
+        name == alias.value && importStat.parent.exists(isAncestor(_, alias))
     }
 
     val patches = ctx.tree.collect { case n @ Move((_, to)) =>
@@ -253,8 +270,11 @@ object ReplaceSymbolOps {
           val (patch, imp) =
             loop(parent, to, isImport = n.parents.exists(_.is[Import]))
           ctx.addGlobalImport(imp) + patch
+        // A renamed symbol keeps its alias via the rewritten rename import, so
+        // its use sites are left alone -- unless the alias was dropped by a
+        // wildcard rewrite, in which case fall through to rewrite the use site.
         case Some(Identifier(parent, Symbol.Global(_, sig)))
-            if sig.name != parent.value =>
+            if sig.name != parent.value && !aliasDropped(parent) =>
           Patch.empty // do nothing because it was a renamed symbol
         case Some(_) =>
           lazy val mayCauseCollision =
@@ -288,7 +308,7 @@ object ReplaceSymbolOps {
           case Importee.Rename(nm, _) => Move.unapply(nm).isDefined
           case _ => false
         }
-        val unimports: List[Importee] = names.toList
+        val unimports: List[Importee] = names
           .filterNot(name =>
             importer.importees.exists {
               case Importee.Unimport(n) => n.value == name

--- a/scalafix-tests/input/src/main/scala/test/ReplaceSymbolUnimport.scala
+++ b/scalafix-tests/input/src/main/scala/test/ReplaceSymbolUnimport.scala
@@ -1,0 +1,46 @@
+/*
+rules = [
+  "replace:scala.concurrent.Future/com.geirsson.Future"
+  "replace:scala.util.Random/com.geirsson.Random"
+]
+ */
+package test
+
+// The replaced symbols are brought into scope by *nested* wildcard imports
+// (inside a def body and inside an object) that also bring other, used names
+// into scope. The replacement's named import is added at the top level, so
+// leaving the nested wildcards untouched would expose the old bindings in an
+// inner scope and produce an ambiguous import (scalacenter/scalafix#376). Each
+// nested wildcard must unimport the replaced name while keeping the rest.
+object ReplaceSymbolUnimport {
+  def run: Any = {
+    import scala.concurrent._
+    Future.successful(1)
+    Future.successful(2)
+    Promise[Int]()
+  }
+
+  object Nested {
+    import scala.util._
+    Random.nextInt()
+    Try(1)
+  }
+
+  // The replaced name is *both* explicitly imported and wildcard-imported. The
+  // explicit importee must be folded into the unimport rather than left
+  // alongside it (which would re-import the old binding).
+  def grouped: Any = {
+    import scala.concurrent.{Future, _}
+    Future.successful(3)
+    Promise[Int]()
+  }
+
+  // The replaced name is renamed alongside a wildcard. The rename selector is
+  // dropped (the alias usage is rewritten to the replacement) and turned into
+  // an unimport so the wildcard no longer re-introduces the old binding.
+  def renamed: Any = {
+    import scala.concurrent.{Future => ScalaFuture, _}
+    ScalaFuture.successful(4)
+    Promise[Int]()
+  }
+}

--- a/scalafix-tests/input/src/main/scala/test/ReplaceSymbolUnimport.scala
+++ b/scalafix-tests/input/src/main/scala/test/ReplaceSymbolUnimport.scala
@@ -43,4 +43,12 @@ object ReplaceSymbolUnimport {
     ScalaFuture.successful(4)
     Promise[Int]()
   }
+
+  // The alias of a dropped rename selector is used at a constructor call. That
+  // use site must be rewritten too, since the alias binding no longer exists.
+  def aliased: Any = {
+    import scala.util.{Random => Rnd, _}
+    val r: Rnd = new Rnd()
+    Try(r)
+  }
 }

--- a/scalafix-tests/input/src/main/scala/test/ReplaceSymbolUnimportCombined.scala
+++ b/scalafix-tests/input/src/main/scala/test/ReplaceSymbolUnimportCombined.scala
@@ -1,0 +1,22 @@
+/*
+rules = [
+  "replace:scala.concurrent.Future/com.geirsson.Future"
+  "replace:scala.concurrent.Promise/com.geirsson.Promise"
+]
+ */
+package test
+
+// A single nested wildcard importer that both renames one replaced symbol and
+// explicitly names another, alongside the wildcard. Every moved selector must
+// be dropped and folded into unimports so the wildcard cannot re-introduce the
+// old bindings (scalacenter/scalafix#376), while the surviving wildcard name
+// (ExecutionContext) stays available.
+object ReplaceSymbolUnimportCombined {
+  def f: Any = {
+    import scala.concurrent.{Future => AliasF, Promise, _}
+    AliasF.successful(1)
+    Promise[Int]()
+    val ec: ExecutionContext = null
+    ec
+  }
+}

--- a/scalafix-tests/output/src/main/scala/com/geirsson/Promise.scala
+++ b/scalafix-tests/output/src/main/scala/com/geirsson/Promise.scala
@@ -1,0 +1,6 @@
+package com.geirsson
+
+class Promise[T]
+object Promise {
+  def apply[T](): Promise[T] = ???
+}

--- a/scalafix-tests/output/src/main/scala/test/ReplaceSymbolUnimport.scala
+++ b/scalafix-tests/output/src/main/scala/test/ReplaceSymbolUnimport.scala
@@ -1,0 +1,41 @@
+package test
+
+import com.geirsson.{Future, Random}
+// The replaced symbols are brought into scope by *nested* wildcard imports
+// (inside a def body and inside an object) that also bring other, used names
+// into scope. The replacement's named import is added at the top level, so
+// leaving the nested wildcards untouched would expose the old bindings in an
+// inner scope and produce an ambiguous import (scalacenter/scalafix#376). Each
+// nested wildcard must unimport the replaced name while keeping the rest.
+object ReplaceSymbolUnimport {
+  def run: Any = {
+    import scala.concurrent.{Future => _, _}
+    Future.successful(1)
+    Future.successful(2)
+    Promise[Int]()
+  }
+
+  object Nested {
+    import scala.util.{Random => _, _}
+    Random.nextInt()
+    Try(1)
+  }
+
+  // The replaced name is *both* explicitly imported and wildcard-imported. The
+  // explicit importee must be folded into the unimport rather than left
+  // alongside it (which would re-import the old binding).
+  def grouped: Any = {
+    import scala.concurrent.{Future => _, _}
+    Future.successful(3)
+    Promise[Int]()
+  }
+
+  // The replaced name is renamed alongside a wildcard. The rename selector is
+  // dropped (the alias usage is rewritten to the replacement) and turned into
+  // an unimport so the wildcard no longer re-introduces the old binding.
+  def renamed: Any = {
+    import scala.concurrent.{Future => _, _}
+    Future.successful(4)
+    Promise[Int]()
+  }
+}

--- a/scalafix-tests/output/src/main/scala/test/ReplaceSymbolUnimport.scala
+++ b/scalafix-tests/output/src/main/scala/test/ReplaceSymbolUnimport.scala
@@ -38,4 +38,12 @@ object ReplaceSymbolUnimport {
     Future.successful(4)
     Promise[Int]()
   }
+
+  // The alias of a dropped rename selector is used at a constructor call. That
+  // use site must be rewritten too, since the alias binding no longer exists.
+  def aliased: Any = {
+    import scala.util.{Random => _, _}
+    val r: Random = new Random()
+    Try(r)
+  }
 }

--- a/scalafix-tests/output/src/main/scala/test/ReplaceSymbolUnimportCombined.scala
+++ b/scalafix-tests/output/src/main/scala/test/ReplaceSymbolUnimportCombined.scala
@@ -1,0 +1,17 @@
+package test
+
+import com.geirsson.{Future, Promise}
+// A single nested wildcard importer that both renames one replaced symbol and
+// explicitly names another, alongside the wildcard. Every moved selector must
+// be dropped and folded into unimports so the wildcard cannot re-introduce the
+// old bindings (scalacenter/scalafix#376), while the surviving wildcard name
+// (ExecutionContext) stays available.
+object ReplaceSymbolUnimportCombined {
+  def f: Any = {
+    import scala.concurrent.{Future => _, Promise => _, _}
+    Future.successful(1)
+    Promise[Int]()
+    val ec: ExecutionContext = null
+    ec
+  }
+}


### PR DESCRIPTION
Fixes #376.

## Fix

Each affected **nested** wildcard importer is rewritten **in place** to unimport the replaced name(s), preserving the wildcard's other names:

| before | after |
|---|---|
| `import p._` | `import p.{A => _, _}` |
| `import p.{A, _}` | `import p.{A => _, _}` |
| `import p.{A => Alias, _}` | `import p.{A => _, _}` |

Only **nested** wildcards are touched — a top-level one is already outranked by the named import we add in the same scope. In-place rewriting keeps the wildcard's lexical scope, which is what stops the old binding from shadowing the replacement.

The rewrite is the importer's **sole editor**: it drops every moved selector (`Name` and `Rename`), folds them into unimports, and the per-importee branches skip those selectors so patches don't overlap. Verified on Scala 2.13 and 3.3.

## Out of scope

Replacing a symbol that is rename-imported in a **non-wildcard** multi-importee importer (e.g. `import p.{A => Alias, B}`) is a separate, pre-existing issue (an `Importee.Rename` invariant) and is untouched here.