### PR TITLE
OrganizeImports: re-emit unchanged imports verbatim

### DIFF
--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -773,63 +773,105 @@ class OrganizeImports(
         def appendEndComment(pc: Tree.Comments): Unit =
           if (commentsPrinted.add(pc))
             pc.values.foreach(x => sb.append(' ').append(x.syntax))
+        def appendCurly(
+            isMultiline: Boolean,
+            useOuterSpace: Boolean,
+            trailingComma: Boolean
+        )(appendImportees: String => Unit): Unit = {
+          sb.append('{')
+          val sep = if (isMultiline) "\n  " else " "
+          if (isMultiline) sb.append(sep)
+          else if (useOuterSpace) sb.append(' ')
+          appendImportees(sep)
+          if (isMultiline) {
+            if (trailingComma) sb.append(',')
+            sb.append('\n')
+          } else if (useOuterSpace) sb.append(' ')
+          sb.append('}')
+        }
 
         val single =
           if (i.importees.lengthCompare(1) == 0) i.importees.head else null
 
         ps.foreach(_.begComment.foreach(appendBegComment))
         i.begComment.foreach(appendBegComment)
-        if (single != null) single.begComment.foreach(appendBegComment)
-        sb.append("import ").append(treeSyntax(i.ref)).append('.')
-        if (single != null) {
+        val orig = i.originalPrototype() match {
+          case orig: Importer => orig
+          case _ => i
+        }
+        if (i.isUnchangedFrom(orig)) {
+          // Comments within the source text are part of it; those attached
+          // around it are printed as for any other import.
+          def isWithin(pc: Tree.Comments): Boolean = pc.values.forall { c =>
+            c.pos.start >= orig.pos.start && c.pos.end <= orig.pos.end
+          }
+          orig.importees.foreach(_.begComment.foreach { pc =>
+            if (isWithin(pc)) commentsPrinted.add(pc) else appendBegComment(pc)
+          })
+          // Continuation lines are re-indented on insertion, like printed ones.
+          val srcIndent = " " * orig.parent.fold(0)(_.pos.startColumn)
+          val srcLines = orig.tokens.syntax.linesIterator
+          sb.append("import ").append(srcLines.next())
+          srcLines.foreach(l =>
+            sb.append('\n').append(l.stripPrefix(srcIndent))
+          )
+          orig.importees.foreach(_.endComment.foreach { pc =>
+            if (isWithin(pc)) commentsPrinted.add(pc) else appendEndComment(pc)
+          })
+        } else if (single != null) {
+          single.begComment.foreach(appendBegComment)
+          sb.append("import ").append(treeSyntax(i.ref)).append('.')
           val isCurly = single.isCurlyBraced
-          val useOuterSpace = isCurly && single
-            .originalPrototype()
-            .parent
-            .exists(_.hasSpaceInCurly)
-          if (isCurly) {
-            sb.append('{')
-            if (useOuterSpace) sb.append(' ')
+          val origImporter =
+            single.originalPrototype().parent.collect { case p: Importer => p }
+          // Preserve wrapping only for a source that was already a single
+          // importee; imports split from a multi-importee source stay inline.
+          val isMultiline = isCurly && origImporter.exists { imp =>
+            imp.importees.lengthCompare(1) == 0 && imp.spansMultipleLines
           }
-          sb.append(treeSyntax(single))
-          if (isCurly) {
-            if (useOuterSpace) sb.append(' ')
-            sb.append('}')
-          }
+          val useOuterSpace =
+            isCurly && !isMultiline && origImporter.exists(_.hasSpaceInCurly)
+          val trailingComma =
+            isMultiline && origImporter.exists(_.hasTrailingComma)
+          if (isCurly)
+            appendCurly(isMultiline, useOuterSpace, trailingComma) { _ =>
+              sb.append(treeSyntax(single))
+            }
+          else sb.append(treeSyntax(single))
           single.endComment.foreach(appendEndComment)
         } else {
-          val lines = i.importees.iterator.map(_.pos.startLine).filter(_ >= 0)
-          val isMultiline = lines.hasNext && {
-            val line = lines.next()
-            lines.exists(_ != line)
-          }
+          sb.append("import ").append(treeSyntax(i.ref)).append('.')
+          // Synthesized importees (e.g. a coalesced wildcard) have no source importer.
           val origImporters = i.importees
             .flatMap(_.originalPrototype().parent)
+            .collect { case p: Importer if p.isFromSource => p }
             .distinct
+          val lines = i.importees.iterator.map(_.pos.startLine).filter(_ >= 0)
+          // Synthesized importees have no position: fall back to the source importer.
+          val isMultiline = (lines.hasNext && {
+            val line = lines.next()
+            lines.exists(_ != line)
+          }) || (origImporters match {
+            case Seq(origImporter) => origImporter.spansMultipleLines
+            case _ => false
+          })
           val useOuterSpace =
             !isMultiline && origImporters.exists(_.hasSpaceInCurly)
           // Preserve a trailing comma if the (single) source importer had one.
           val trailingComma = isMultiline && (origImporters match {
-            case Seq(origImporter: Importer) => origImporter.hasTrailingComma
+            case Seq(origImporter) => origImporter.hasTrailingComma
             case _ => false
           })
-          sb.append('{')
-          val sep = if (isMultiline) "\n  " else " "
-          if (isMultiline) sb.append(sep)
-          else if (useOuterSpace) sb.append(' ')
-          val sblen = sb.length
-          i.importees.foreach { i2 =>
-            if (sb.length > sblen) sb.append(',').append(sep)
-            val proto = i2.originalPrototype()
-            proto.begComment.foreach(appendBegComment)
-            sb.append(treeSyntax(i2))
-            proto.endComment.foreach(appendEndComment)
+          appendCurly(isMultiline, useOuterSpace, trailingComma) { sep =>
+            val sblen = sb.length
+            i.importees.foreach { i2 =>
+              if (sb.length > sblen) sb.append(',').append(sep)
+              val proto = i2.originalPrototype()
+              proto.begComment.foreach(appendBegComment)
+              sb.append(treeSyntax(i2))
+              proto.endComment.foreach(appendEndComment)
+            }
           }
-          if (isMultiline) {
-            if (trailingComma) sb.append(',')
-            sb.append('\n')
-          } else if (useOuterSpace) sb.append(' ')
-          sb.append('}')
         }
         i.endComment.foreach(appendEndComment)
         ps.foreach(_.endComment.foreach(appendEndComment))
@@ -1224,13 +1266,39 @@ object OrganizeImports {
       tokens.getWideOpt(idx).exists(_.is[Token.Comma])
     }
 
-  }
+    def spansMultipleLines: Boolean =
+      importer.pos.startLine != importer.pos.endLine
 
-  implicit private class TreeExtension(val tree: Tree) extends AnyVal {
-    def hasSpaceInCurly: Boolean = tree match {
-      case i: Importer => i.hasSpaceInCurly
-      case _ => false
-    }
+    def isFromSource: Boolean = importer.parent.exists(_.is[Import])
+
+    /**
+     * Checks whether pretty-printing under `dialect` would rewrite the syntax
+     * of some `Importee`s (`=>` vs `as`, `_` vs `*`).
+     */
+    def needsDialectRewrite(implicit dialect: Dialect): Boolean =
+      importer.importees.exists {
+        case i: Importee.Wildcard =>
+          i.tokens.exists(_.is[Token.Underscore]) ==
+            dialect.allowStarWildcardImport
+        case i @ (_: Importee.Rename | _: Importee.Unimport) =>
+          i.tokens.exists(_.is[Token.RightArrow]) ==
+            dialect.allowAsForImportRename
+        case _ => false
+      }
+
+    /**
+     * Checks whether the `Importer` is structurally identical to `orig`, its
+     * parsed source counterpart, and needs no syntax migration to `dialect`, so
+     * that the source text can be re-emitted as is. Only wrapped imports
+     * qualify: their layout is owned by the formatter, while single-line ones
+     * are still normalized.
+     */
+    def isUnchangedFrom(orig: Importer)(implicit dialect: Dialect): Boolean =
+      orig.isFromSource &&
+        orig.spansMultipleLines &&
+        importer.structure == orig.structure &&
+        !orig.needsDialectRewrite
+
   }
 
 }

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/CoalesceMultiLineTrailingComma.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/CoalesceMultiLineTrailingComma.scala
@@ -1,0 +1,23 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Keep
+  removeUnused = false
+  coalesceToWildcardImportThreshold = 2
+}
+ */
+package test.organizeImports
+
+// Coalescing rewrites the importees, but the wrapping and the trailing comma
+// of the source import are kept.
+import scala.collection.immutable.{
+  Map => M,
+  Set,
+  Seq,
+}
+
+object CoalesceMultiLineTrailingComma {
+  val m: M[Int, Int] = M.empty
+  val s: Set[Int] = Set.empty
+  val q: Seq[Int] = Seq.empty
+}

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/SingleImporteeSplitInline.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/SingleImporteeSplitInline.scala
@@ -1,0 +1,20 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Explode
+  removeUnused = false
+}
+ */
+package test.organizeImports
+
+// Importees split out of a wrapped multi-importee import are printed inline:
+// the wrapping belonged to the source import, not to each importee.
+import scala.collection.immutable.{
+  Set,
+  Map => M,
+}
+
+object SingleImporteeSplitInline {
+  val m: M[Int, Int] = M.empty
+  val s: Set[Int] = Set.empty
+}

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/SingleImporteeWrapped.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/SingleImporteeWrapped.scala
@@ -1,0 +1,17 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Keep
+  removeUnused = false
+}
+ */
+package test.organizeImports
+
+// A wrapped single importee keeps its multi-line layout.
+import scala.collection.{
+  immutable => imm,
+}
+
+object SingleImporteeWrapped {
+  val m: imm.Map[Int, Int] = imm.Map.empty
+}

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/SingleImporteeWrappedNoComma.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/SingleImporteeWrappedNoComma.scala
@@ -1,0 +1,18 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Keep
+  removeUnused = false
+}
+ */
+package test.organizeImports
+
+// A wrapped single importee without a trailing comma keeps its layout, and
+// does not gain a comma.
+import scala.collection.{
+  immutable => imm
+}
+
+object SingleImporteeWrappedNoComma {
+  val m: imm.Map[Int, Int] = imm.Map.empty
+}

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/nested/NestedPackageWrapped.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/nested/NestedPackageWrapped.scala
@@ -1,0 +1,23 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Keep
+  removeUnused = false
+}
+ */
+package test.organizeImports.nested {
+  // Wrapped imports inside an indented block keep their relative indentation.
+  import scala.collection.immutable.{
+    Map => M,
+    Set,
+  }
+  import scala.collection.{
+    immutable => imm,
+  }
+
+  object NestedPackageWrapped {
+    val m: M[Int, Int] = M.empty
+    val s: Set[Int] = Set.empty
+    val i: imm.Map[Int, Int] = imm.Map.empty
+  }
+}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/CoalesceMultiLineTrailingComma.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/CoalesceMultiLineTrailingComma.scala
@@ -1,0 +1,14 @@
+package test.organizeImports
+
+// Coalescing rewrites the importees, but the wrapping and the trailing comma
+// of the source import are kept.
+import scala.collection.immutable.{
+  Map => M,
+  _,
+}
+
+object CoalesceMultiLineTrailingComma {
+  val m: M[Int, Int] = M.empty
+  val s: Set[Int] = Set.empty
+  val q: Seq[Int] = Seq.empty
+}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/SingleImporteeSplitInline.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/SingleImporteeSplitInline.scala
@@ -1,0 +1,11 @@
+package test.organizeImports
+
+// Importees split out of a wrapped multi-importee import are printed inline:
+// the wrapping belonged to the source import, not to each importee.
+import scala.collection.immutable.Set
+import scala.collection.immutable.{Map => M}
+
+object SingleImporteeSplitInline {
+  val m: M[Int, Int] = M.empty
+  val s: Set[Int] = Set.empty
+}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/SingleImporteeWrapped.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/SingleImporteeWrapped.scala
@@ -1,0 +1,10 @@
+package test.organizeImports
+
+// A wrapped single importee keeps its multi-line layout.
+import scala.collection.{
+  immutable => imm,
+}
+
+object SingleImporteeWrapped {
+  val m: imm.Map[Int, Int] = imm.Map.empty
+}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/SingleImporteeWrappedNoComma.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/SingleImporteeWrappedNoComma.scala
@@ -1,0 +1,11 @@
+package test.organizeImports
+
+// A wrapped single importee without a trailing comma keeps its layout, and
+// does not gain a comma.
+import scala.collection.{
+  immutable => imm
+}
+
+object SingleImporteeWrappedNoComma {
+  val m: imm.Map[Int, Int] = imm.Map.empty
+}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/nested/NestedPackageWrapped.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/nested/NestedPackageWrapped.scala
@@ -1,0 +1,16 @@
+package test.organizeImports.nested {
+  // Wrapped imports inside an indented block keep their relative indentation.
+  import scala.collection.immutable.{
+    Map => M,
+    Set,
+  }
+  import scala.collection.{
+    immutable => imm,
+  }
+
+  object NestedPackageWrapped {
+    val m: M[Int, Int] = M.empty
+    val s: Set[Int] = Set.empty
+    val i: imm.Map[Int, Int] = imm.Map.empty
+  }
+}


