### PR TITLE
fix(organizeImports): preserve source spelling and layout of already-organized imports

### DIFF
--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -791,7 +791,7 @@ class OrganizeImports(
             sb.append('{')
             if (useOuterSpace) sb.append(' ')
           }
-          sb.append(treeSyntax(single))
+          sb.append(importeeSyntax(single))
           if (isCurly) {
             if (useOuterSpace) sb.append(' ')
             sb.append('}')
@@ -822,7 +822,7 @@ class OrganizeImports(
             if (sb.length > sblen) sb.append(',').append(sep)
             val proto = i2.originalPrototype()
             proto.begComment.foreach(appendBegComment)
-            sb.append(treeSyntax(i2))
+            sb.append(importeeSyntax(i2))
             proto.endComment.foreach(appendEndComment)
           }
           if (isMultiline) {
@@ -1152,22 +1152,72 @@ object OrganizeImports {
       Try(symbol.info).toOption.flatten
   }
 
-  @inline
+  /**
+   * Emits an importer ref segment by segment: only leaf names can be taken from
+   * the source, so inter-segment trivia (`a . b`, a ref wrapped over several
+   * lines) can never leak into the output.
+   */
   private def refSyntax(ref: Term)(implicit dialect: Dialect): String =
     ref match {
-      case Term.Select(qual, name) if !name.pos.isEmpty =>
-        refSyntax(qual) + "." + name.pos.text
-      case _ if !ref.pos.isEmpty =>
-        ref.pos.text
-      case Term.Select(qual, name) =>
-        refSyntax(qual) + "." + treeSyntax(name)
-      case _ =>
-        treeSyntax(ref)
+      case t: Term.Name => nameSyntax(t)
+      case Term.Select(qual, name) => refSyntax(qual) + "." + nameSyntax(name)
+      case _ => treeSyntax(ref)
     }
 
-  @inline
+  /**
+   * Canonical, dialect-normalized syntax. Use for comparison keys ONLY (dedup,
+   * grouping, sorting): two importers/importees that mean the same thing must
+   * produce the same key regardless of how they were spelled in the source, so
+   * ordering here deliberately follows the dialect-normalized spelling rather
+   * than e.g. an author's backticks (see `refSyntax`/`importeeSyntax` for
+   * output, and https://github.com/scalacenter/scalafix/pull/2500 for why these
+   * two must not be conflated).
+   */
   private def treeSyntax(tree: Tree)(implicit dialect: Dialect): String =
     tree.reprint()
+
+  /**
+   * Emits a leaf `Name` as it was spelled in the source, so that backquotes
+   * around identifiers the target dialect does not consider keywords are not
+   * dropped (soft keywords, e.g. `` `export` ``,
+   * https://github.com/scalacenter/scalafix/issues/2480).
+   *
+   * NB: always reads the name's own position, never `originalPrototype()` --
+   * the latter would resurrect pre-rewrite text for a node produced by
+   * `copy(field = ...)` (e.g. `expandRelative`'s `replaceTopQualifier`).
+   */
+  private def nameSyntax(name: Name)(implicit dialect: Dialect): String =
+    name.pos match {
+      case p: Position.Range => p.text
+      case _ => treeSyntax(name)
+    }
+
+  private def typeSyntax(tpe: Type)(implicit dialect: Dialect): String =
+    tpe match {
+      case t: Type.Name => nameSyntax(t)
+      case Type.Select(qual, name) => refSyntax(qual) + "." + nameSyntax(name)
+      case _ => treeSyntax(tpe) // Type.Apply, Type.Project, ...
+    }
+
+  /**
+   * Emits an importee: leaf names come from the source, every connective token
+   * (`=>` vs `as`, `given`) is produced for the target dialect, so a dialect
+   * migration keeps the source spelling of the names it moves. Separators match
+   * the pretty-printer's, so output is unchanged for unescaped names.
+   */
+  private def importeeSyntax(importee: Importee)(implicit
+      dialect: Dialect
+  ): String = {
+    def arrow = if (dialect.allowAsForImportRename) "as" else "=>"
+    importee match {
+      case Importee.Name(name) => nameSyntax(name)
+      case Importee.Rename(name, rename) =>
+        s"${nameSyntax(name)} $arrow ${nameSyntax(rename)}"
+      case Importee.Unimport(name) => s"${nameSyntax(name)} $arrow _"
+      case Importee.Given(tpe) => "given " + typeSyntax(tpe)
+      case _ => treeSyntax(importee) // Wildcard, GivenAll
+    }
+  }
 
   implicit private class ImporteeExtension(val importee: Importee)
       extends AnyVal {

--- a/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
+++ b/scalafix-rules/src/main/scala/scalafix/internal/rule/OrganizeImports.scala
@@ -779,57 +779,71 @@ class OrganizeImports(
 
         ps.foreach(_.begComment.foreach(appendBegComment))
         i.begComment.foreach(appendBegComment)
-        if (single != null) single.begComment.foreach(appendBegComment)
-        sb.append("import ").append(refSyntax(i.ref)).append('.')
-        if (single != null) {
-          val isCurly = single.isCurlyBraced
-          val useOuterSpace = isCurly && single
-            .originalPrototype()
-            .parent
-            .exists(_.hasSpaceInCurly)
-          if (isCurly) {
+        if (i.isUnchangedFromSource) {
+          // An already-organized wrapped import: re-emit its source text as is,
+          // leaving its layout to the formatter. Interior comments come along
+          // in the token stream; comments around the import are printed as
+          // usual, above and below this branch.
+          // Continuation lines are re-indented on insertion, like printed ones.
+          val srcIndent = " " * i.parent.fold(0)(_.pos.startColumn)
+          val srcLines = i.tokens.syntax.linesIterator
+          sb.append("import ").append(srcLines.next())
+          srcLines.foreach(l =>
+            sb.append('\n').append(l.stripPrefix(srcIndent))
+          )
+        } else {
+          if (single != null) single.begComment.foreach(appendBegComment)
+          sb.append("import ").append(refSyntax(i.ref)).append('.')
+          if (single != null) {
+            val isCurly = single.isCurlyBraced
+            val useOuterSpace = isCurly && single
+              .originalPrototype()
+              .parent
+              .exists(_.hasSpaceInCurly)
+            if (isCurly) {
+              sb.append('{')
+              if (useOuterSpace) sb.append(' ')
+            }
+            sb.append(importeeSyntax(single))
+            if (isCurly) {
+              if (useOuterSpace) sb.append(' ')
+              sb.append('}')
+            }
+            single.endComment.foreach(appendEndComment)
+          } else {
+            val lines = i.importees.iterator.map(_.pos.startLine).filter(_ >= 0)
+            val isMultiline = lines.hasNext && {
+              val line = lines.next()
+              lines.exists(_ != line)
+            }
+            val origImporters = i.importees
+              .flatMap(_.originalPrototype().parent)
+              .distinct
+            val useOuterSpace =
+              !isMultiline && origImporters.exists(_.hasSpaceInCurly)
+            // Preserve a trailing comma if the (single) source importer had one.
+            val trailingComma = isMultiline && (origImporters match {
+              case Seq(origImporter: Importer) => origImporter.hasTrailingComma
+              case _ => false
+            })
             sb.append('{')
-            if (useOuterSpace) sb.append(' ')
-          }
-          sb.append(importeeSyntax(single))
-          if (isCurly) {
-            if (useOuterSpace) sb.append(' ')
+            val sep = if (isMultiline) "\n  " else " "
+            if (isMultiline) sb.append(sep)
+            else if (useOuterSpace) sb.append(' ')
+            val sblen = sb.length
+            i.importees.foreach { i2 =>
+              if (sb.length > sblen) sb.append(',').append(sep)
+              val proto = i2.originalPrototype()
+              proto.begComment.foreach(appendBegComment)
+              sb.append(importeeSyntax(i2))
+              proto.endComment.foreach(appendEndComment)
+            }
+            if (isMultiline) {
+              if (trailingComma) sb.append(',')
+              sb.append('\n')
+            } else if (useOuterSpace) sb.append(' ')
             sb.append('}')
           }
-          single.endComment.foreach(appendEndComment)
-        } else {
-          val lines = i.importees.iterator.map(_.pos.startLine).filter(_ >= 0)
-          val isMultiline = lines.hasNext && {
-            val line = lines.next()
-            lines.exists(_ != line)
-          }
-          val origImporters = i.importees
-            .flatMap(_.originalPrototype().parent)
-            .distinct
-          val useOuterSpace =
-            !isMultiline && origImporters.exists(_.hasSpaceInCurly)
-          // Preserve a trailing comma if the (single) source importer had one.
-          val trailingComma = isMultiline && (origImporters match {
-            case Seq(origImporter: Importer) => origImporter.hasTrailingComma
-            case _ => false
-          })
-          sb.append('{')
-          val sep = if (isMultiline) "\n  " else " "
-          if (isMultiline) sb.append(sep)
-          else if (useOuterSpace) sb.append(' ')
-          val sblen = sb.length
-          i.importees.foreach { i2 =>
-            if (sb.length > sblen) sb.append(',').append(sep)
-            val proto = i2.originalPrototype()
-            proto.begComment.foreach(appendBegComment)
-            sb.append(importeeSyntax(i2))
-            proto.endComment.foreach(appendEndComment)
-          }
-          if (isMultiline) {
-            if (trailingComma) sb.append(',')
-            sb.append('\n')
-          } else if (useOuterSpace) sb.append(' ')
-          sb.append('}')
         }
         i.endComment.foreach(appendEndComment)
         ps.foreach(_.endComment.foreach(appendEndComment))
@@ -1286,6 +1300,40 @@ object OrganizeImports {
       val idx = tokens.skipWideIf(_.is[Token.HTrivia], tokens.length)
       tokens.getWideOpt(idx).exists(_.is[Token.Comma])
     }
+
+    def spansMultipleLines: Boolean =
+      importer.pos.startLine != importer.pos.endLine
+
+    /**
+     * Would pretty-printing under `dialect` rewrite `=>` to `as` or `_` to `*`?
+     */
+    def needsDialectRewrite(implicit dialect: Dialect): Boolean =
+      importer.importees.exists {
+        case i: Importee.Wildcard =>
+          i.tokens.exists(_.is[Token.Underscore]) ==
+            dialect.allowStarWildcardImport
+        case i @ (_: Importee.Rename | _: Importee.Unimport) =>
+          i.tokens.exists(_.is[Token.RightArrow]) ==
+            dialect.allowAsForImportRename
+        case _ => false
+      }
+
+    /**
+     * Checks whether this `Importer` can be re-emitted verbatim from its own
+     * source text, so its layout (indentation, alignment, trailing comma) is
+     * left to the formatter rather than re-flowed by this rule.
+     *
+     * The signal is position presence: a node the pipeline rewrote is a
+     * `copy()` and carries no position (same invariant `nameSyntax` relies on),
+     * so an `Importer` that still has its parsed `Position.Range` was not
+     * restructured -- same qualifier, same importees, same order. Only wrapped
+     * imports qualify: single-line ones are still normalized (`import a.{ B }`
+     * -> `import a.B`), and one needing a dialect migration is being rewritten.
+     */
+    def isUnchangedFromSource(implicit dialect: Dialect): Boolean =
+      importer.pos.isInstanceOf[Position.Range] &&
+        importer.spansMultipleLines &&
+        !importer.needsDialectRewrite
 
   }
 

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/CoalesceMultiLineTrailingComma.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/CoalesceMultiLineTrailingComma.scala
@@ -1,0 +1,24 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Keep
+  removeUnused = false
+  coalesceToWildcardImportThreshold = 2
+}
+ */
+package test.organizeImports
+
+// Coalescing rewrites the importees, so the import no longer counts as
+// already-organized: it is pretty-printed (re-flowed to one line) rather than
+// re-emitted verbatim, and the formatter re-wraps it afterwards.
+import scala.collection.immutable.{
+  Map => M,
+  Set,
+  Seq,
+}
+
+object CoalesceMultiLineTrailingComma {
+  val m: M[Int, Int] = M.empty
+  val s: Set[Int] = Set.empty
+  val q: Seq[Int] = Seq.empty
+}

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/MergeScala3KeywordImportee.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/MergeScala3KeywordImportee.scala
@@ -1,0 +1,14 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports.removeUnused = false
+OrganizeImports.targetDialect = StandardLayout
+OrganizeImports.groupedImports = Merge
+*/
+package test.organizeImports
+
+// `export` is a plain member name here, not a qualifier; merging two imports
+// from the same prefix into one importer must not drop its backticks.
+import test.organizeImports.QuotedIdent.ea
+import test.organizeImports.QuotedIdent.`export`
+
+object MergeScala3KeywordImportee

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/SingleImporteeSplitInline.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/SingleImporteeSplitInline.scala
@@ -1,0 +1,20 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Explode
+  removeUnused = false
+}
+ */
+package test.organizeImports
+
+// Importees split out of a wrapped multi-importee import are printed inline:
+// the wrapping belonged to the source import, not to each importee.
+import scala.collection.immutable.{
+  Set,
+  Map => M,
+}
+
+object SingleImporteeSplitInline {
+  val m: M[Int, Int] = M.empty
+  val s: Set[Int] = Set.empty
+}

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/SingleImporteeWrapped.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/SingleImporteeWrapped.scala
@@ -1,0 +1,17 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Keep
+  removeUnused = false
+}
+ */
+package test.organizeImports
+
+// A wrapped single importee keeps its multi-line layout.
+import scala.collection.{
+  immutable => imm,
+}
+
+object SingleImporteeWrapped {
+  val m: imm.Map[Int, Int] = imm.Map.empty
+}

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/SingleImporteeWrappedNoComma.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/SingleImporteeWrappedNoComma.scala
@@ -1,0 +1,18 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Keep
+  removeUnused = false
+}
+ */
+package test.organizeImports
+
+// A wrapped single importee without a trailing comma keeps its layout, and
+// does not gain a comma.
+import scala.collection.{
+  immutable => imm
+}
+
+object SingleImporteeWrappedNoComma {
+  val m: imm.Map[Int, Int] = imm.Map.empty
+}

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/VerbatimInteriorComment.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/VerbatimInteriorComment.scala
@@ -1,0 +1,19 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Keep
+  removeUnused = false
+}
+ */
+package test.organizeImports
+
+import scala.collection.immutable.{
+  // pick a map
+  Map,
+  Set,
+}
+
+object VerbatimInteriorComment {
+  val m: Map[Int, Int] = Map.empty
+  val s: Set[Int] = Set.empty
+}

