### PR TITLE
OrganizeImports: preserve trailing comma in multi-line imports

### DIFF
--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -794,10 +794,16 @@ class OrganizeImports(
             val line = lines.next()
             lines.exists(_ != line)
           }
-          val useOuterSpace = !isMultiline && i.importees
+          val origImporters = i.importees
             .flatMap(_.originalPrototype().parent)
             .distinct
-            .exists(_.hasSpaceInCurly)
+          val useOuterSpace =
+            !isMultiline && origImporters.exists(_.hasSpaceInCurly)
+          // Preserve a trailing comma if the (single) source importer had one.
+          val trailingComma = isMultiline && (origImporters match {
+            case Seq(i: Importer) => i.hasTrailingComma
+            case _ => false
+          })
           sb.append('{')
           val sep = if (isMultiline) "\n  " else " "
           if (isMultiline) sb.append(sep)
@@ -810,8 +816,10 @@ class OrganizeImports(
             sb.append(treeSyntax(i2))
             proto.endComment.foreach(appendEndComment)
           }
-          if (isMultiline) sb.append('\n')
-          else if (useOuterSpace) sb.append(' ')
+          if (isMultiline) {
+            if (trailingComma) sb.append(',')
+            sb.append('\n')
+          } else if (useOuterSpace) sb.append(' ')
           sb.append('}')
         }
         i.endComment.foreach(appendEndComment)
@@ -1199,6 +1207,13 @@ object OrganizeImports {
         tokens.getWideOpt(idx).exists(_.is[Token.RightBrace])
       }
       lspace || rspace
+    }
+
+    def hasTrailingComma: Boolean = {
+      val tokens = importer.importees.last.tokens
+      // The first token right after the last importee is a comma when the source
+      // importer ends with a trailing comma (before any whitespace or `}`).
+      tokens.getWideOpt(tokens.length).exists(_.is[Token.Comma])
     }
 
   }

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -801,7 +801,7 @@ class OrganizeImports(
             !isMultiline && origImporters.exists(_.hasSpaceInCurly)
           // Preserve a trailing comma if the (single) source importer had one.
           val trailingComma = isMultiline && (origImporters match {
-            case Seq(i: Importer) => i.hasTrailingComma
+            case Seq(origImporter: Importer) => origImporter.hasTrailingComma
             case _ => false
           })
           sb.append('{')

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -1211,9 +1211,9 @@ object OrganizeImports {
 
     def hasTrailingComma: Boolean = {
       val tokens = importer.importees.last.tokens
-      // The first token right after the last importee is a comma when the source
-      // importer ends with a trailing comma (before any whitespace or `}`).
-      tokens.getWideOpt(tokens.length).exists(_.is[Token.Comma])
+      // Skip trivia between the last importee and the next token.
+      val idx = tokens.skipWideIf(_.is[Token.HTrivia], tokens.length)
+      tokens.getWideOpt(idx).exists(_.is[Token.Comma])
     }
 
   }

--- a/scalafix-tests/input/src/main/scala-3/test/organizeImports/MultiLineImportsWithAliasesReorder.scala
+++ b/scalafix-tests/input/src/main/scala-3/test/organizeImports/MultiLineImportsWithAliasesReorder.scala
@@ -8,10 +8,12 @@ OrganizeImports {
  */
 package test.organizeImports
 
-// Imports are in WRONG order: TreeMap before HashMap - rule must reorder
+// Imports are in WRONG order, mixing aliased and plain names - rule must reorder
 import scala.collection.immutable.{
   TreeMap as TMap,
+  Vector,
   HashMap as HMap,
+  Queue,
   ArraySeq as ASeq,
 }
 

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/MultiLineTrailingComma.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/MultiLineTrailingComma.scala
@@ -1,0 +1,17 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Merge
+  removeUnused = false
+}
+ */
+package test.organizeImports
+
+// The source importer ends with a trailing comma: it must be preserved after reordering.
+import scala.collection.immutable.{
+  TreeMap,
+  HashMap,
+  BitSet,
+}
+
+object MultiLineTrailingComma

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/MultiLineTrailingCommaWithTrivia.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/MultiLineTrailingCommaWithTrivia.scala
@@ -1,0 +1,18 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Merge
+  removeUnused = false
+}
+ */
+package test.organizeImports
+
+// The trailing comma is separated from the last importee by trivia (whitespace here,
+// but comments behave the same); it must still be detected and preserved after reordering.
+import scala.collection.immutable.{
+  TreeMap,
+  HashMap,
+  BitSet ,
+}
+
+object MultiLineTrailingCommaWithTrivia

