### PR TITLE
Fix `RemoveUnused` / `OrganizeImports.removeUnused` for Scala 3.10+

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/internal/config/ScalaVersion.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/config/ScalaVersion.scala
@@ -157,6 +157,17 @@ object ScalaVersion {
 
   private val yyyyMMdd = DateTimeFormatter.ofPattern("yyyyMMdd")
 
+  implicit val ordering: Ordering[ScalaVersion] =
+    Ordering.by(v =>
+      (v.major.value, v.minor.getOrElse(0), v.patch.getOrElse(0))
+    )
+
+  // unused warnings were only exposed to SemanticDB starting with Scala 3.3.4
+  def unusedDiagnosticsInSemanticdb(version: String): Boolean =
+    from(version).toOption.forall { v =>
+      v.isScala2 || ordering.gteq(v, Patch(Major.Scala3, 3, 4))
+    }
+
   def from(version: String): Try[ScalaVersion] = {
     version match {
       case NightlyVersion(major, minor, patch, rc, date, shortSha1) =>

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -865,8 +865,7 @@ object OrganizeImports {
       scalaVersion: String
   ): Configured[Rule] = {
     val hasCompilerSupport =
-      Seq("3.0", "3.1", "3.2", "3.3.0", "3.3.1", "3.3.2", "3.3.3")
-        .forall(v => !scalaVersion.startsWith(v))
+      ScalaVersion.unusedDiagnosticsInSemanticdb(scalaVersion)
 
     val hasWarnUnused = hasCompilerSupport && {
       val warnUnusedPrefix = Set("-Wunused", "-Ywarn-unused")

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/RemoveUnused.scala
@@ -6,6 +6,7 @@ import scala.meta._
 import scala.meta.tokens.Token
 
 import metaconfig.Configured
+import scalafix.internal.config.ScalaVersion
 import scalafix.v1._
 
 class RemoveUnused(config: RemoveUnusedConfig)
@@ -33,8 +34,7 @@ class RemoveUnused(config: RemoveUnusedConfig)
   private def warnUnusedString = List("-Wall", "-Xlint", "-Xlint:unused")
   override def withConfiguration(config: Configuration): Configured[Rule] = {
     val diagnosticsAvailableInSemanticdb =
-      Seq("3.0", "3.1", "3.2", "3.3.0", "3.3.1", "3.3.2", "3.3.3")
-        .forall(v => !config.scalaVersion.startsWith(v))
+      ScalaVersion.unusedDiagnosticsInSemanticdb(config.scalaVersion)
 
     val hasWarnUnused = config.scalacOptions.exists(option =>
       warnUnusedPrefix.exists(prefix => option.startsWith(prefix)) ||

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/config/OrganizeImportsConfigSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/config/OrganizeImportsConfigSuite.scala
@@ -80,4 +80,55 @@ class OrganizeImportsConfigSuite extends AnyFunSuite {
       "Expected OrganizeImports to succeed when RemoveUnused is not configured"
     )
   }
+
+  private def checkRemoveUnusedScalaVersion(
+      scalaVersion: String,
+      expectedOk: Boolean
+  ): Unit = {
+    val rawConfig =
+      """|rules = [OrganizeImports]
+        |OrganizeImports.removeUnused = true
+        |""".stripMargin
+    val conf = Conf.parseString("test", rawConfig).get
+    val config = Configuration()
+      .withConf(conf)
+      .withScalaVersion(scalaVersion)
+      .withScalacOptions(List("-Wunused:all"))
+    val result = new OrganizeImports().withConfiguration(config)
+    assert(
+      result.isOk == expectedOk,
+      s"OrganizeImports.removeUnused with Scala $scalaVersion: expected isOk=$expectedOk, got $result"
+    )
+    if (!expectedOk) {
+      result match {
+        case Configured.NotOk(error) =>
+          assert(
+            error.msg.contains("not supported") &&
+              error.msg.contains("3.3.4"),
+            s"Error should mention unsupported compiler. Got: ${error.msg}"
+          )
+        case _ => fail("Expected Configured.NotOk")
+      }
+    }
+  }
+
+  test("OrganizeImports.removeUnused accepts Scala 3.10.0-RC1") {
+    checkRemoveUnusedScalaVersion("3.10.0-RC1", expectedOk = true)
+  }
+
+  test("OrganizeImports.removeUnused accepts Scala 3.3.4") {
+    checkRemoveUnusedScalaVersion("3.3.4", expectedOk = true)
+  }
+
+  test("OrganizeImports.removeUnused accepts Scala 2.13.18") {
+    checkRemoveUnusedScalaVersion("2.13.18", expectedOk = true)
+  }
+
+  test("OrganizeImports.removeUnused rejects Scala 3.3.3") {
+    checkRemoveUnusedScalaVersion("3.3.3", expectedOk = false)
+  }
+
+  test("OrganizeImports.removeUnused rejects Scala 3.1.3") {
+    checkRemoveUnusedScalaVersion("3.1.3", expectedOk = false)
+  }
 }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/config/RemoveUnusedConfigSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/config/RemoveUnusedConfigSuite.scala
@@ -1,0 +1,39 @@
+package scalafix.tests.config
+
+import org.scalatest.funsuite.AnyFunSuite
+import scalafix.internal.rule.RemoveUnused
+import scalafix.v1.Configuration
+
+class RemoveUnusedConfigSuite extends AnyFunSuite {
+
+  private def check(scalaVersion: String, expectedOk: Boolean): Unit = {
+    val config = Configuration()
+      .withScalaVersion(scalaVersion)
+      .withScalacOptions(List("-Wunused:all"))
+    val result = new RemoveUnused().withConfiguration(config)
+    assert(
+      result.isOk == expectedOk,
+      s"RemoveUnused with Scala $scalaVersion: expected isOk=$expectedOk, got $result"
+    )
+  }
+
+  test("RemoveUnused accepts Scala 3.10.0-RC1") {
+    check("3.10.0-RC1", expectedOk = true)
+  }
+
+  test("RemoveUnused accepts Scala 3.3.4") {
+    check("3.3.4", expectedOk = true)
+  }
+
+  test("RemoveUnused accepts Scala 2.13.18") {
+    check("2.13.18", expectedOk = true)
+  }
+
+  test("RemoveUnused rejects Scala 3.3.3") {
+    check("3.3.3", expectedOk = false)
+  }
+
+  test("RemoveUnused rejects Scala 3.1.3") {
+    check("3.1.3", expectedOk = false)
+  }
+}

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ScalaVersionSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ScalaVersionSuite.scala
@@ -51,4 +51,26 @@ class ScalaVersionSuite extends munit.FunSuite {
     assert(scala3.isFailure)
   }
 
+  test("unusedDiagnosticsInSemanticdb") {
+    val cases = List(
+      "3.10.0-RC1" -> true,
+      "3.3.4" -> true,
+      "3.3.4-RC1" -> true,
+      "2.13.18" -> true,
+      "3.3.3" -> false,
+      "3.1.3" -> false,
+      "3.0.0" -> false,
+      "3.2.2" -> false,
+      "3.6.0-RC1-bin-20241008-3408ed7-NIGHTLY" -> true,
+      "not-a-version" -> true // unparseable stays permissive
+    )
+    cases.foreach { case (version, expected) =>
+      assertEquals(
+        ScalaVersion.unusedDiagnosticsInSemanticdb(version),
+        expected,
+        clue = version
+      )
+    }
+  }
+
 }


### PR DESCRIPTION
Fixes https://github.com/scalacenter/scalafix/issues/2503