### PR TITLE
feat(OrganizeImports): add groupRelativeImports option

### DIFF
--- a/docs/rules/OrganizeImports.md
+++ b/docs/rules/OrganizeImports.md
@@ -374,6 +374,77 @@ import scala.util.control.NonFatal
 import sun.misc.BASE64Encoder
 ```
 
+
+`groupRelativeImports`
+----------------------
+
+Control how relative imports are handled when `expandRelative` is `false`.
+
+### Value type
+
+Enum: `KeepOrdered | Grouped`
+
+#### `KeepOrdered`
+Relative imports are moved to a separate order-preserving group that is
+appended after all the other configured import groups. This is the default
+behavior and preserves the original relative ordering.
+
+#### `Grouped`
+Relative imports participate in regular group matching. They are matched
+against the configured `groups` patterns using their textual form (as
+written in the source code) and sorted together with fully qualified
+imports. This avoids a blank line between fully qualified and relative
+imports that belong to the same logical group.
+
+> **Note**: When using `Grouped`, relative imports are sorted by their
+> textual form, not their fully qualified form. For example, `pekko.actor._`
+> sorts under `p`, not under its resolved path `org.apache.pekko.actor._`.
+
+### Default value
+
+`KeepOrdered`
+
+### Examples
+
+```conf
+OrganizeImports {
+  expandRelative = false
+  groupRelativeImports = Grouped
+  groups = ["re:javax?\\.", "scala.", "*"]
+}
+```
+
+Before:
+
+```scala
+import scala.util
+import util.control
+import control.NonFatal
+import java.time.Clock
+```
+
+After (`Grouped` — relative imports mixed into regular groups):
+
+```scala
+import java.time.Clock
+
+import scala.util
+
+import control.NonFatal
+import util.control
+```
+
+After (`KeepOrdered` — default, relative imports in separate group):
+
+```scala
+import java.time.Clock
+
+import scala.util
+
+import util.control
+import control.NonFatal
+```
+
 `groupedImports`
 ----------------
 
@@ -628,8 +699,8 @@ same group and sorted by the order defined by the
 > order-preserving import group may appear after all the configured import
 > groups when:
 > 
-> 1.  The `expandRelative` option is set to `false` and there are relative
->     imports.
+> 1.  The `expandRelative` option is set to `false`, `groupRelativeImports`
+>     is `KeepOrdered` (the default), and there are relative imports.
 > 
 > 2.  The `groupSeparately` parameter is set, and there are
 >     [matching imports](#groupseparately).
@@ -1303,6 +1374,7 @@ OrganizeImports {
   blankLines = Auto
   coalesceToWildcardImportThreshold = null
   expandRelative = false
+  groupRelativeImports = KeepOrdered
   groupSeparately = []
   groupedImports = Explode
   groups = [
@@ -1332,6 +1404,7 @@ OrganizeImports {
   blankLines = Auto
   coalesceToWildcardImportThreshold = 5
   expandRelative = false
+  groupRelativeImports = KeepOrdered
   groupSeparately = []
   groupedImports = Merge
   groups = [

--- a/docs/rules/OrganizeImports.md
+++ b/docs/rules/OrganizeImports.md
@@ -374,7 +374,6 @@ import scala.util.control.NonFatal
 import sun.misc.BASE64Encoder
 ```
 
-
 `groupRelativeImports`
 ----------------------
 
@@ -396,6 +395,12 @@ written in the source code) and sorted together with fully qualified
 imports. This avoids a blank line between fully qualified and relative
 imports that belong to the same logical group.
 
+> Relative imports can depend on imports that appear before them. `Grouped`
+> allows those imports to be regrouped and reordered, so moving a relative
+> import before its prerequisite can make the rewritten source fail to
+> compile. Use `KeepOrdered` unless the configured `groups` and
+> `importsOrder` preserve those dependencies.
+>
 > **Note**: When using `Grouped`, relative imports are sorted by their
 > textual form, not their fully qualified form. For example, `pekko.actor._`
 > sorts under `p`, not under its resolved path `org.apache.pekko.actor._`.
@@ -410,7 +415,7 @@ imports that belong to the same logical group.
 OrganizeImports {
   expandRelative = false
   groupRelativeImports = Grouped
-  groups = ["re:javax?\\.", "scala.", "*"]
+  groups = ["re:javax?\\.", "*"]
 }
 ```
 
@@ -418,9 +423,8 @@ Before:
 
 ```scala
 import scala.util