--- a/scalafix-tests/output/src/main/scala-2-xsource3/test/organizeImports/MultiLineImportsWithAliasesPreservation.scala
+++ b/scalafix-tests/output/src/main/scala-2-xsource3/test/organizeImports/MultiLineImportsWithAliasesPreservation.scala
@@ -4,7 +4,7 @@ package test.organizeImports
 import scala.collection.immutable.{
   HashMap as HMap,
   ListMap as LMap,
-  TreeMap as TMap
+  TreeMap as TMap,
 }
 
 object MultiLineImportsWithAliasesPreservation

--- a/scalafix-tests/output/src/main/scala-2-xsource3/test/organizeImports/MultiLineImportsWithAliasesUsed.scala
+++ b/scalafix-tests/output/src/main/scala-2-xsource3/test/organizeImports/MultiLineImportsWithAliasesUsed.scala
@@ -4,7 +4,7 @@ package test.organizeImports
 import scala.collection.immutable.{
   HashMap as HMap,
   ListMap as LMap,
-  TreeMap as TMap
+  TreeMap as TMap,
 }
 
 object MultiLineImportsWithAliasesUsed {

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/MultiLineImportsWithAliasesAndWildcard.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/MultiLineImportsWithAliasesAndWildcard.scala
@@ -6,7 +6,7 @@ import scala.collection.immutable.*
 import scala.collection.immutable.{
   ArraySeq as ASeq,
   HashMap as HMap,
-  TreeMap as TMap
+  TreeMap as TMap,
 }
 
 object MultiLineImportsWithAliasesAndWildcard

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/MultiLineImportsWithAliasesPreservation.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/MultiLineImportsWithAliasesPreservation.scala
@@ -4,7 +4,7 @@ package test.organizeImports
 import scala.collection.immutable.{
   ArraySeq as ASeq,
   HashMap as HMap,
-  TreeMap as TMap
+  TreeMap as TMap,
 }
 
 object MultiLineImportsWithAliasesPreservation

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/MultiLineImportsWithAliasesReorder.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/MultiLineImportsWithAliasesReorder.scala
@@ -1,10 +1,12 @@
 package test.organizeImports
 
-// Imports are in WRONG order: TreeMap before HashMap - rule must reorder
+// Imports are in WRONG order, mixing aliased and plain names - rule must reorder
 import scala.collection.immutable.{
   ArraySeq as ASeq,
   HashMap as HMap,
-  TreeMap as TMap
+  Queue,
+  TreeMap as TMap,
+  Vector,
 }
 
 object MultiLineImportsWithAliasesReorder

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/MultiLineTrailingComma.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/MultiLineTrailingComma.scala
@@ -1,0 +1,10 @@
+package test.organizeImports
+
+// The source importer ends with a trailing comma: it must be preserved after reordering.
+import scala.collection.immutable.{
+  BitSet,
+  HashMap,
+  TreeMap,
+}
+
+object MultiLineTrailingComma

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/MultiLineTrailingCommaWithTrivia.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/MultiLineTrailingCommaWithTrivia.scala
@@ -1,0 +1,11 @@
+package test.organizeImports
+
+// The trailing comma is separated from the last importee by trivia (whitespace here,
+// but comments behave the same); it must still be detected and preserved after reordering.
+import scala.collection.immutable.{
+  BitSet,
+  HashMap,
+  TreeMap,
+}
+
+object MultiLineTrailingCommaWithTrivia


### PR DESCRIPTION
Since the switch to scalameta pretty-reprinting ([0d232c9f](https://github.com/scalacenter/scalafix/pull/2427)), the rule stopped re-emitting the trailing comma when reprinting a multi-line import, even when nothing else changed. 
On an already-sorted import the rule would still produce a diff, just to strip the comma.


This makes it effectively impossible to roll OrganizeImports out on a large code base that uses trailing commas: every multi-line import loses its comma on the first run, producing a huge, noisy diff. Worse, it fights with scalafmt — scalafmt is configured to add the trailing commas back, so the two tools keep undoing each other, and the formatting never converges (CI flip-flops, pre-commit hooks loop).