### PR DESCRIPTION
Since 0d232c9f, the rule deletes every import and re-inserts a pretty-print of its tree, whether or not it changed anything. It then has to recover, one by one, each formatting detail the printer discards: spaces inside curly braces (#2427), trailing commas (#2468), wrapped single importees (reported on #2468)... and there is always one more (#2500, backticks).

An import that is already organized and wrapped over several lines is now re-emitted from its source text, byte for byte. "Already organized" means: after applying the whole configuration (groupedImports, expandRelative, coalesceToWildcardImportThreshold, importSelectorsOrder, removeUnused...), the resulting importer is structurally identical to the source one -- same qualifier, same importees, same order -- and needs no syntax migration to the target dialect (`_` to `*`, `=>` to `as`). The configuration still decides the *structure* of every import; verbatim only preserves the *layout* of wrapped imports that are already in the configured structure. Single-line imports, and everything the rule rewrites, go through the pretty printer as before, so `import a.{ B }` is still normalized to `import a.B`.

Principle: an already-organized import must produce no diff. How an untouched import is formatted is scalafmt's business, not this rule's; the two must never fight over the same line.

For rewritten imports, the wrapping and trailing comma of the source import are kept when all importees come from a single wrapped source import, even if some importees are synthesized (coalesced wildcard).

What changes for users: a wrapped import the rule has no reason to touch keeps its exact layout (indentation, alignment, trailing comma, spacing). No existing expected output changes.

 Fixes the single-importee case reported on #2468 and the case reported in go through the pretty printer and need #2500 for their qualifier. #2473 (duplicated trailing comment on reorder) is unrelated and not addressed.