-import util.control
-import control.NonFatal
 import java.time.Clock
+import util.Random
 ```
 
 After (`Grouped` — relative imports mixed into regular groups):
@@ -429,9 +433,7 @@ After (`Grouped` — relative imports mixed into regular groups):
 import java.time.Clock
 
 import scala.util
-
-import control.NonFatal
-import util.control
+import util.Random
 ```
 
 After (`KeepOrdered` — default, relative imports in separate group):
@@ -441,8 +443,7 @@ import java.time.Clock
 
 import scala.util
 
-import util.control
-import control.NonFatal
+import util.Random
 ```
 
 `groupedImports`
@@ -1626,4 +1627,3 @@ import scala.collection.immutable.{List => L}
 import scala.collection.mutable.Map
 import scala.collection.mutable.{Buffer => _, Seq => S, _}
 ```
-

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -104,12 +104,15 @@ class OrganizeImports(
         .flatMap(_.importers)
         .flatMap(removeUnusedImporters(unusedImporteePositions))
 
+      val groupRelative = config.groupRelativeImports == GroupRelativeImports.Grouped
       val relativeImporters = new ArrayBuffer[Importer]
       val fullyQualifiedIterator =
         if (config.expandRelative)
           noUnusedIterator.map { i =>
             if (isFullyQualified(diagnostics)(i)) i else expandRelative(i)
           }
+        else if (groupRelative)
+          noUnusedIterator
         else
           noUnusedIterator.filter { i =>
             val ok = isFullyQualified(diagnostics)(i)
@@ -119,9 +122,13 @@ class OrganizeImports(
       val dedupedIterator = deduplicateImportees(fullyQualifiedIterator)
       val mergedIterator = mergeOrExplodeImporters(diagnostics)(dedupedIterator)
 
-      // Moves relative imports (when `config.expandRelative` is false) and
-      // explicitly imported implicit names into a separate order preserving
-      // group. This group will be appended after all the other groups.
+      // Moves relative imports (when `config.expandRelative` is false and
+      // `config.groupRelativeImports` is `KeepOrdered`) and explicitly imported
+      // implicit names into a separate order preserving group. This group will
+      // be appended after all the other groups.
+      //
+      // When `config.groupRelativeImports` is `Grouped`, relative imports
+      // participate in regular group matching and are not added here.
       //
       // See https://github.com/liancheng/scalafix-organize-imports/issues/30
       // for why implicits require special handling.

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -104,7 +104,8 @@ class OrganizeImports(
         .flatMap(_.importers)
         .flatMap(removeUnusedImporters(unusedImporteePositions))
 
-      val groupRelative = config.groupRelativeImports == GroupRelativeImports.Grouped
+      val groupRelative =
+        config.groupRelativeImports == GroupRelativeImports.Grouped
       val relativeImporters = new ArrayBuffer[Importer]
       val fullyQualifiedIterator =
         if (config.expandRelative)

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImportsConfig.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImportsConfig.scala
@@ -67,10 +67,20 @@ object GroupSeparately {
     .getCodecFrom(ByNameImplicits, ByTypeGivens)
 }
 
+sealed trait GroupRelativeImports
+object GroupRelativeImports {
+  case object KeepOrdered extends GroupRelativeImports
+  case object Grouped extends GroupRelativeImports
+
+  implicit val codec: ConfCodecEx[GroupRelativeImports] = OrganizeImportsConfig
+    .getCodecFrom(KeepOrdered, Grouped)
+}
+
 final case class OrganizeImportsConfig(
     blankLines: BlankLines = BlankLines.Auto,
     coalesceToWildcardImportThreshold: Option[Int] = None,
     expandRelative: Boolean = false,
+    groupRelativeImports: GroupRelativeImports = GroupRelativeImports.KeepOrdered,
     groupSeparately: Seq[GroupSeparately] = Seq(GroupSeparately.ByTypeGivens),
     groupedImports: GroupedImports = GroupedImports.Explode,
     groups: Seq[String] = Seq(

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImportsConfig.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImportsConfig.scala
@@ -80,7 +80,8 @@ final case class OrganizeImportsConfig(
     blankLines: BlankLines = BlankLines.Auto,
     coalesceToWildcardImportThreshold: Option[Int] = None,
     expandRelative: Boolean = false,
-    groupRelativeImports: GroupRelativeImports = GroupRelativeImports.KeepOrdered,
+    groupRelativeImports: GroupRelativeImports =
+      GroupRelativeImports.KeepOrdered,
     groupSeparately: Seq[GroupSeparately] = Seq(GroupSeparately.ByTypeGivens),
     groupedImports: GroupedImports = GroupedImports.Explode,
     groups: Seq[String] = Seq(

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/GroupRelativeImportsGrouped.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/GroupRelativeImportsGrouped.scala
@@ -2,12 +2,12 @@
 rules = [OrganizeImports]
 OrganizeImports.removeUnused = false
 OrganizeImports.groupRelativeImports = Grouped
-OrganizeImports.groups = ["scala.", "*"]
+OrganizeImports.groups = ["re:javax?\\.", "*"]
  */
 package test.organizeImports
 
 import scala.util
-import com.sun.management.DiagnosticCommandMBean
+import java.time.Clock
 import util.Random
 
 object GroupRelativeImportsGrouped

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/GroupRelativeImportsGrouped.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/GroupRelativeImportsGrouped.scala
@@ -1,0 +1,13 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports.removeUnused = false
+OrganizeImports.groupRelativeImports = Grouped
+OrganizeImports.groups = ["scala.", "*"]
+ */
+package test.organizeImports
+
+import scala.util
+import com.sun.management.DiagnosticCommandMBean
+import util.Random
+
+object GroupRelativeImportsGrouped

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/GroupRelativeImportsGrouped.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/GroupRelativeImportsGrouped.scala
@@ -1,0 +1,8 @@
+package test.organizeImports
+
+import scala.util
+
+import com.sun.management.DiagnosticCommandMBean
+import util.Random
+
+object GroupRelativeImportsGrouped

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/GroupRelativeImportsGrouped.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/GroupRelativeImportsGrouped.scala
@@ -1,8 +1,8 @@
 package test.organizeImports
 
-import scala.util
+import java.time.Clock
 
-import com.sun.management.DiagnosticCommandMBean
+import scala.util
 import util.Random
 
 object GroupRelativeImportsGrouped


### PR DESCRIPTION
## Summary
- Add `groupRelativeImports` configuration option to `OrganizeImports` rule
- When set to `Grouped` (with `expandRelative = false`), relative imports participate in regular group matching instead of being separated into an order-preserving group
- Eliminates the unwanted blank line between fully qualified and relative imports that belong to the same logical group (e.g., `org.apache.pekko` and `pekko.*` in the Apache Pekko project)

## Motivation
In projects like Apache Pekko, imports use both fully qualified (`org.apache.pekko.*`) and short (`pekko.*`) forms. The short form resolves to the same package but is classified as a "relative import" by the semantic analyzer because `pekko` resolves to `org.apache.pekko` (whose owner is `org.apache`, not root).

Currently, `OrganizeImports` always places relative imports in a separate order-preserving group with a mandatory blank line separator. This creates an unwanted blank line between `import org.apache.pekko` and `import pekko.annotation.*`, even when the user configures them to be in the same group.

## Modification
- Added `GroupRelativeImports` sealed trait with two values:
  - `KeepOrdered` (default): preserves existing behavior — relative imports go to order-preserving group
  - `Grouped`: relative imports participate in regular group matching using their textual form
- Modified `organizeGlobalImports` in `OrganizeImports.scala` to skip filtering relative imports when `groupRelativeImports = Grouped`
- Added documentation and test case

## Example
```conf
OrganizeImports {
  expandRelative = false
  groupRelativeImports = Grouped
  groups = ["re:javax?\\.", "scala.", "*"]
}
```

Before (blank line between pekko groups):
```scala
import org.apache.pekko

import pekko.annotation.ApiMayChange
import pekko.annotation.InternalApi
```

After (no blank line, same group):
```scala
import org.apache.pekko
import pekko.annotation.ApiMayChange
import pekko.annotation.InternalApi
```

## Test plan
- [x] Added `GroupRelativeImportsGrouped` input/output test case
- [x] All 159 existing expect tests pass
- [x] All 3 config unit tests pass
- [x] Code compiles for Scala 2.13