--- a/scalafix-tests/input/src/main/scala/test/organizeImports/nested/NestedPackageWrapped.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/nested/NestedPackageWrapped.scala
@@ -1,0 +1,23 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Keep
+  removeUnused = false
+}
+ */
+package test.organizeImports.nested {
+  // Wrapped imports inside an indented block keep their relative indentation.
+  import scala.collection.immutable.{
+    Map => M,
+    Set,
+  }
+  import scala.collection.{
+    immutable => imm,
+  }
+
+  object NestedPackageWrapped {
+    val m: M[Int, Int] = M.empty
+    val s: Set[Int] = Set.empty
+    val i: imm.Map[Int, Int] = imm.Map.empty
+  }
+}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/CoalesceMultiLineTrailingComma.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/CoalesceMultiLineTrailingComma.scala
@@ -1,0 +1,12 @@
+package test.organizeImports
+
+// Coalescing rewrites the importees, so the import no longer counts as
+// already-organized: it is pretty-printed (re-flowed to one line) rather than
+// re-emitted verbatim, and the formatter re-wraps it afterwards.
+import scala.collection.immutable.{Map => M, _}
+
+object CoalesceMultiLineTrailingComma {
+  val m: M[Int, Int] = M.empty
+  val s: Set[Int] = Set.empty
+  val q: Seq[Int] = Seq.empty
+}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/MergeScala3KeywordImportee.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/MergeScala3KeywordImportee.scala
@@ -1,0 +1,10 @@
+package test.organizeImports
+
+// `export` is a plain member name here, not a qualifier; merging two imports
+// from the same prefix into one importer must not drop its backticks.
+import test.organizeImports.QuotedIdent.{
+  ea,
+  `export`
+}
+
+object MergeScala3KeywordImportee

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/SingleImporteeSplitInline.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/SingleImporteeSplitInline.scala
@@ -1,0 +1,11 @@
+package test.organizeImports
+
+// Importees split out of a wrapped multi-importee import are printed inline:
+// the wrapping belonged to the source import, not to each importee.
+import scala.collection.immutable.Set
+import scala.collection.immutable.{Map => M}
+
+object SingleImporteeSplitInline {
+  val m: M[Int, Int] = M.empty
+  val s: Set[Int] = Set.empty
+}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/SingleImporteeWrapped.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/SingleImporteeWrapped.scala
@@ -1,0 +1,10 @@
+package test.organizeImports
+
+// A wrapped single importee keeps its multi-line layout.
+import scala.collection.{
+  immutable => imm,
+}
+
+object SingleImporteeWrapped {
+  val m: imm.Map[Int, Int] = imm.Map.empty
+}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/SingleImporteeWrappedNoComma.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/SingleImporteeWrappedNoComma.scala
@@ -1,0 +1,11 @@
+package test.organizeImports
+
+// A wrapped single importee without a trailing comma keeps its layout, and
+// does not gain a comma.
+import scala.collection.{
+  immutable => imm
+}
+
+object SingleImporteeWrappedNoComma {
+  val m: imm.Map[Int, Int] = imm.Map.empty
+}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/VerbatimInteriorComment.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/VerbatimInteriorComment.scala
@@ -1,0 +1,12 @@
+package test.organizeImports
+
+import scala.collection.immutable.{
+  // pick a map
+  Map,
+  Set,
+}
+
+object VerbatimInteriorComment {
+  val m: Map[Int, Int] = Map.empty
+  val s: Set[Int] = Set.empty
+}

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/nested/NestedPackageWrapped.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/nested/NestedPackageWrapped.scala
@@ -1,0 +1,16 @@
+package test.organizeImports.nested {
+  // Wrapped imports inside an indented block keep their relative indentation.
+  import scala.collection.immutable.{
+    Map => M,
+    Set,
+  }
+  import scala.collection.{
+    immutable => imm,
+  }
+
+  object NestedPackageWrapped {
+    val m: M[Int, Int] = M.empty
+    val s: Set[Int] = Set.empty
+    val i: imm.Map[Int, Int] = imm.Map.empty
+  }
+}


