### PR TITLE
fix docusaurusPublishGhpages after mdoc 2.9.1 update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -450,6 +450,7 @@ lazy val docs = projectMatrix
   .in(file("scalafix-docs"))
   .settings(
     noPublishAndNoMima,
+    docusaurusVersion := DocusaurusVersion.V1,
     fork := true,
     run / baseDirectory := (ThisBuild / baseDirectory).value,
     moduleName := "scalafix-docs",


### PR DESCRIPTION
Follows https://github.com/scalacenter/scalafix/pull/2490

See https://github.com/scalameta/mdoc/pull/1103