### PR TITLE
Fix `ExplicitResultTypes` for Scala 3.10+

### DIFF
--- a/scalafix-core/src/main/scala/scalafix/internal/config/ScalaVersion.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/config/ScalaVersion.scala
@@ -168,6 +168,11 @@ object ScalaVersion {
       v.isScala2 || ordering.gteq(v, Patch(Major.Scala3, 3, 4))
     }
 
+  def explicitResultTypesSupported(version: String): Boolean =
+    from(version).toOption.forall { v =>
+      !v.isScala3 || ordering.gteq(v, Patch(Major.Scala3, 3, 0))
+    }
+
   def from(version: String): Try[ScalaVersion] = {
     version match {
       case NightlyVersion(major, minor, patch, rc, date, shortSha1) =>

--- a/scalafix-rules/src/main/scala-3/scalafix/internal/rule/ExplicitResultTypes.scala
+++ b/scalafix-rules/src/main/scala-3/scalafix/internal/rule/ExplicitResultTypes.scala
@@ -7,6 +7,7 @@ import scala.meta.*
 
 import dotty.tools.pc.ScalaPresentationCompiler
 import metaconfig.Configured
+import scalafix.internal.config.ScalaVersion
 import scalafix.internal.pc.PresentationCompilerTypeInferrer
 import scalafix.patch.Patch
 import scalafix.v1.*
@@ -61,7 +62,7 @@ final class ExplicitResultTypes(
           s"To fix this problem, either remove ExplicitResultTypes from .scalafix.conf or make sure Scalafix is loaded with $majorMinorScalaVersion."
       )
     } else if (
-      Seq("3.0", "3.1", "3.2").exists(v => config.scalaVersion.startsWith(v))
+      !ScalaVersion.explicitResultTypesSupported(config.scalaVersion)
     ) {
       Configured.error(
         s"The ExplicitResultTypes rule requires Scala 3 target sources to be compiled with Scala 3.3.0 or greater, but they were compiled with ${config.scalaVersion}. " +

--- a/scalafix-tests/integration/src/test/scala-3/scalafix/tests/rules/ExplicitResultTypesSuite.scala
+++ b/scalafix-tests/integration/src/test/scala-3/scalafix/tests/rules/ExplicitResultTypesSuite.scala
@@ -68,4 +68,20 @@ class ExplicitResultTypesSuite extends AnyFunSuite {
     assert(rule.withConfiguration(neitherLTSNorNext.withConf(conf)).isOk)
   }
 
+  test("Scala 3.10 is not mistaken for Scala 3.1") {
+    val scala310 =
+      config.withScalaVersion("3.10.0-RC1")
+
+    val v =
+      buildinfo.RulesBuildInfo.scalaVersion.split('.').take(2).mkString(".")
+
+    val expected =
+      s"The ExplicitResultTypes rule was compiled with a different Scala 3 minor ($v) than the target sources (3.10). " +
+        "To fix this problem, make sure you are running the latest version of Scalafix. " +
+        "If that is the case, either change your build to stick to the Scala 3 LTS or Next versions supported by Scalafix, or " +
+        "enable ExplicitResultTypes.fetchScala3CompilerArtifactsOnVersionMismatch in .scalafix.conf in order to try to load what is needed dynamically."
+
+    assert(rule.withConfiguration(scala310) == Configured.error(expected))
+  }
+
 }

--- a/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ScalaVersionSuite.scala
+++ b/scalafix-tests/unit/src/test/scala/scalafix/tests/config/ScalaVersionSuite.scala
@@ -73,4 +73,21 @@ class ScalaVersionSuite extends munit.FunSuite {
     }
   }
 
+  test("explicitResultTypesSupported") {
+    val cases = List(
+      "3.10.0-RC1" -> true,
+      "3.3.0" -> true,
+      "3.2.2" -> false,
+      "3.1.3" -> false,
+      "not-a-version" -> true // unparseable stays permissive
+    )
+    cases.foreach { case (version, expected) =>
+      assertEquals(
+        ScalaVersion.explicitResultTypesSupported(version),
+        expected,
+        clue = version
+      )
+    }
+  }
+
 }


### PR DESCRIPTION
Fixes https://github.com/scalacenter/scalafix/issues/2511