### PR TITLE
Support custom `onTestFailure` message on `--check` failure

### DIFF
--- a/docs/users/configuration.md
+++ b/docs/users/configuration.md
@@ -100,6 +100,24 @@ Similarly, diagnostics can be controlled through `lint.ignore`, `lint.info`,
 and `lint.warning`, which respectively suppress matching diagnostics, force
 them to be at info level, and force them to be at warning level.
 
+## Customizing the message on `--check` failure
+
+When running in check mode (`--check`/`--test`), Scalafix prints a unified
+diff and exits with a non-zero code if some files would be modified by the
+configured rules. Use `onTestFailure` to print an additional custom message
+after the diff, for example to give contributors instructions on how to fix
+the failure:
+
+```scala
+// .scalafix.conf
+onTestFailure = "To fix this, run: sbt scalafixAll"
+```
+
+The message is only printed when the entire failure is auto-fixable by
+running Scalafix. If the run also reports errors that Scalafix cannot fix by
+rewriting sources — for example linter errors or parse errors — the message
+is not printed.
+
 ## Passing configuration as CLI arguments
 
 It is possible to pass configuration flags with scalar values as CLI arguments,

--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
@@ -275,6 +275,14 @@ case class Args(
     }
   }
 
+  def configuredOnTestFailure(base: Conf): Configured[Option[String]] =
+    ConfGet.getOrOK(
+      base,
+      "onTestFailure" :: Nil,
+      (conf: Conf) => conf.as[String].map(Some(_)),
+      None
+    )
+
   def configuredRules(
       base: Conf,
       scalafixConfig: ScalafixConfig
@@ -416,11 +424,15 @@ case class Args(
           configuredRules(base, scalafixConfig) |@|
           resolvedPathReplace |@|
           configuredDiffDisable |@|
-          configureScalaVersions(scalafixConfig)
+          configureScalaVersions(scalafixConfig) |@|
+          configuredOnTestFailure(base)
       ).map {
         case (
-              ((((root, symtab), rulez), pathReplace), diffDisable),
-              scalafixConfig
+              (
+                ((((root, symtab), rulez), pathReplace), diffDisable),
+                scalafixConfig
+              ),
+              onTestFailure
             ) =>
           ValidatedArgs(
             this,
@@ -432,7 +444,8 @@ case class Args(
             pathReplace,
             diffDisable,
             delegator,
-            semanticdbFilterMatcher
+            semanticdbFilterMatcher,
+            onTestFailure
           )
       }
     }

--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/MainOps.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/MainOps.scala
@@ -104,7 +104,10 @@ object MainOps {
         )
       }
       case _: Seq[Rule] =>
