### PR TITLE
Organize Imports: order import selectors by kind for IntelliJ preset

### DIFF
--- a/docs/rules/OrganizeImports.md
+++ b/docs/rules/OrganizeImports.md
@@ -19,7 +19,7 @@ option](#preset). To make it easier to add `OrganizeImports` into
 existing Scala projects built using the IntelliJ Scala plugin,
 `OrganizeImports` provides a preset style compatible with the default
 configuration of the IntelliJ Scala import optimizer. Please check the
-[`INTELLIJ_2020_3`](#intellij-2020-3) preset style for more details.
+[`INTELLIJ_2020_3`](#intellij_2020_3) preset style for more details.
 
 ### Source formatting tools
 
@@ -1143,10 +1143,10 @@ equivalent to the
 rewriting rule in Scalafmt.
 
 #### `IntelliJ`  
-Sort import selectors following IntelliJ IDEA Scala plugin's selector-kind
-ordering: plain imported names first (sorted by ASCII), then renames/aliases
-(sorted by ASCII), unimports (sorted by ASCII), wildcards, givens (sorted by
-ASCII), and given-wildcards.
+Sort import selectors according to the selector-kind precedence used by
+IntelliJ IDEA's Scala import optimizer: plain imported names first (sorted by
+ASCII), then renames/aliases (sorted by ASCII), unimports (sorted by ASCII),
+wildcards, givens (sorted by ASCII), and given-wildcards.
 
 #### `Keep`  
 Keep the original order.

--- a/docs/rules/OrganizeImports.md
+++ b/docs/rules/OrganizeImports.md
@@ -1146,7 +1146,7 @@ rewriting rule in Scalafmt.
 Sort import selectors according to the selector-kind precedence used by
 IntelliJ IDEA's Scala import optimizer: plain imported names first (sorted by
 ASCII), then renames/aliases (sorted by ASCII), unimports (sorted by ASCII),
-wildcards, givens (sorted by ASCII), and given-wildcards.
+givens (sorted by ASCII), wildcards, and given-wildcards.
 
 #### `Keep`  
 Keep the original order.

--- a/docs/rules/OrganizeImports.md
+++ b/docs/rules/OrganizeImports.md
@@ -19,7 +19,7 @@ option](#preset). To make it easier to add `OrganizeImports` into
 existing Scala projects built using the IntelliJ Scala plugin,
 `OrganizeImports` provides a preset style compatible with the default
 configuration of the IntelliJ Scala import optimizer. Please check the
-[`INTELLIJ_2020_3`](#intellij_2020_3) preset style for more details.
+[`INTELLIJ_2020_3`](#intellij-2020-3) preset style for more details.
 
 ### Source formatting tools
 
@@ -1129,7 +1129,7 @@ expression.
 
 ### Value type
 
-Enum: `Ascii | SymbolsFirst | Keep`
+Enum: `Ascii | SymbolsFirst | IntelliJ | Keep`
 
 #### `Ascii`  
 Sort import selectors by ASCII codes, equivalent to the
@@ -1141,6 +1141,12 @@ Sort import selectors by the groups: symbols, lower-case, upper-case,
 equivalent to the
 [`SortImports`](https://scalameta.org/scalafmt/docs/configuration.html#sortimports)
 rewriting rule in Scalafmt.
+
+#### `IntelliJ`  
+Sort import selectors following IntelliJ IDEA Scala plugin's selector-kind
+ordering: plain imported names first (sorted by ASCII), then renames/aliases
+(sorted by ASCII), unimports (sorted by ASCII), wildcards, givens (sorted by
+ASCII), and given-wildcards.
 
 #### `Keep`  
 Keep the original order.
@@ -1190,6 +1196,27 @@ import foo.{Random, `symbol`, bar, ~>}
 After:
 ```scala
 import foo.{~>, `symbol`, bar, Random}
+```
+
+#### `IntelliJ`  
+
+```conf
+OrganizeImports {
+  groupedImports = Keep
+  importSelectorsOrder = IntelliJ
+}
+```
+
+Before:
+
+```scala
+import org.mockito.Mockito.{timeout => mockitoTimeout, verify, when}
+```
+
+After:
+
+```scala
+import org.mockito.Mockito.{verify, when, timeout => mockitoTimeout}
 ```
 
 `importsOrder`
@@ -1338,7 +1365,7 @@ OrganizeImports {
     "*"
     "re:(javax?|scala)\\."
   ]
-  importSelectorsOrder = Ascii
+  importSelectorsOrder = IntelliJ
   importsOrder = Ascii
   preset = INTELLIJ_2020_3
   removeUnused = true

--- a/docs/rules/OrganizeImports.md
+++ b/docs/rules/OrganizeImports.md
@@ -1146,7 +1146,7 @@ rewriting rule in Scalafmt.
 Sort import selectors according to the selector-kind precedence used by
 IntelliJ IDEA's Scala import optimizer: plain imported names first (sorted by
 ASCII), then renames/aliases (sorted by ASCII), unimports (sorted by ASCII),
-givens (sorted by ASCII), wildcards, and given-wildcards.
+wildcards, typed givens (sorted by ASCII), and given-wildcards.
 
 #### `Keep`  
 Keep the original order.

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -655,8 +655,8 @@ class OrganizeImports(
         names.sortBy(treeSyntax) ++
           renames.sortBy(treeSyntax) ++
           unimports.sortBy(treeSyntax) ++
-          givens.sortBy(treeSyntax) ++
           wildcard ++
+          givens.sortBy(treeSyntax) ++
           givenAll
       case Keep =>
         importer.importees

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -649,6 +649,15 @@ class OrganizeImports(
         Seq(others, wildcards) map (_.sortBy(treeSyntax)) reduce (_ ++ _)
       case SymbolsFirst =>
         Seq(others, wildcards) map sortImporteesSymbolsFirst reduce (_ ++ _)
+      case IntelliJ =>
+        val Importees(names, renames, unimports, givens, givenAll, wildcard) =
+          importer.importees
+        names.sortBy(treeSyntax) ++
+          renames.sortBy(treeSyntax) ++
+          unimports.sortBy(treeSyntax) ++
+          wildcard ++
+          givens.sortBy(treeSyntax) ++
+          givenAll
       case Keep =>
         importer.importees
     }

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -655,8 +655,8 @@ class OrganizeImports(
         names.sortBy(treeSyntax) ++
           renames.sortBy(treeSyntax) ++
           unimports.sortBy(treeSyntax) ++
-          wildcard ++
           givens.sortBy(treeSyntax) ++
+          wildcard ++
           givenAll
       case Keep =>
         importer.importees

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImportsConfig.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImportsConfig.scala
@@ -19,10 +19,11 @@ sealed trait ImportSelectorsOrder
 object ImportSelectorsOrder {
   case object Ascii extends ImportSelectorsOrder
   case object SymbolsFirst extends ImportSelectorsOrder
+  case object IntelliJ extends ImportSelectorsOrder
   case object Keep extends ImportSelectorsOrder
 
   implicit val codec: ConfCodecEx[ImportSelectorsOrder] = OrganizeImportsConfig
-    .getCodecFrom(Ascii, SymbolsFirst, Keep)
+    .getCodecFrom(Ascii, SymbolsFirst, IntelliJ, Keep)
 }
 
 sealed trait GroupedImports
@@ -92,7 +93,8 @@ final case class OrganizeImportsConfig(
           case ("preset", Conf.Str("INTELLIJ_2020_3")) =>
             OrganizeImportsConfig(
               coalesceToWildcardImportThreshold = Some(5),
-              groupedImports = GroupedImports.Merge
+              groupedImports = GroupedImports.Merge,
+              importSelectorsOrder = ImportSelectorsOrder.IntelliJ
             )
         }
         remapped.map { case (state, elems) => state -> Conf.Obj(elems) }

--- a/scalafix-tests/input/src/main/scala-3/test/organizeImports/SortImportSelectorsIntelliJScala3.scala
+++ b/scalafix-tests/input/src/main/scala-3/test/organizeImports/SortImportSelectorsIntelliJScala3.scala
@@ -4,6 +4,7 @@ OrganizeImports {
   importSelectorsOrder = IntelliJ
   groupedImports = Keep
   removeUnused = false
+  groupSeparately = []
   targetDialect = Scala3
 }
  */

--- a/scalafix-tests/input/src/main/scala-3/test/organizeImports/SortImportSelectorsIntelliJScala3.scala
+++ b/scalafix-tests/input/src/main/scala-3/test/organizeImports/SortImportSelectorsIntelliJScala3.scala
@@ -1,0 +1,34 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  importSelectorsOrder = IntelliJ
+  groupedImports = Keep
+  removeUnused = false
+  targetDialect = Scala3
+}
+ */
+package test.organizeImports
+
+import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures._
+import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.A
+import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.B
+
+// Category test 1: names (a, b), renames (c as C), wildcard (*), givenAll (given)
+import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.{b, c as C, a, *, given}
+
+// Category test 2: names (a, b), renames (c as C), unimports (d => _), givens (given A, given B)
+import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.{b, c as C, d => _, a, given B, given A}
+
+object SortImportSelectorsIntelliJScala3 {
+  object fixtures {
+    trait A
+    trait B
+    object a
+    object b
+    object c
+    object d
+    object e
+    given A = new A {}
+    given B = new B {}
+  }
+}

--- a/scalafix-tests/input/src/main/scala-3/test/organizeImports/SortImportSelectorsIntelliJScala3.scala
+++ b/scalafix-tests/input/src/main/scala-3/test/organizeImports/SortImportSelectorsIntelliJScala3.scala
@@ -13,8 +13,8 @@ import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures._
 import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.A
 import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.B
 
-// All six categories in a single import: givens, unimports, renames, wildcard, names, givenAll
-import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.{given B, d as _, c as C, *, a, given A, b, given}
+// All six selector categories in a single import
+import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.{b, a, c as C, d as _, given B, given A, *, given}
 
 object SortImportSelectorsIntelliJScala3 {
   object fixtures {

--- a/scalafix-tests/input/src/main/scala-3/test/organizeImports/SortImportSelectorsIntelliJScala3.scala
+++ b/scalafix-tests/input/src/main/scala-3/test/organizeImports/SortImportSelectorsIntelliJScala3.scala
@@ -13,11 +13,8 @@ import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures._
 import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.A
 import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.B
 
-// Category test 1: names (a, b), renames (c as C), wildcard (*), givenAll (given)
-import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.{b, c as C, a, *, given}
-
-// Category test 2: names (a, b), renames (c as C), unimports (d => _), givens (given A, given B)
-import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.{b, c as C, d => _, a, given B, given A}
+// All six categories in a single import: givens, unimports, renames, wildcard, names, givenAll
+import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.{given B, d as _, c as C, *, a, given A, b, given}
 
 object SortImportSelectorsIntelliJScala3 {
   object fixtures {

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/PresetIntelliJ_2020_3_Selectors.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/PresetIntelliJ_2020_3_Selectors.scala
@@ -1,0 +1,26 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  preset = INTELLIJ_2020_3
+  removeUnused = false
+}
+ */
+package test.organizeImports
+
+import test.organizeImports.PresetIntelliJ_2020_3_Selectors.metrics.MetricRegistry
+import test.organizeImports.PresetIntelliJ_2020_3_Selectors.metrics.{Gauge => DropwizardGauge}
+import test.organizeImports.PresetIntelliJ_2020_3_Selectors.mockito.verify
+import test.organizeImports.PresetIntelliJ_2020_3_Selectors.mockito.when
+import test.organizeImports.PresetIntelliJ_2020_3_Selectors.mockito.{timeout => mockitoTimeout}
+
+object PresetIntelliJ_2020_3_Selectors {
+  object metrics {
+    object MetricRegistry
+    object Gauge
+  }
+  object mockito {
+    object verify
+    object when
+    object timeout
+  }
+}

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/SortImportSelectorsIntelliJ.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/SortImportSelectorsIntelliJ.scala
@@ -1,0 +1,14 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  importSelectorsOrder = IntelliJ
+  groupedImports = Keep
+  removeUnused = false
+}
+ */
+package test.organizeImports
+
+import scala.{Option, List => L, Any, Vector => _, collection}
+import scala.collection.{immutable => _, mutable => m, _}
+
+object SortImportSelectorsIntelliJ

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/SortImportSelectorsIntelliJScala3.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/SortImportSelectorsIntelliJScala3.scala
@@ -5,7 +5,7 @@ import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.A
 import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.B
 
 // All six selector categories in a single import
-import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.{a, b, c as C, d as _, *, given A, given B, given}
+import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.{a, b, c as C, d as _, given A, given B, *, given}
 
 object SortImportSelectorsIntelliJScala3 {
   object fixtures {

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/SortImportSelectorsIntelliJScala3.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/SortImportSelectorsIntelliJScala3.scala
@@ -3,9 +3,8 @@ package test.organizeImports
 import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.*
 import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.A
 import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.B
-
 // All six selector categories in a single import
-import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.{a, b, c as C, d as _, given A, given B, *, given}
+import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.{a, b, c as C, d as _, *, given A, given B, given}
 
 object SortImportSelectorsIntelliJScala3 {
   object fixtures {

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/SortImportSelectorsIntelliJScala3.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/SortImportSelectorsIntelliJScala3.scala
@@ -4,7 +4,7 @@ import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.*
 import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.A
 import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.B
 
-// All six categories in a single import: givens, unimports, renames, wildcard, names, givenAll
+// All six selector categories in a single import
 import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.{a, b, c as C, d as _, *, given A, given B, given}
 
 object SortImportSelectorsIntelliJScala3 {

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/SortImportSelectorsIntelliJScala3.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/SortImportSelectorsIntelliJScala3.scala
@@ -3,12 +3,9 @@ package test.organizeImports
 import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.*
 import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.A
 import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.B
-// Category test 2: names (a, b), renames (c as C), unimports (d => _), givens (given A, given B)
-import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.d as _
-// Category test 1: names (a, b), renames (c as C), wildcard (*), givenAll (given)
-import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.{a, b, c as C, *, given}
 
-import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.{given A, given B}
+// All six categories in a single import: givens, unimports, renames, wildcard, names, givenAll
+import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.{a, b, c as C, d as _, *, given A, given B, given}
 
 object SortImportSelectorsIntelliJScala3 {
   object fixtures {

--- a/scalafix-tests/output/src/main/scala-3/test/organizeImports/SortImportSelectorsIntelliJScala3.scala
+++ b/scalafix-tests/output/src/main/scala-3/test/organizeImports/SortImportSelectorsIntelliJScala3.scala
@@ -1,0 +1,25 @@
+package test.organizeImports
+
+import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.*
+import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.A
+import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.B
+// Category test 2: names (a, b), renames (c as C), unimports (d => _), givens (given A, given B)
+import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.d as _
+// Category test 1: names (a, b), renames (c as C), wildcard (*), givenAll (given)
+import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.{a, b, c as C, *, given}
+
+import test.organizeImports.SortImportSelectorsIntelliJScala3.fixtures.{given A, given B}
+
+object SortImportSelectorsIntelliJScala3 {
+  object fixtures {
+    trait A
+    trait B
+    object a
+    object b
+    object c
+    object d
+    object e
+    given A = new A {}
+    given B = new B {}
+  }
+}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/PresetIntelliJ_2020_3_Selectors.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/PresetIntelliJ_2020_3_Selectors.scala
@@ -1,0 +1,23 @@
+package test.organizeImports
+
+import test.organizeImports.PresetIntelliJ_2020_3_Selectors.metrics.{
+  MetricRegistry,
+  Gauge => DropwizardGauge
+}
+import test.organizeImports.PresetIntelliJ_2020_3_Selectors.mockito.{
+  verify,
+  when,
+  timeout => mockitoTimeout
+}
+
+object PresetIntelliJ_2020_3_Selectors {
+  object metrics {
+    object MetricRegistry
+    object Gauge
+  }
+  object mockito {
+    object verify
+    object when
+    object timeout
+  }
+}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/SortImportSelectorsIntelliJ.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/SortImportSelectorsIntelliJ.scala
@@ -1,0 +1,6 @@
+package test.organizeImports
+
+import scala.collection.{mutable => m, immutable => _, _}
+import scala.{Any, Option, collection, List => L, Vector => _}
+
+object SortImportSelectorsIntelliJ


### PR DESCRIPTION
Problem : 

Previously, grouped import selectors under `INTELLIJ_2020_3` were ordered purely lexicographically (ASCII), leading to discrepancies with IntelliJ IDEA's import optimizer which applies selector-kind precedence before sorting lexicographically within each kind:
1. Plain imported names (`a`, `b`)
2. Renames / aliases (`c as C`, `timeout => mockitoTimeout`)
3. Unimports / exclusions (`d => _`)
4. Wildcards (`*`, `_`)
5. Givens (`given A`)
6. Given wildcards (`given`)
For example:
```scala
// IntelliJ IDEA:
import org.mockito.Mockito.{verify, when, timeout => mockitoTimeout}
// Scalafix previous output:
import org.mockito.Mockito.{timeout => mockitoTimeout, verify, when}

What i had worked on (solution) : 

- Added ImportSelectorsOrder.IntelliJ to categorize importees by selector kind before sorting.
- Configured INTELLIJ_2020_3 preset to default to importSelectorsOrder = IntelliJ.
- Added unit and regression test fixtures for Scala 2 and Scala 3.
- Updated docs/rules/OrganizeImports.md to document the new IntelliJ value for importSelectorsOrder.

Summary :

Fixes the import selector sorting behavior in `OrganizeImports` when using the `INTELLIJ_2020_3` preset or explicit IntelliJ selector ordering.

Please review the changes and let me know if anything needs adjustment or further testing. If everything looks good, feel free to merge. Thank you!