### PR TITLE
Rules from private GitHub repos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,23 +81,6 @@ sbt ci-docs
 cd website && yarn start
 ```
 
-### GitHub Remote Rule Authentication
-Scalafix supports loading source rules through `github:org/repo[/Rule]?sha=...`
-via `scalafix-reflect`. When working on private repository support:
-- Prefer GitHub's documented repository contents API for authenticated GitHub
-  file reads, using `Accept: application/vnd.github.raw+json` and
-  `Authorization: Bearer <token>`.
-- A fine-grained personal access token can be limited to the selected rule
-  repository with `Contents` read permission. The environment variable should
-  contain only the raw token value, without the `Bearer ` or `token ` prefix.
-- If adding configuration, prefer a Scalafix-specific token variable first
-  (for example `SCALAFIX_GITHUB_TOKEN`), then common GitHub environment names
-  such as `GITHUB_TOKEN` and `GH_TOKEN`.
-- Never attach a GitHub token to arbitrary HTTP(S) URLs. Restrict token use to
-  GitHub repository contents requests for the matching `github:` rule source.
-- Unit tests should use fake URL connections or local test servers. Do not
-  require real private repositories or real tokens in CI.
-
 ## Rule Development Patterns
 
 ### Rule Types

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ The build uses `sbt-projectmatrix` to generate multiple sub-projects per module,
 - Each test project is built with a specific Scala version (the "target")
 - Test frameworks compiled with another Scala version can test against that target
 - Some targets include `-Xsource:3` flag (tagged with `Xsource3Axis`)
-- Example: `expect3_3_6Target3_3_6` tests rules compiled with 3.3.6 against input also compiled with 3.3.6
+- Example: `expect3_8_4Target3_8_4` tests rules compiled with 3.8.4 against input also compiled with 3.8.4
 
 **Key build concepts:**
 - `projectMatrix`: Defines modules that cross-compile
@@ -34,20 +34,24 @@ The build uses `sbt-projectmatrix` to generate multiple sub-projects per module,
 
 ### Running Tests
 ```bash
-# Unit tests for latest Scala 3.3.6 version
-sbt "unit3_3_6 / test"
+# Unit tests for latest Scala 3.8.4 version
+sbt "unit3_8_4 / test"
 
 # Integration tests (contains many suites - use testOnly to narrow)
-sbt "integration3_3_6 / testOnly -- -z ProcedureSyntax"
+sbt "integration3_8_4 / testOnly -- -z ProcedureSyntax"
 
 # Test built-in rules using scalafix-testkit
-sbt "expect3_3_6Target3_3_6 / test"
+sbt "expect3_8_4Target3_8_4 / test"
 
 # Windows-compatible tests only
-sbt "unit3_3_6 / testWindows"
+sbt "unit3_8_4 / testWindows"
 ```
 
 **Pattern**: Test project names combine the Scala version used to compile the test framework with the target being tested: `unit{CompilerVersion}` or `expect{CompilerVersion}Target{TargetVersion}`
+
+If a project name from these examples stops resolving, run `sbt projects` and
+pick the matching latest generated project name from the matrix instead of
+falling back to the root `test` task.
 
 ### Applying Scalafix to Itself (Dogfooding)
 ```bash
