### PR TITLE
Handle scala3 placeholder symbols

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/internal/v0/LegacySemanticdbIndex.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/v0/LegacySemanticdbIndex.scala
@@ -67,7 +67,13 @@ final class LegacySemanticdbIndex(val doc: v1.SemanticDocument)
     }
 
   override def symbol(position: Position): Option[v0.Symbol] =
-    doc.internal.symbols(position).toList.map(s => v0.Symbol(s.value)) match {
+    doc.internal
+      .symbols(position)
+      .toList
+      // Scala 3's SemanticDB can emit occurrences whose symbol is the
+      // placeholder string "<?>".
+      // For example, see https://github.com/scala/scala3/issues/26521.
+      .flatMap(s => scala.util.Try(v0.Symbol(s.value)).toOption) match {
       case Nil => None
       case head :: Nil => Some(head)
       case multi => Some(v0.Symbol.Multi(multi))

--- a/scalafix-tests/input/src/main/scala/test/ReplaceSymbol.scala
+++ b/scalafix-tests/input/src/main/scala/test/ReplaceSymbol.scala
@@ -55,4 +55,9 @@ object ReplaceSymbol {
   val y: mutable.ListBuffer[Int] = mutable.ListBuffer.empty[Int]
   val z: scala.collection.mutable.ListBuffer[Int] =
     scala.collection.mutable.ListBuffer.empty[Int]
+  def build(): Int = {
+    case class Local(a: Int, b: Int)
+    val x = Local(a = 1, b = 2)
+    x.a + x.b
+  }
 }

--- a/scalafix-tests/output/src/main/scala/test/ReplaceSymbol.scala
+++ b/scalafix-tests/output/src/main/scala/test/ReplaceSymbol.scala
@@ -20,4 +20,9 @@ object ReplaceSymbol {
   val y: mutable.CoolBuffer[Int] = mutable.CoolBuffer.empty[Int]
   val z: com.geirsson.mutable.CoolBuffer[Int] =
     com.geirsson.mutable.CoolBuffer.empty[Int]
+  def build(): Int = {
+    case class Local(a: Int, b: Int)
+    val x = Local(a = 1, b = 2)
+    x.a + x.b
+  }
 }


### PR DESCRIPTION
This is a workaround for https://github.com/scala/scala3/issues/26521 (assuming it is a bug as I think it is)

Basically, Scala 3 semanticdb will include placeholder symbols sometimes which causes `Patch.replaceSymbols` to crash.

I split this into 2 PRs because if you check out the commit with just the tests will pass with Scala 2.13.18, but fail with 3.3.8
```sh
# Passes
sbt "expect2_13_18Target2_13_18 / test"
# Fails
sbt "expect3_3_8Target3_3_8 / test"
```

If you include the workaround commit, then the Scala 3.3.8 tests also pass.