### PR TITLE
fix scala 3 doc generation

### DIFF
--- a/project/ScalafixBuild.scala
+++ b/project/ScalafixBuild.scala
@@ -206,7 +206,8 @@ object ScalafixBuild extends AutoPlugin with GhpagesKeys {
         }
     },
     commands += Command.command("ci-docs") { state =>
-      "docs2_13/run" :: // reduce risk of errors on deploy-website.yml
+      "core3 / Compile / doc" ::
+        "docs2_13/run" :: // reduce risk of errors on deploy-website.yml
         "interfaces/doc" ::
         state
     },

--- a/scalafix-core/src/main/scala/scalafix/v1/Rule.scala
+++ b/scalafix-core/src/main/scala/scalafix/v1/Rule.scala
@@ -17,7 +17,7 @@ abstract class Rule(val name: RuleName) {
 
   /**
    * Configure this rule according to user `.scalafix.conf` settings and
-   * compiler information from [[Configuration]].
+   * compiler information from [[scalafix.v1.Configuration]].
    *
    * This method is called once per project/module. The same rule instance is
    * used to analyze multiple source files.


### PR DESCRIPTION
Release process was broken since https://github.com/scalacenter/scalafix/pull/2481

```
[error] /home/runner/work/scalafix/scalafix/scalafix-core/src/main/scala/scalafix/v1/Rule.scala:18:3: Could not find any member to link for "Configuration".
[error] /**
[error] ^
[error] one error found
```