@@ -76,6 +80,23 @@ The `dogfoodScalafixInterfaces` command:
 sbt ci-docs
 cd website && yarn start
 ```
+
+### GitHub Remote Rule Authentication
+Scalafix supports loading source rules through `github:org/repo[/Rule]?sha=...`
+via `scalafix-reflect`. When working on private repository support:
+- Prefer GitHub's documented repository contents API for authenticated GitHub
+  file reads, using `Accept: application/vnd.github.raw+json` and
+  `Authorization: Bearer <token>`.
+- A fine-grained personal access token can be limited to the selected rule
+  repository with `Contents` read permission. The environment variable should
+  contain only the raw token value, without the `Bearer ` or `token ` prefix.
+- If adding configuration, prefer a Scalafix-specific token variable first
+  (for example `SCALAFIX_GITHUB_TOKEN`), then common GitHub environment names
+  such as `GITHUB_TOKEN` and `GH_TOKEN`.
+- Never attach a GitHub token to arbitrary HTTP(S) URLs. Restrict token use to
+  GitHub repository contents requests for the matching `github:` rule source.
+- Unit tests should use fake URL connections or local test servers. Do not
+  require real private repositories or real tokens in CI.
 
 ## Rule Development Patterns
 
@@ -138,8 +159,8 @@ import Unused  // assert: UnusedImport  (linter assertion)
 
 ## Common Pitfalls
 
-1. **Wrong test scope**: Use `unit3_3_6 / test` not `test` (ambiguous without projectmatrix context)
-2. **Missing BuildInfo**: IntelliJ debugger requires running `sbt "unit3_3_6 / test"` once to generate BuildInfo
+1. **Wrong test scope**: Use a generated matrix project such as `unit3_8_4 / test` not `test` (ambiguous without projectmatrix context)
+2. **Missing BuildInfo**: IntelliJ debugger requires running a matrix test such as `sbt "unit3_8_4 / test"` once to generate BuildInfo
 3. **Scala 3 reflect**: No `reflect3` module - Scala 3 rules can't dynamically compile
 4. **Dependency resolution**: When bumping Scala versions, update `versionPolicyIgnored` in `ScalafixBuild.scala`
 5. **Test failures on Windows**: Use `testWindows` task, not `test`

--- a/docs/developers/tutorial.md
+++ b/docs/developers/tutorial.md
@@ -665,6 +665,20 @@ The expansion rules for `github:org/repo` are the following:
 | `github:org/repo/RuleName?sha=main`    | (on `main`) `scalafix/rules/src/main/scala/fix/RuleName.scala`           |
 | `github:org/repo/RuleName?sha=HASH125` | (at commit `HASH125`) `scalafix/rules/src/main/scala/fix/RuleName.scala` |
 
+Private repositories are supported when a GitHub token is available. Scalafix
+looks for a token in the following places, in order:
+
+- the `scalafix.github.token` system property
+- the `SCALAFIX_GITHUB_TOKEN` environment variable
+- the `GITHUB_TOKEN` environment variable
+- the `GH_TOKEN` environment variable
+
+The token value should be the raw token, without a `Bearer` or `token` prefix.
+For a fine-grained personal access token, grant access only to the repository
+that contains the rule and set `Contents` to read-only. A classic personal
+access token also works, but it needs the broader `repo` scope to read private
+repositories.
+
 ## Publish the rule to Maven Central
 
 > If your rule only targets a single codebase and is not meant to be

--- a/docs/developers/tutorial.md
+++ b/docs/developers/tutorial.md
@@ -679,6 +679,10 @@ that contains the rule and set `Contents` to read-only. A classic personal
 access token also works, but it needs the broader `repo` scope to read private
 repositories.
 
+The same authentication is also applied when you use a direct
+`https://raw.githubusercontent.com/...` rule URL, including rules stored outside
+the standard `scalafix/rules/src/main/scala` layout.
+
 ## Publish the rule to Maven Central
 
 > If your rule only targets a single codebase and is not meant to be

--- a/scalafix-core/src/main/scala/scalafix/internal/util/FileOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/util/FileOps.scala
@@ -70,37 +70,66 @@ object FileOps {
   }
 
   private def gitHubContentsUrl(url: URL): Option[(URL, String)] =
