### PR TITLE
DisableSyntax.regex: don't self-report inside suppression anchors

### DIFF
--- a/docs/rules/DisableSyntax.md
+++ b/docs/rules/DisableSyntax.md
@@ -62,6 +62,11 @@ DisableSyntax.regex = [
    of code is in, in case your regex is complicated and also matches characters 
    not useful in an error message.
 
+Patterns are matched against the raw source text, including comments. Text
+inside [suppression comments](../users/suppression.md) (`// scalafix:ok ...`,
+`// scalafix:off ...`, `// scalafix:on ...`) is exempt, so an anchor such as
+`// scalafix:ok println` never reports the very pattern it suppresses.
+
 ### Error Messages  
 
 Error messages have access to the capture groups of the regex. To access the 

--- a/docs/rules/DisableSyntax.md
+++ b/docs/rules/DisableSyntax.md
@@ -65,7 +65,8 @@ DisableSyntax.regex = [
 Patterns are matched against the raw source text, including comments. Text
 inside [suppression comments](../users/suppression.md) (`// scalafix:ok ...`,
 `// scalafix:off ...`, `// scalafix:on ...`) is exempt, so an anchor such as
-`// scalafix:ok println` never reports the very pattern it suppresses.
+`// scalafix:ok println` never reports the very pattern it suppresses. Only
+matches starting inside such a comment are exempt.
 
 ### Error Messages  
 

--- a/scalafix-core/src/main/scala/scalafix/internal/patch/EscapeHatch.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/patch/EscapeHatch.scala
@@ -6,6 +6,7 @@ import scala.collection.immutable.TreeMap
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.util.control.TailCalls._
+import scala.util.matching.Regex
 
 import scala.meta._
 import scala.meta.contrib._
@@ -143,6 +144,40 @@ object EscapeHatch {
 
   private object EscapeOffset {
     implicit val ordering: Ordering[EscapeOffset] = Ordering.by(_.offset)
+  }
+
+  /**
+   * Grammar of the suppression comments (anchors). Kept in one place so that
+   * rules recognizing anchors in comment text (e.g. DisableSyntax.regex) stay
+   * in sync with the escape mechanism by construction.
+   */
+  object Anchor {
+    val Prefix: String = "scalafix:"
+    val Ok: String = Prefix + "ok"
+    val On: String = Prefix + "on"
+    val Off: String = Prefix + "off"
+    val OkRgx: Regex = regex(Ok)
+    val OnRgx: Regex = regex(On)
+    val OffRgx: Regex = regex(Off)
+
+    private def regex(anchor: String) = s"\\s?$anchor\\s?(.*?)(?:;.*)?".r
+
+    def splitRules(rules: String): List[String] = {
+      val trimmed = rules.trim
+      if (trimmed.isEmpty) Nil else trimmed.split("\\s*,\\s*").toList
+    }
+
+    /**
+     * The rules named by an `ok`, `on` or `off` anchor comment; None if the
+     * comment is not an anchor, Nil if the anchor is a wildcard.
+     */
+    def unapply(comment: String): Option[List[String]] =
+      comment match {
+        case OkRgx(rules) => Some(splitRules(rules))
+        case OnRgx(rules) => Some(splitRules(rules))
+        case OffRgx(rules) => Some(splitRules(rules))
+        case _ => None
+      }
   }
 
   def apply(
@@ -338,21 +373,12 @@ object EscapeHatch {
   }
 
   private object AnchoredEscapes {
-    private val Prefix = "scalafix:"
-    private val ScalafixOk = Prefix + "ok"
-    private val ScalafixOn = Prefix + "on"
-    private val ScalafixOff = Prefix + "off"
-    private val ScalafixOkRgx = regex(ScalafixOk)
-    private val ScalafixOnRgx = regex(ScalafixOn)
-    private val ScalafixOffRgx = regex(ScalafixOff)
-
-    private def regex(anchor: String) = s"\\s?$anchor\\s?(.*?)(?:;.*)?".r
 
     def apply(
         input: Input,
         tree: LazyValue[Tree]
     ): AnchoredEscapes = {
-      if (input.text.contains(Prefix))
+      if (input.text.contains(Anchor.Prefix))
         collectEscapes(input, tree.value)
       else new AnchoredEscapes(EmptyEscapeTree, EmptyEscapeTree, Nil)
     }
@@ -384,11 +410,6 @@ object EscapeHatch {
         }
       }
 
-      def splitRules(rules: String): List[String] = {
-        val trimmed = rules.trim
-        if (trimmed.isEmpty) Nil else trimmed.split("\\s*,\\s*").toList
-      }
-
       def rulesWithPosition(
           rules: String,
           anchor: Comment
@@ -396,7 +417,7 @@ object EscapeHatch {
         val rulesToPos = ListBuffer.empty[(String, Position)]
         var fromIdx = 0
 
-        for (rule <- splitRules(rules)) {
+        for (rule <- Anchor.splitRules(rules)) {
           val idx = anchor.text.indexOf(rule, fromIdx)
           val startPos = anchor.start + idx
           val endPos = startPos + rule.length
@@ -407,12 +428,16 @@ object EscapeHatch {
         rulesToPos.result()
       }
 
-      if (input.text.contains(ScalafixOk)) {
+      if (input.text.contains(Anchor.Ok)) {
         tree.foreach { t =>
           t.endComment.foreach { ec =>
             val ownerPos = t.pos
             // include line start in case the rule captures leading tokens
             val start = EscapeOffset(ownerPos.start - ownerPos.startColumn)
+            // the range ends before the trailing comment, so a diagnostic
+            // positioned inside the anchor text cannot mark the anchor as
+            // used; rules linting comment text skip anchors themselves
+            // (see DisableSyntax.checkRegex)
             val end = Some(EscapeOffset(ownerPos.end))
             ec.values.foreach(_.tokens.foreach {
               // matches simple expressions
@@ -422,7 +447,7 @@ object EscapeHatch {
               //   2
               // ) // scalafix:ok RuleA
               //
-              case comment @ Token.Comment(ScalafixOkRgx(rules)) =>
+              case comment @ Token.Comment(Anchor.OkRgx(rules)) =>
                 if (visitedFilterExpression.add(comment.pos.start)) {
                   val rulesPos = rulesWithPosition(rules, comment)
                   disableList +=
@@ -442,7 +467,7 @@ object EscapeHatch {
             // // scalafix:off RuleA
             // ...
             //
-            case ScalafixOffRgx(rules) =>
+            case Anchor.OffRgx(rules) =>
               val rulesPos = rulesWithPosition(rules, comment)
               val start = EscapeOffset(comment.pos.start)
               disableList +=
@@ -454,7 +479,7 @@ object EscapeHatch {
             // ...
             // // scalafix:on RuleA
             //
-            case ScalafixOnRgx(rules) =>
+            case Anchor.OnRgx(rules) =>
               val rulesPos = rulesWithPosition(rules, comment)
               val start = EscapeOffset(comment.pos.start)
               enable += (start -> makeFilters(rulesPos, start, None, comment))
@@ -465,7 +490,7 @@ object EscapeHatch {
             // object Dummy { // scalafix:ok NoDummy
             //   1
             // }
-            case ScalafixOkRgx(rules) =>
+            case Anchor.OkRgx(rules) =>
               val pos = comment.pos
               if (!visitedFilterExpression.contains(pos.start)) {
                 val rulesPos = rulesWithPosition(rules, comment)

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
@@ -6,6 +6,7 @@ import scala.meta._
 import scala.meta.tokens.Token
 
 import metaconfig.Configured
+import scalafix.internal.patch.EscapeHatch
 import scalafix.v0.LintCategory
 import scalafix.v1._
 
@@ -24,6 +25,20 @@ final class DisableSyntax(config: DisableSyntaxConfig)
       .map(new DisableSyntax(_))
 
   private def checkRegex(doc: SyntacticDocument): Seq[Diagnostic] = {
+    // matches inside suppression anchors are never reported, as an anchor
+    // may name the very pattern it suppresses
+    // (https://github.com/scalacenter/scalafix/issues/507)
+    lazy val anchors: Seq[(Int, Int)] =
+      doc.tree.tokens.collect {
+        case token @ Token.Comment(EscapeHatch.Anchor(_)) =>
+          (token.start, token.end)
+      }
+
+    def withinAnchor(position: Position): Boolean =
+      anchors.exists { case (start, end) =>
+        start <= position.start && position.start < end
+      }
+
     def pos(matcher: Matcher, groupIndex: Int): Position =
       if (matcher.group(groupIndex) == null)
         Position.Range(doc.input, matcher.start, matcher.end)
@@ -60,14 +75,17 @@ final class DisableSyntax(config: DisableSyntaxConfig)
           )
       }
 
+      val id = regex.id.getOrElse(pattern)
       val message = regex.message.getOrElse(s"$pattern is disabled")
       while (matcher.find()) {
-        regexDiagnostics +=
-          Diagnostic(
-            id = regex.id.getOrElse(pattern),
-            message = messageSubstitution(matcher, message),
-            position = pos(matcher, groupIndex)
-          )
+        val position = pos(matcher, groupIndex)
+        if (!withinAnchor(position))
+          regexDiagnostics +=
+            Diagnostic(
+              id = id,
+              message = messageSubstitution(matcher, message),
+              position = position
+            )
       }
     }
     regexDiagnostics.result()

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/DisableSyntax.scala
@@ -25,9 +25,10 @@ final class DisableSyntax(config: DisableSyntaxConfig)
       .map(new DisableSyntax(_))
 
   private def checkRegex(doc: SyntacticDocument): Seq[Diagnostic] = {
-    // matches inside suppression anchors are never reported, as an anchor
-    // may name the very pattern it suppresses
-    // (https://github.com/scalacenter/scalafix/issues/507)
+    // matches starting inside suppression anchors are never reported, as an
+    // anchor may name the very pattern it suppresses
+    // (https://github.com/scalacenter/scalafix/issues/507); keying on the
+    // start offset mirrors EscapeHatch
     lazy val anchors: Seq[(Int, Int)] =
       doc.tree.tokens.collect {
         case token @ Token.Comment(EscapeHatch.Anchor(_)) =>

--- a/scalafix-tests/input/src/main/scala/test/escapeHatch/Issue507.scala
+++ b/scalafix-tests/input/src/main/scala/test/escapeHatch/Issue507.scala
@@ -1,0 +1,51 @@
+/*
+rules = DisableSyntax
+DisableSyntax.noVars = true
+DisableSyntax.regex = [
+  # adjacent strings concatenate, so that the pattern does not match this config comment
+  "print""ln"
+  {
+    id = offensive
+    pattern = "[Pp]imp"
+    message = "Please consider a less offensive word such as Extension"
+  }
+]
+ */
+package test.escapeHatch
+
+// https://github.com/scalacenter/scalafix/issues/507
+object Issue507 {
+
+  // the regex reports matches in code and in regular comments
+  println("reported") // assert: DisableSyntax.println
+
+  val pimpMyLibrary = 1 // assert: DisableSyntax.offensive
+
+  /* pimp in a regular comment */ // assert: DisableSyntax.offensive
+  val regularComment = 1
+
+  // an ok anchor naming the pattern-derived id must not report itself
+  println("suppressed") // scalafix:ok println
+
+  // neither must a multi-line ok anchor
+  println("suppressed") /* scalafix:ok
+  println */
+
+  // an ok anchor whose explanation matches a pattern it suppresses must not
+  // report itself
+  val pimped = 1 // scalafix:ok; avoid pimp
+
+  // anchor text is never linted, even when the anchor names another rule
+  var vp = 1 // scalafix:ok var; pimp
+
+  // scalafix:off println
+  println("suppressed")
+  // an on anchor naming the pattern-derived id must not report itself
+  // scalafix:on println
+
+  println("reported again") // assert: DisableSyntax.println
+
+  // anchors suppressing only their own text are unused
+  /* scalafix:ok println */ // assert: UnusedScalafixSuppression
+  /* scalafix:off println */ // assert: UnusedScalafixSuppression
+}

--- a/scalafix-tests/input/src/main/scala/test/escapeHatch/Issue507.scala
+++ b/scalafix-tests/input/src/main/scala/test/escapeHatch/Issue507.scala
@@ -9,6 +9,10 @@ DisableSyntax.regex = [
     pattern = "[Pp]imp"
     message = "Please consider a less offensive word such as Extension"
   }
+  {
+    id = spanning
+    pattern = "rest of ""the line.*"
+  }
 ]
  */
 package test.escapeHatch
@@ -44,6 +48,12 @@ object Issue507 {
   // scalafix:on println
 
   println("reported again") // assert: DisableSyntax.println
+
+  // only matches starting inside an anchor are exempt; matches merely
+  // spanning into one are still reported and suppressible
+  val spanningReported = "rest of the line" // assert: DisableSyntax.spanning
+
+  val spanningSuppressed = "rest of the line" // scalafix:ok spanning
 
   // anchors suppressing only their own text are unused
   /* scalafix:ok println */ // assert: UnusedScalafixSuppression


### PR DESCRIPTION
Fixes #507

## Problem

`DisableSyntax.regex` matches raw source text, so an anchor naming the pattern it suppresses — e.g. `// scalafix:ok println` for the pattern `println` — contains a match itself. `EscapeHatch` can never suppress it (the escape range ends before the trailing comment), so the anchor reports a spurious diagnostic.

## Fix

`checkRegex` now drops matches positioned inside `scalafix:ok`/`off`/`on` comments — anchor text is scalafix control syntax, exempt from regex linting entirely. The anchor grammar moved into the shared `EscapeHatch.Anchor` object so `EscapeHatch` and `DisableSyntax` can't drift apart.

## Behavior changes

- Patterns policing comment text no longer see text inside anchors.
- Anchors previously "used" only by their own text (e.g. a stale `// scalafix:off println` with no matches below) now correctly report `UnusedScalafixSuppression`.