-        val files = getFilesFrom(args)
+        // The evaluation API reports results per file, so a missing input
+        // path only surfaces through the reporter and does not affect the
+        // overall evaluation status.
+        val (files, _) = getFilesFrom(args)
         if (files.nonEmpty) {
           val fileEvaluations = {
             files.map { file =>
@@ -145,10 +148,16 @@ object MainOps {
     }
   }
 
-  def getFilesFrom(args: ValidatedArgs): Seq[AbsolutePath] =
+  /**
+   * Returns the files to fix along with the exit status of the input discovery
+   * itself, so that an invalid input path is accounted for in the exit status
+   * and not only reported to the reporter.
+   */
+  def getFilesFrom(args: ValidatedArgs): (Seq[AbsolutePath], ExitStatus) =
     args.args.ls match {
       case Ls.Find =>
         val buf = Vector.newBuilder[AbsolutePath]
+        var exit = ExitStatus.Ok
         val visitor = new SimpleFileVisitor[Path] {
           override def visitFile(
               file: Path,
@@ -173,9 +182,12 @@ object MainOps {
               buf += root
             }
           } else if (root.isDirectory) Files.walkFileTree(root.toNIO, visitor)
-          else args.config.reporter.error(s"$root is not a file")
+          else {
+            args.config.reporter.error(s"$root is not a file")
+            exit = ExitStatus.merge(exit, ExitStatus.UnexpectedError)
+          }
         }
-        buf.result()
+        (buf.result(), exit)
     }
 
   final class StaleSemanticDB(val path: AbsolutePath, val diff: String)
@@ -203,7 +215,7 @@ object MainOps {
       ExitStatus.merge(ExitStatus.LinterError, code)
     } else if (args.callback.hasErrors && code.isOk) {
       ExitStatus.merge(ExitStatus.UnexpectedError, code)
-    } else if (files.isEmpty) {
+    } else if (files.isEmpty && code.isOk) {
       args.config.reporter.error("No files to fix")
       ExitStatus.merge(ExitStatus.NoFilesError, code)
     } else {
@@ -390,11 +402,11 @@ object MainOps {
   }
 
   def run(args: ValidatedArgs): ExitStatus = {
-    val files = getFilesFrom(args)
+    val (files, discoveryError) = getFilesFrom(args)
     var i = 0
     val N = files.length
     val width = N.toString.length
-    var exit = ExitStatus.Ok
+    var exit = discoveryError
 
     args.rules.rules.foreach(_.beforeStart())
 
@@ -410,7 +422,14 @@ object MainOps {
 
     args.rules.rules.foreach(_.afterComplete())
 
-    adjustExitCode(args, exit, files)
+    val result = adjustExitCode(args, exit, files)
+    // Only print the message when the entire failure is auto-fixable, i.e.
+    // the exit status is exactly TestError, not merged with lint, parse,
+    // input or other errors that running Scalafix cannot resolve.
+    if (result == ExitStatus.TestError) {
+      args.onTestFailure.foreach(args.args.out.println)
+    }
+    result
   }
 
   def version: String =

--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/ValidatedArgs.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/ValidatedArgs.scala
@@ -23,7 +23,8 @@ case class ValidatedArgs(
     pathReplace: AbsolutePath => AbsolutePath,
     diffDisable: DiffDisable,
     callback: DelegatingMainCallback,
-    semanticdbFileFilter: FilterMatcher
+    semanticdbFileFilter: FilterMatcher,
+    onTestFailure: Option[String] = None
 ) {
 
   def input(file: AbsolutePath): Input =

--- a/scalafix-tests/integration/src/test/scala/scalafix/tests/cli/CliSyntacticSuite.scala
+++ b/scalafix-tests/integration/src/test/scala/scalafix/tests/cli/CliSyntacticSuite.scala
@@ -129,6 +129,19 @@ class CliSyntacticSuite extends BaseCliSuite {
     expectedExit = ExitStatus.NoRulesError
   )
 
+  val expectedCheckDiff: String =
+    """|<expected fix>
+      |@@ -1,5 +1,5 @@
+      | object Main {
+      |   def foo(): Unit = {
+      |-    s"hello"
+      |+    "hello"
+      |   }
+      | }
+      |""".stripMargin
+
+  val onTestFailureMessage: String = "To fix this, run: sbt scalafixAll"
+
   check(
     name = "TestError",
     originalLayout = s"""/foobar.scala
@@ -138,19 +151,7 @@ class CliSyntacticSuite extends BaseCliSuite {
       |$original""".stripMargin,
     expectedExit = ExitStatus.TestError,
     outputAssert = { out =>
-      assert(
-        out.endsWith(
-          """|<expected fix>
-            |@@ -1,5 +1,5 @@
-            | object Main {
-            |   def foo(): Unit = {
-            |-    s"hello"
-            |+    "hello"
-            |   }
-            | }
-            |""".stripMargin
-        )
-      )
+      assert(out.endsWith(expectedCheckDiff))
     }
   )
 
@@ -162,6 +163,90 @@ class CliSyntacticSuite extends BaseCliSuite {
     expectedLayout = s"""/foobar.scala
       |$expected""".stripMargin,
     expectedExit = ExitStatus.Ok
+  )
+
+  check(
+    name = "TestError prints onTestFailure message",
+    originalLayout = s"""/.scalafix.conf
+      |onTestFailure = "$onTestFailureMessage"
+      |/foobar.scala
+      |$original""".stripMargin,
+    args = Array("--check", "-r", "RedundantSyntax", "foobar.scala"),
+    expectedLayout = s"""/.scalafix.conf
+      |onTestFailure = "$onTestFailureMessage"
+      |/foobar.scala
+      |$original""".stripMargin,
+    expectedExit = ExitStatus.TestError,
+    outputAssert = { out =>
+      assert(out.endsWith(expectedCheckDiff + onTestFailureMessage + "\n"))
+    }
+  )
+
+  check(
+    name = "--check OK does not print onTestFailure message",
+    originalLayout = s"""/.scalafix.conf
+      |onTestFailure = "$onTestFailureMessage"
+      |/foobar.scala
+      |$expected""".stripMargin,
+    args = Array("--check", "-r", "RedundantSyntax", "foobar.scala"),
+    expectedLayout = s"""/.scalafix.conf
+      |onTestFailure = "$onTestFailureMessage"
+      |/foobar.scala
+      |$expected""".stripMargin,
+    expectedExit = ExitStatus.Ok,
+    outputAssert = { out =>
+      assert(!out.contains(onTestFailureMessage))
+    }
+  )
+
+  check(
+    name =
+      "onTestFailure message not printed when mixed with non-fixable errors",
+    originalLayout = s"""/.scalafix.conf
+      |onTestFailure = "$onTestFailureMessage"
+      |/dir/a.scala
+      |$original
+      |/dir/b.scala
+      |object Broken {
+      |""".stripMargin,
+    args = Array("--check", "-r", "RedundantSyntax", "dir"),
+    expectedLayout = s"""/.scalafix.conf
+      |onTestFailure = "$onTestFailureMessage"
+      |/dir/a.scala
+      |$original
+      |/dir/b.scala
+      |object Broken {
+      |""".stripMargin,
+    expectedExit =
+      ExitStatus.merge(ExitStatus.ParseError, ExitStatus.TestError),
+    outputAssert = { out =>
+      assert(!out.contains(onTestFailureMessage))
+    }
+  )
+
+  check(
+    name = "onTestFailure message not printed when an input path is missing",
+    originalLayout = s"""/.scalafix.conf
+      |onTestFailure = "$onTestFailureMessage"
+      |/foobar.scala
+      |$original""".stripMargin,
+    args = Array(
+      "--check",
+      "-r",
+      "RedundantSyntax",
+      "foobar.scala",
+      "missing.scala"
+    ),
+    expectedLayout = s"""/.scalafix.conf
+      |onTestFailure = "$onTestFailureMessage"
+      |/foobar.scala
+      |$original""".stripMargin,
+    expectedExit =
+      ExitStatus.merge(ExitStatus.UnexpectedError, ExitStatus.TestError),
+    outputAssert = { out =>
+      assert(out.contains("is not a file"))
+      assert(!out.contains(onTestFailureMessage))
+    }
   )
 
   check(


### PR DESCRIPTION
Closes #549.

Like scalafmt's setting of the same name, prints project-specific instructions when `scalafix --check` fails:

```hocon
// .scalafix.conf
onTestFailure = "To fix this, run: sbt scalafixAll"
```

The message is printed after the diffs, and only when the failure is entirely auto-fixable (exit status exactly `TestError`) — not when the run also hits linter errors, parse errors, or invalid inputs that re-running Scalafix can't fix.

**Notes for reviewers:**

- Exit-code change: a nonexistent input path now merges `UnexpectedError` into the exit status, so `--check existing.scala missing.scala` exits `TestError+UnexpectedError` instead of plain `TestError`. Other exit codes unchanged.
- `ScalafixEvaluation` is untouched; surfacing the message via sbt-scalafix's `scalafixTest` needs a follow-up there.