-    gitHubToken.flatMap { token =>
-      val filePrefix = "/scalafix/rules/src/main/scala/"
-      val path = url.getPath.stripPrefix("/")
-      val filePrefixIndex = path.indexOf(filePrefix)
-      if (
-        url.getProtocol == "https" &&
-        url.getHost == "raw.githubusercontent.com" &&
-        filePrefixIndex >= 0
-      ) {
-        val beforeFile = path.take(filePrefixIndex)
-        val coordinates = beforeFile.split("/", 3)
-        if (coordinates.length == 3) {
-          val owner = coordinates(0)
-          val repo = coordinates(1)
-          val ref = coordinates(2)
-          val file = path.drop(filePrefixIndex + 1)
-          Some(
-            (
-              new URI(
-                "https",
-                "api.github.com",
-                s"/repos/$owner/$repo/contents/$file",
-                s"ref=$ref",
-                null
-              ).toURL,
-              token
-            )
-          )
-        } else None
-      } else None
+    for {
+      token <- gitHubToken
+      (owner, repo, ref, file) <- gitHubRawContent(url)
+    } yield (gitHubContentsApiUrl(owner, repo, ref, file), token)
+
+  private def gitHubContentsApiUrl(
+      owner: String,
+      repo: String,
+      ref: String,
+      file: String
+  ): URL =
+    new URI(
+      "https",
+      "api.github.com",
+      s"/repos/$owner/$repo/contents/$file",
+      s"ref=$ref",
+      null
+    ).toURL
+
+  private def gitHubRawContent(
+      url: URL
+  ): Option[(String, String, String, String)] = {
+    val segments = url.getPath.stripPrefix("/").split("/").toVector
+    if (
+      url.getProtocol == "https" &&
+      url.getHost == "raw.githubusercontent.com" &&
+      segments.length >= 4
+    ) {
+      val owner = segments(0)
+      val repo = segments(1)
+      val refAndFile = segments.drop(2)
+      splitRefAndFile(refAndFile).map { case (refSegments, fileSegments) =>
+        (owner, repo, refSegments.mkString("/"), fileSegments.mkString("/"))
+      }
+    } else None
+  }
+
+  private def splitRefAndFile(
+      segments: Vector[String]
+  ): Option[(Vector[String], Vector[String])] = {
+    val standardRulePrefix =
+      Vector("scalafix", "rules", "src", "main", "scala")
+    val standardRulePrefixIndex = segments.indexOfSlice(standardRulePrefix)
+    if (standardRulePrefixIndex > 0) {
+      Some(
+        segments.take(standardRulePrefixIndex) ->
+          segments.drop(standardRulePrefixIndex)
+      )
+    } else {
+      segments match {
+        case "refs" +: refKind +: refName +: file
+            if (refKind == "heads" || refKind == "tags") && file.nonEmpty =>
+          Some(Vector("refs", refKind, refName) -> file)
+        case ref +: file if file.nonEmpty =>
+          Some(Vector(ref) -> file)
+        case _ =>
+          None
+      }
     }
+  }
 
   private def gitHubToken: Option[String] =
     sys.props

--- a/scalafix-core/src/main/scala/scalafix/internal/util/FileOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/util/FileOps.scala
@@ -11,6 +11,7 @@ import java.net.URLConnection
 import scala.meta.io.AbsolutePath
 
 object FileOps {
+  private val GitHubApiVersion = "2026-03-10"
 
   def listFiles(path: String): Vector[String] = {
     listFiles(new File(path))
@@ -61,7 +62,7 @@ object FileOps {
           "application/vnd.github.raw+json"
         )
         connection.setRequestProperty("Authorization", s"Bearer $token")
-        connection.setRequestProperty("X-GitHub-Api-Version", "2022-11-28")
+        connection.setRequestProperty("X-GitHub-Api-Version", GitHubApiVersion)
         connection
       case None =>
         openConnection(url)

--- a/scalafix-core/src/main/scala/scalafix/internal/util/FileOps.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/util/FileOps.scala
@@ -6,6 +6,7 @@ import java.io.FileReader
 import java.io.PrintWriter
 import java.net.URI
 import java.net.URL
+import java.net.URLConnection
 
 import scala.meta.io.AbsolutePath
 
@@ -34,11 +35,80 @@ object FileOps {
     }
   }
 
-  def readURL(url: URL): String = {
-    val src = scala.io.Source.fromURL(url)("UTF-8")
+  def readURL(url: URL): String =
+    readURL(url, _.openConnection())
+
+  private[scalafix] def readURL(
+      url: URL,
+      openConnection: URL => URLConnection
+  ): String = {
+    val connection = authenticatedConnection(url, openConnection)
+    val src =
+      scala.io.Source.fromInputStream(connection.getInputStream)("UTF-8")
     try src.getLines().mkString("\n")
     finally src.close()
   }
+
+  private def authenticatedConnection(
+      url: URL,
+      openConnection: URL => URLConnection
+  ): URLConnection = {
+    gitHubContentsUrl(url) match {
+      case Some((apiUrl, token)) =>
+        val connection = openConnection(apiUrl)
+        connection.setRequestProperty(
+          "Accept",
+          "application/vnd.github.raw+json"
+        )
+        connection.setRequestProperty("Authorization", s"Bearer $token")
+        connection.setRequestProperty("X-GitHub-Api-Version", "2022-11-28")
+        connection
+      case None =>
+        openConnection(url)
+    }
+  }
+
+  private def gitHubContentsUrl(url: URL): Option[(URL, String)] =
+    gitHubToken.flatMap { token =>
+      val filePrefix = "/scalafix/rules/src/main/scala/"
+      val path = url.getPath.stripPrefix("/")
+      val filePrefixIndex = path.indexOf(filePrefix)
+      if (
+        url.getProtocol == "https" &&
+        url.getHost == "raw.githubusercontent.com" &&
+        filePrefixIndex >= 0
+      ) {
+        val beforeFile = path.take(filePrefixIndex)
+        val coordinates = beforeFile.split("/", 3)
+        if (coordinates.length == 3) {
+          val owner = coordinates(0)
+          val repo = coordinates(1)
+          val ref = coordinates(2)
+          val file = path.drop(filePrefixIndex + 1)
+          Some(
+            (
+              new URI(
+                "https",
+                "api.github.com",
+                s"/repos/$owner/$repo/contents/$file",
+                s"ref=$ref",
+                null
+              ).toURL,
+              token
+            )
+          )
+        } else None
+      } else None
+    }
+
+  private def gitHubToken: Option[String] =
+    sys.props
+      .get("scalafix.github.token")
+      .orElse(sys.env.get("SCALAFIX_GITHUB_TOKEN"))
+      .orElse(sys.env.get("GITHUB_TOKEN"))
+      .orElse(sys.env.get("GH_TOKEN"))
+      .map(_.trim)
+      .filter(_.nonEmpty)
 
   /**
    * Reads file from file system or from http url.

--- a/scalafix-reflect/src/main/scala/scalafix/internal/reflect/GitHubUrlRule.scala
+++ b/scalafix-reflect/src/main/scala/scalafix/internal/reflect/GitHubUrlRule.scala
@@ -10,6 +10,7 @@ import metaconfig.Conf
 import metaconfig.ConfError
 import metaconfig.Configured
 import metaconfig.Configured.Ok
+import scalafix.internal.util.FileOps
 
 object GitHubUrlRule {
 
@@ -76,7 +77,7 @@ object GitHubUrlRule {
     string.split(NonAlphaNumeric).map(_.capitalize).mkString
 
   private def checkUrl(url: URL): Try[URL] =
-    Try(url.openStream().close()).map(_ => url)
+    Try(FileOps.readURL(url)).map(_ => url)
 
   private def expandGitHubURL(
       org: String,

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/util/FileOpsSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/util/FileOpsSuite.scala
@@ -38,6 +38,30 @@ class FileOpsSuite extends AnyFunSuite {
     }
   }
 
+  test("readURL authenticates raw GitHub rule source outside standard layout") {
+    withSystemProperty(GitHubTokenProperty, "secret-token") {
+      val url = URI
+        .create(
+          "https://raw.githubusercontent.com/org/repo/refs/heads/main/" +
+            "custom-rules/Rule.scala?token=raw-url-token"
+        )
+        .toURL
+
+      assert(
+        FileOps.readURL(
+          url,
+          authenticatedConnection(
+            expectedUrl =
+              "https://api.github.com/repos/org/repo/contents/custom-rules/Rule.scala?ref=refs/heads/main",
+            expectedAuthorization = Some("Bearer secret-token"),
+            expectedAccept = Some("application/vnd.github.raw+json"),
+            expectedGitHubApiVersion = Some("2026-03-10")
+          )
+        ) == RuleSource
+      )
+    }
+  }
+
   test("readURL does not send GitHub token to non-GitHub URLs") {
     withSystemProperty(GitHubTokenProperty, "secret-token") {
       val url = URI.create("https://example.com/rules/Rule.scala").toURL

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/util/FileOpsSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/util/FileOpsSuite.scala
@@ -1,0 +1,95 @@
+package scalafix.tests.util
+
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.net.URL
+import java.net.URLConnection
+import java.nio.charset.StandardCharsets
+
+import org.scalatest.funsuite.AnyFunSuite
+import scalafix.internal.util.FileOps
+
+class FileOpsSuite extends AnyFunSuite {
+  private val GitHubTokenProperty = "scalafix.github.token"
+  private val RuleSource = "package fix"
+
+  test("readURL sends GitHub token when reading raw GitHub rule source") {
+    withSystemProperty(GitHubTokenProperty, "secret-token") {
+      val url = new URL(
+        "https://raw.githubusercontent.com/org/repo/main/" +
+          "scalafix/rules/src/main/scala/fix/Rule.scala"
+      )
+
+      assert(
+        FileOps.readURL(
+          url,
+          authenticatedConnection(
+            expectedUrl =
+              "https://api.github.com/repos/org/repo/contents/scalafix/rules/src/main/scala/fix/Rule.scala?ref=main",
+            expectedAuthorization = Some("Bearer secret-token"),
+            expectedAccept = Some("application/vnd.github.raw+json")
+          )
+        ) == RuleSource
+      )
+    }
+  }
+
+  test("readURL does not send GitHub token to non-GitHub URLs") {
+    withSystemProperty(GitHubTokenProperty, "secret-token") {
+      val url = new URL("https://example.com/rules/Rule.scala")
+
+      assert(
+        FileOps.readURL(
+          url,
+          authenticatedConnection(
+            expectedUrl = "https://example.com/rules/Rule.scala",
+            expectedAuthorization = None,
+            expectedAccept = None
+          )
+        ) == RuleSource
+      )
+    }
+  }
+
+  private def authenticatedConnection(
+      expectedUrl: String,
+      expectedAuthorization: Option[String],
+      expectedAccept: Option[String]
+  ): URL => URLConnection = { url =>
+    assert(url.toString == expectedUrl)
+    new URLConnection(url) {
+      override def connect(): Unit = ()
+
+      override def getInputStream: InputStream = {
+        val obtainedAuthorization = Option(getRequestProperty("Authorization"))
+        assert(
+          obtainedAuthorization == expectedAuthorization,
+          s"expected Authorization header $expectedAuthorization, obtained $obtainedAuthorization"
+        )
+        val obtainedAccept = Option(getRequestProperty("Accept"))
+        assert(
+          obtainedAccept == expectedAccept,
+          s"expected Accept header $expectedAccept, obtained $obtainedAccept"
+        )
+        new ByteArrayInputStream(
+          RuleSource.getBytes(StandardCharsets.UTF_8)
+        )
+      }
+    }
+  }
+
+  private def withSystemProperty[A](
+      key: String,
+      value: String
+  )(body: => A): A = {
+    val original = Option(System.getProperty(key))
+    System.setProperty(key, value)
+    try body
+    finally {
+      original match {
+        case Some(originalValue) => System.setProperty(key, originalValue)
+        case None => System.clearProperty(key)
+      }
+    }
+  }
+}

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/util/FileOpsSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/util/FileOpsSuite.scala
@@ -2,6 +2,7 @@ package scalafix.tests.util
 
 import java.io.ByteArrayInputStream
 import java.io.InputStream
+import java.net.URI
 import java.net.URL
 import java.net.URLConnection
 import java.nio.charset.StandardCharsets
@@ -15,10 +16,12 @@ class FileOpsSuite extends AnyFunSuite {
 
   test("readURL sends GitHub token when reading raw GitHub rule source") {
     withSystemProperty(GitHubTokenProperty, "secret-token") {
-      val url = new URL(
-        "https://raw.githubusercontent.com/org/repo/main/" +
-          "scalafix/rules/src/main/scala/fix/Rule.scala"
-      )
+      val url = URI
+        .create(
+          "https://raw.githubusercontent.com/org/repo/main/" +
+            "scalafix/rules/src/main/scala/fix/Rule.scala"
+        )
+        .toURL
 
       assert(
         FileOps.readURL(
@@ -36,7 +39,7 @@ class FileOpsSuite extends AnyFunSuite {
 
   test("readURL does not send GitHub token to non-GitHub URLs") {
     withSystemProperty(GitHubTokenProperty, "secret-token") {
-      val url = new URL("https://example.com/rules/Rule.scala")
+      val url = URI.create("https://example.com/rules/Rule.scala").toURL
 
       assert(
         FileOps.readURL(

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/util/FileOpsSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/util/FileOpsSuite.scala
@@ -30,7 +30,8 @@ class FileOpsSuite extends AnyFunSuite {
             expectedUrl =
               "https://api.github.com/repos/org/repo/contents/scalafix/rules/src/main/scala/fix/Rule.scala?ref=main",
             expectedAuthorization = Some("Bearer secret-token"),
-            expectedAccept = Some("application/vnd.github.raw+json")
+            expectedAccept = Some("application/vnd.github.raw+json"),
+            expectedGitHubApiVersion = Some("2026-03-10")
           )
         ) == RuleSource
       )
@@ -47,7 +48,8 @@ class FileOpsSuite extends AnyFunSuite {
           authenticatedConnection(
             expectedUrl = "https://example.com/rules/Rule.scala",
             expectedAuthorization = None,
-            expectedAccept = None
+            expectedAccept = None,
+            expectedGitHubApiVersion = None
           )
         ) == RuleSource
       )
@@ -57,7 +59,8 @@ class FileOpsSuite extends AnyFunSuite {
   private def authenticatedConnection(
       expectedUrl: String,
       expectedAuthorization: Option[String],
-      expectedAccept: Option[String]
+      expectedAccept: Option[String],
+      expectedGitHubApiVersion: Option[String]
   ): URL => URLConnection = { url =>
     assert(url.toString == expectedUrl)
     new URLConnection(url) {
@@ -73,6 +76,12 @@ class FileOpsSuite extends AnyFunSuite {
         assert(
           obtainedAccept == expectedAccept,
           s"expected Accept header $expectedAccept, obtained $obtainedAccept"
+        )
+        val obtainedGitHubApiVersion =
+          Option(getRequestProperty("X-GitHub-Api-Version"))
+        assert(
+          obtainedGitHubApiVersion == expectedGitHubApiVersion,
+          s"expected X-GitHub-Api-Version header $expectedGitHubApiVersion, obtained $obtainedGitHubApiVersion"
         )
         new ByteArrayInputStream(
           RuleSource.getBytes(StandardCharsets.UTF_8)


### PR DESCRIPTION
## What issue does this solve?

Fixes https://github.com/scalacenter/scalafix/issues/2460.

This adds support for loading Scalafix source rules from private GitHub
repositories through the existing `github:` rule syntax, for example:

```sh
scalafix --rules=github:OWNER/PRIVATE_REPO/RuleName?sha=main
```

Previously this only worked for public repositories because Scalafix expanded
`github:` rules to `raw.githubusercontent.com` URLs and fetched them without
GitHub authentication.

It also supports direct `https://raw.githubusercontent.com/...` rule URLs, so
private rules can live outside the standard `github:` expansion layout.

## How does it solve it?

- Adds authenticated GitHub rule loading in `FileOps.readURL`.
- When a `github:` rule or direct `https://raw.githubusercontent.com/...` rule
  resolves to a GitHub raw-content URL and a token is configured, Scalafix reads
  the rule through the GitHub Contents API instead.
- Uses the currently supported GitHub REST API version `2026-03-10`.
- Sends `Authorization: Bearer <token>` only for recognized GitHub rule URLs,
  avoiding accidental token forwarding to arbitrary `http:` URLs.
- Looks up the token in this order:
  - `scalafix.github.token` system property
  - `SCALAFIX_GITHUB_TOKEN`
  - `GITHUB_TOKEN`
  - `GH_TOKEN`
- Keeps the existing public-repository behavior when no token is configured.
- Updates the preliminary `github:` URL check to use the same authenticated read
  path as the actual rule load.
- Documents how to use private repositories, including the recommended token
  permissions.

For a fine-grained GitHub personal access token, selected-repository access with
`Contents: read-only` is enough. A classic PAT also works, but requires the
broader `repo` scope for private repositories.

## How was this tested?

Automated tests:

```sh
sbt "unit2_12_21 / test" "unit2_13_18 / test" "unit3_8_4 / test"
sbt "cli2_12_21 / publishLocalTransitive" \
  "cli2_13_18 / publishLocalTransitive" \
  "integration3_8_4 / test"
sbt "unit2_12_21 / testOnly scalafix.tests.util.FileOpsSuite" \
  "unit2_13_18 / testOnly scalafix.tests.util.FileOpsSuite" \
  "unit3_8_4 / testOnly scalafix.tests.util.FileOpsSuite"
./bin/scalafmt --test \
  scalafix-core/src/main/scala/scalafix/internal/util/FileOps.scala \
  scalafix-tests/unit/src/test/scala/scalafix/tests/util/FileOpsSuite.scala
```

The unit test covers the authenticated URL transformation and checks that
non-GitHub URLs do not receive GitHub auth headers.

Manual smoke test:

- Created a private fixture repository with a source-loaded rule,
  `PrivateRepoProbe`.
- The rule replaces:

```scala
"SCALAFIX_PRIVATE_REPO_PROBE"
```

with:

```scala
"loaded-from-private-github"
```

- Used a tiny Scala smoke project with a single target source file containing
  the marker string.
- Ran the patched Scalafix CLI against the private fixture rule using:

```sh
SCALAFIX_GITHUB_TOKEN=<fine-grained-token-with-contents-read> \
  sbt "cli3_8_4 / runMain scalafix.cli.Cli \
    --cwd /path/to/scalafix-private-rule-smoke \
    --config /path/to/scalafix-private-rule-smoke/.scalafix.conf \
    --syntactic \
    --rules=github:OWNER/PRIVATE_REPO/PrivateRepoProbe?sha=main \
    /path/to/scalafix-private-rule-smoke/src/main/scala/privateprobe/Smoke.scala"
```

- Verified that the target file was rewritten to the expected output.
- Also created a second private fixture rule outside the standard layout:

```text
custom-rules/RawPrivateRepoProbe.scala
```

- Ran the patched Scalafix CLI against the private fixture through a direct raw
  GitHub URL:

```sh
sbt "cli3_8_4 / runMain scalafix.cli.Cli \
  --cwd /path/to/scalafix-private-rule-smoke \
  --config /path/to/scalafix-private-rule-smoke/.scalafix.conf \
  --syntactic \
  --rules=https://raw.githubusercontent.com/OWNER/PRIVATE_REPO/refs/heads/main/custom-rules/RawPrivateRepoProbe.scala \
  /path/to/scalafix-private-rule-smoke/src/main/scala/privateprobe/RawSmoke.scala"
```

- Verified that the raw-URL rule rewrote:

```scala
"SCALAFIX_RAW_PRIVATE_REPO_PROBE"
```

to:

```scala
"loaded-from-direct-raw-github"
```

## AI assistance disclosure

I used OpenAI Codex to assist with the implementation, tests, documentation, and
manual smoke-test scaffolding for this change. I reviewed the generated changes
before submitting them.
