### PR TITLE
don't target all sources when --diff reports only deletions

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/internal/diff/DiffDisable.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/diff/DiffDisable.scala
@@ -16,19 +16,17 @@ object DiffDisable {
 sealed trait DiffDisable {
   def isDisabled(position: Position): Boolean
   def isDisabled(file: Input): Boolean
-  def isEmpty: Boolean
+  def canSkip: Boolean
 }
 
 object EmptyDiff extends DiffDisable {
-  override def isEmpty: Boolean = true
+  override def canSkip: Boolean = true
   def isDisabled(position: Position): Boolean = false
   def isDisabled(file: Input): Boolean = false
 }
 
 class FullDiffDisable(diffs: List[GitDiff]) extends DiffDisable {
-  // Always non-empty: distinguish "diff requested but empty" (delete-only /
-  // no changes) from EmptyDiff ("no diff requested"). See #2505.
-  override def isEmpty: Boolean = false
+  override def canSkip: Boolean = false
   private val newFiles: Set[String] = diffs.collect { case NewFile(path) =>
     path.toAbsolutePath.toString
   }.toSet

--- a/scalafix-core/src/main/scala/scalafix/internal/diff/DiffDisable.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/diff/DiffDisable.scala
@@ -26,7 +26,9 @@ object EmptyDiff extends DiffDisable {
 }
 
 class FullDiffDisable(diffs: List[GitDiff]) extends DiffDisable {
-  override def isEmpty: Boolean = diffs.isEmpty
+  // Always non-empty: distinguish "diff requested but empty" (delete-only /
+  // no changes) from EmptyDiff ("no diff requested"). See #2505.
+  override def isEmpty: Boolean = false
   private val newFiles: Set[String] = diffs.collect { case NewFile(path) =>
     path.toAbsolutePath.toString
   }.toSet

--- a/scalafix-core/src/main/scala/scalafix/internal/patch/EscapeHatch.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/patch/EscapeHatch.scala
@@ -119,7 +119,7 @@ class EscapeHatch private (
   }
 
   def isEmpty: Boolean =
-    diffDisable.isEmpty && anchoredEscapes.isEmpty && annotatedEscapes.isEmpty
+    diffDisable.canSkip && anchoredEscapes.isEmpty && annotatedEscapes.isEmpty
 }
 
 object EscapeHatch {

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliGitDiffSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliGitDiffSuite.scala
@@ -268,33 +268,34 @@ class CliGitDiffSuite extends AnyFunSuite with DiffAssertions {
     assertNoDiff(obtained, expected)
   }
 
-  gitTest("delete-only diff does not lint all files", SkipWindows) { (fs, git, cli) =>
-    val keep = "keep.scala"
-    val gone = "gone.scala"
+  gitTest("delete-only diff does not lint all files", SkipWindows) {
+    (fs, git, cli) =>
+      val keep = "keep.scala"
+      val gone = "gone.scala"
 
-    fs.add(
-      keep,
-      """|object Keep {
-        |  var keepVar = 1
-        |}""".stripMargin
-    )
-    fs.add(
-      gone,
-      """|object Gone {
-        |  var goneVar = 1
-        |}""".stripMargin
-    )
-    git.add(keep)
-    git.add(gone)
-    addConf(fs, git)
-    git.commit()
+      fs.add(
+        keep,
+        """|object Keep {
+          |  var keepVar = 1
+          |}""".stripMargin
+      )
+      fs.add(
+        gone,
+        """|object Gone {
+          |  var goneVar = 1
+          |}""".stripMargin
+      )
+      git.add(keep)
+      git.add(gone)
+      addConf(fs, git)
+      git.commit()
 
-    git.checkout("pr-1")
-    git.rm(gone)
-    git.commit()
+      git.checkout("pr-1")
+      git.rm(gone)
+      git.commit()
 
-    val obtained = runDiff(cli, ExitStatus.Ok)
-    assert(!obtained.contains("keepVar"))
+      val obtained = runDiff(cli, ExitStatus.Ok)
+      assert(!obtained.contains("keepVar"))
   }
 
   private def runDiff(cli: Cli, expected: ExitStatus, args: String*): String =

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliGitDiffSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/cli/CliGitDiffSuite.scala
@@ -268,6 +268,35 @@ class CliGitDiffSuite extends AnyFunSuite with DiffAssertions {
     assertNoDiff(obtained, expected)
   }
 
+  gitTest("delete-only diff does not lint all files", SkipWindows) { (fs, git, cli) =>
+    val keep = "keep.scala"
+    val gone = "gone.scala"
+
+    fs.add(
+      keep,
+      """|object Keep {
+        |  var keepVar = 1
+        |}""".stripMargin
+    )
+    fs.add(
+      gone,
+      """|object Gone {
+        |  var goneVar = 1
+        |}""".stripMargin
+    )
+    git.add(keep)
+    git.add(gone)
+    addConf(fs, git)
+    git.commit()
+
+    git.checkout("pr-1")
+    git.rm(gone)
+    git.commit()
+
+    val obtained = runDiff(cli, ExitStatus.Ok)
+    assert(!obtained.contains("keepVar"))
+  }
+
   private def runDiff(cli: Cli, expected: ExitStatus, args: String*): String =
     noColor(
       cli.run(

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/EscapeHatchSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/EscapeHatchSuite.scala
@@ -172,6 +172,15 @@ class EscapeHatchSuite extends AnyFunSuite {
     assert(!hatch.isEmpty)
   }
 
+  test("FullDiffDisable with no new/modified files is not empty (#2505)") {
+    val diff = DiffDisable(Nil)
+    assert(!diff.isEmpty)
+    assert(diff.isDisabled(Input.String("object Untouched")))
+    val (input, tree) = params(noEscapes)
+    val hatch = EscapeHatch(input, tree, diff)
+    assert(!hatch.isEmpty)
+  }
+
   private def params(
       input: Input
   ): (Input, LazyValue[Tree]) = {

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/core/EscapeHatchSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/core/EscapeHatchSuite.scala
@@ -172,9 +172,9 @@ class EscapeHatchSuite extends AnyFunSuite {
     assert(!hatch.isEmpty)
   }
 
-  test("FullDiffDisable with no new/modified files is not empty (#2505)") {
+  test("FullDiffDisable with no new/modified files cannot skip (#2505)") {
     val diff = DiffDisable(Nil)
-    assert(!diff.isEmpty)
+    assert(!diff.canSkip)
     assert(diff.isDisabled(Input.String("object Untouched")))
     val (input, tree) = params(noEscapes)
     val hatch = EscapeHatch(input, tree, diff)


### PR DESCRIPTION
## Problem

When `--diff` / `--diff-base` is used and the git diff contains no added or modified files (e.g. delete-only changes), Scalafix lints **all** files instead of none.

`JGitDiff` drops `DELETE` entries, so a delete-only diff produces `diffs = Nil`. `FullDiffDisable.isEmpty` was defined as `diffs.isEmpty`, making that case indistinguishable from `EmptyDiff` ("no diff requested"). `EscapeHatch.filter` then short-circuits on `isEmpty` and returns all patches/diagnostics without diff filtering.

Closes #2505

## Fix

Implement option 1 as endorsed by @bjaglin: make `FullDiffDisable.isEmpty` always return `false`, even when `diffs` is empty. `EmptyDiff` remains the only "no diff requested" sentinel. The slow path in `EscapeHatch.filter` then correctly suppresses everything via `isDisabled`.

## Tests

- `EscapeHatchSuite`: `FullDiffDisable(Nil)` is not empty, disables untouched inputs, and keeps `EscapeHatch` non-empty.
- `CliGitDiffSuite`: delete-only branch (`keep.scala` + `gone.scala`, then `rm gone`) under `--diff` does not report `keepVar` / lint all files.

Verified locally:

```text
unit2_13_18/testOnly scalafix.tests.core.EscapeHatchSuite scalafix.tests.cli.CliGitDiffSuite
# 21 tests, all passed (including both new cases)
```