### PR DESCRIPTION
Since 0d232c9f (first released in 0.14.7), the rule deletes every import and re-prints it from the tree via `reprint()`, which prints from *structure* under a *dialect* and so discards anything the source had that the tree does not model — identifier spelling and layout. Each loss has been patched back one at a time (#2427 brace spacing, #2468 trailing commas, #2500 qualifier backticks…). This PR addresses the two remaining axes, keyed on a single invariant instead of more heuristics: **a node the pipeline rewrote is a `copy()` and carries no position; a node it left alone keeps its parsed position.** So position presence tells us, per node, when the source text can be re-emitted as is.

### 1. Emit escaped names from source, not reprint, everywhere

`refSyntax` (#2500) preserved backticks for an importer's *qualifier* only. This generalizes it to every emitted leaf name (`nameSyntax`), used by both the ref (`refSyntax`) and the importee (new `importeeSyntax`, covering `Rename`/`Unimport`/`Given` by rebuilding from parts rather than taking a composite span). `treeSyntax` (`reprint()`) stays for comparison keys only (dedup, grouping, sorting) — those must stay dialect-normalized so `A => B` and `A as B` dedup to one entry and sort order does not depend on backticks.

### 2. Re-emit already-organized wrapped imports verbatim

A wrapped import the rule leaves untouched is currently collapsed onto one line by the pretty-printer, fighting scalafmt over the same lines. Now such an import is re-emitted from its own source text, so its layout (indentation, alignment, trailing comma) is the formatter's business, not this rule's.

`isUnchangedFromSource` = has a range position (so it was not restructured — same qualifier, importees, order), spans multiple lines (single-line imports are still normalized, e.g. `import a.{ B }` -> `import a.B`), and needs no dialect migration (`=>`/`as`, `_`/`*`). No structural comparison, no `originalPrototype()` navigation. The reconstruction path is untouched: anything the rule rewrites — reordered, merged, coalesced, exploded, expanded — still goes through the pretty-printer as before (a coalesced multi-line import, for instance, re-flows to one line and the formatter re-wraps it).

Fixtures and code for this axis are adapted from #2507.

## New expect tests across releases

| expect test | 0.14.6 | 0.14.7 | this PR |
|---|---|---|---|
| CoalesceMultiLineTrailingComma | ✅ | ✅ | ✅ |
| SingleImporteeSplitInline | ✅ | ✅ | ✅ |
| SingleImporteeWrapped | ✅ | ❌ | ✅ |
| SingleImporteeWrappedNoComma | ✅ | ❌ | ✅ |
| NestedPackageWrapped | ❌ | ❌ | ✅ |
| VerbatimInteriorComment | ❌ | ❌ | ✅ |
| MergeScala3KeywordImportee | ❌ | ❌ | ✅ |
