### PR TITLE
add regression test for #2473

### DIFF
--- a/scalafix-tests/input/src/main/scala/test/organizeImports/InlineCommentMoves.scala
+++ b/scalafix-tests/input/src/main/scala/test/organizeImports/InlineCommentMoves.scala
@@ -7,6 +7,7 @@ package test.organizeImports
 
 import z.Z // commentZ
 
+import c._ //commentWildcard
 import a.A
 
 object InlineCommentMoves {

--- a/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentMoves.scala
+++ b/scalafix-tests/output/src/main/scala/test/organizeImports/InlineCommentMoves.scala
@@ -1,6 +1,7 @@
 package test.organizeImports
 
 import a.A
+import c._ //commentWildcard
 import z.Z // commentZ
 
 object InlineCommentMoves {


### PR DESCRIPTION
Follows https://github.com/scalacenter/scalafix/pull/2513

Adds test ensuring https://github.com/scalameta/scalameta/pull/4791 is effective against https://github.com/scalacenter/scalafix/issues/2473