### PR TITLE
Add `--dry-run` to report linter errors without rewriting files

### DIFF
--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -209,6 +209,22 @@ To automatically enforce that Scalafix has been run on all sources, use
 
 Use `scalafixAll --check`  to enforce Scalafix on your entire project.
 
+### Report linter errors only
+
+To look at linter errors without rewriting any file, use `scalafix --dry-run`.
+Unlike `--check`, it does not print the diff that a rewrite would produce, and
+files that could be fixed do not fail the invocation on their own - only linter
+errors do. Files with pending rewrites are reported as a count, so you know
+that running `scalafix` without `--dry-run` would change something.
+
+```sh
+$ scalafix --dry-run
+src/main/scala/Main.scala:4:18: error: [DisableSyntax.noSemicolons] semicolons are disabled
+    println("ok");
+                 ^
+2 files can be fixed by running scalafix without --dry-run
+```
+
 ### Cache in CI
 
 To avoid binary compatibility conflicts with the sbt classpath

--- a/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixArgumentsImpl.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/interfaces/ScalafixArgumentsImpl.scala
@@ -210,6 +210,8 @@ final case class ScalafixArgumentsImpl(args: Args = Args.default)
         copy(args = args.copy(stdout = true))
       case ScalafixMainMode.AUTO_SUPPRESS_LINTER_ERRORS =>
         copy(args = args.copy(autoSuppressLinterErrors = true))
+      case ScalafixMainMode.DRY_RUN =>
+        copy(args = args.copy(dryRun = true))
       case ScalafixMainMode.IN_PLACE_TRIGGERED =>
         copy(args = args.copy(triggered = true))
     }

--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/Args.scala
@@ -71,6 +71,12 @@ case class Args(
     @Description("Print fixed output to stdout instead of writing in-place.")
     stdout: Boolean = false,
     @Description(
+      "Report linter errors without writing to files or printing a diff, " +
+        "reporting how many files could be fixed by a subsequent run. " +
+        "Unlike --check, auto-fixable violations alone do not fail the run."
+    )
+    dryRun: Boolean = false,
+    @Description(
       "If set, only apply scalafix to added and edited files in git diff against the master branch."
     )
     diff: Boolean = false,

--- a/scalafix-cli/src/main/scala/scalafix/internal/v1/MainOps.scala
+++ b/scalafix-cli/src/main/scala/scalafix/internal/v1/MainOps.scala
@@ -275,7 +275,13 @@ object MainOps {
         args.config.reporter.lint(diag)
       }
     }
-    if (args.args.check) {
+    if (args.args.dryRun) {
+      // Lint diagnostics were already reported above. Report nothing about
+      // rewrites, and leave it to `run` to count and clear this TestError:
+      // --dry-run reports, it does not assert like --check does.
+      if (fixed == input.text) ExitStatus.Ok
+      else ExitStatus.TestError
+    } else if (args.args.check) {
       if (fixed == input.text) {
         ExitStatus.Ok
       } else {
@@ -407,6 +413,7 @@ object MainOps {
     val N = files.length
     val width = N.toString.length
     var exit = discoveryError
+    var fixable = 0
 
     args.rules.rules.foreach(_.beforeStart())
 
@@ -417,12 +424,26 @@ object MainOps {
         i += 1
       }
       val next = handleFile(args, file)
-      exit = ExitStatus.merge(exit, next)
+      // In --dry-run, TestError only means "this file has pending rewrites".
+      // Count it and clear it here, so that the exit code, and the checks
+      // `adjustExitCode` makes against it, are the same as for a normal run.
+      val status =
+        if (args.args.dryRun && next.is(ExitStatus.TestError)) {
+          fixable += 1
+          ExitStatus(next.code & ~ExitStatus.TestError.code)
+        } else next
+      exit = ExitStatus.merge(exit, status)
     }
 
     args.rules.rules.foreach(_.afterComplete())
 
     val result = adjustExitCode(args, exit, files)
+    if (fixable > 0) {
+      val noun = if (fixable == 1) "file" else "files"
+      args.args.out.println(
+        s"$fixable $noun can be fixed by running scalafix without --dry-run"
+      )
+    }
     // Only print the message when the entire failure is auto-fixable, i.e.
     // the exit status is exactly TestError, not merged with lint, parse,
     // input or other errors that running Scalafix cannot resolve.

--- a/scalafix-interfaces/src/main/java/scalafix/interfaces/ScalafixMainMode.java
+++ b/scalafix-interfaces/src/main/java/scalafix/interfaces/ScalafixMainMode.java
@@ -32,5 +32,14 @@ public enum ScalafixMainMode {
     /**
      * Use when the client triggers the run as a side effect of something else, as opposed to an explicit, interactive invocation. Write fixed contents in-place, with a custom configuration if it exists.
      */
-    IN_PLACE_TRIGGERED
+    IN_PLACE_TRIGGERED,
+
+    /**
+     * Report linter errors only, without printing a diff of the fixed contents.
+     *
+     * Unlike {@link #CHECK}, files that could be fixed do not cause an error to be reported.
+     *
+     * Does not write to files.
+     */
+    DRY_RUN
 }

--- a/scalafix-tests/integration/src/test/scala/scalafix/tests/cli/CliSyntacticSuite.scala
+++ b/scalafix-tests/integration/src/test/scala/scalafix/tests/cli/CliSyntacticSuite.scala
@@ -199,6 +199,148 @@ class CliSyntacticSuite extends BaseCliSuite {
     }
   )
 
+  val fixableHint: String =
+    "can be fixed by running scalafix without --dry-run"
+
+  check(
+    name = "--dry-run does not write to file nor print a diff",
+    originalLayout = s"""/foobar.scala
+      |$original""".stripMargin,
+    args = Array("--dry-run", "-r", "RedundantSyntax", "foobar.scala"),
+    expectedLayout = s"""/foobar.scala
+      |$original""".stripMargin,
+    expectedExit = ExitStatus.Ok,
+    outputAssert = { out =>
+      assert(!out.contains("<expected fix>"))
+      assert(out.contains(s"1 file $fixableHint"), out)
+    }
+  )
+
+  check(
+    name = "--dry-run counts every fixable file",
+    originalLayout = s"""/dir/a.scala
+      |$original
+      |/dir/b.scala
+      |$original
+      |/dir/c.scala
+      |$expected""".stripMargin,
+    args = Array("--dry-run", "-r", "RedundantSyntax", "dir"),
+    expectedLayout = s"""/dir/a.scala
+      |$original
+      |/dir/b.scala
+      |$original
+      |/dir/c.scala
+      |$expected""".stripMargin,
+    expectedExit = ExitStatus.Ok,
+    outputAssert = { out =>
+      assert(out.contains(s"2 files $fixableHint"), out)
+    }
+  )
+
+  check(
+    name = "--dry-run on already fixed file reports nothing",
+    originalLayout = s"""/foobar.scala
+      |$expected""".stripMargin,
+    args = Array("--dry-run", "-r", "RedundantSyntax", "foobar.scala"),
+    expectedLayout = s"""/foobar.scala
+      |$expected""".stripMargin,
+    expectedExit = ExitStatus.Ok,
+    outputAssert = { out =>
+      assert(!out.contains(fixableHint), out)
+    }
+  )
+
+  check(
+    name = "--dry-run reports linter errors",
+    originalLayout = s"""/foobar.scala
+      |$original""".stripMargin,
+    args = Array(
+      "--dry-run",
+      "-r",
+      "scala:scalafix.test.cli.LintError",
+      "foobar.scala"
+    ),
+    expectedLayout = s"""/foobar.scala
+      |$original""".stripMargin,
+    expectedExit = ExitStatus.LinterError,
+    outputAssert = { out =>
+      assert(out.contains("Error!"))
+    }
+  )
+
+  check(
+    name = "--dry-run does not print onTestFailure message",
+    originalLayout = s"""/.scalafix.conf
+      |onTestFailure = "$onTestFailureMessage"
+      |/foobar.scala
+      |$original""".stripMargin,
+    args = Array("--dry-run", "-r", "RedundantSyntax", "foobar.scala"),
+    expectedLayout = s"""/.scalafix.conf
+      |onTestFailure = "$onTestFailureMessage"
+      |/foobar.scala
+      |$original""".stripMargin,
+    expectedExit = ExitStatus.Ok,
+    outputAssert = { out =>
+      assert(!out.contains(onTestFailureMessage))
+    }
+  )
+
+  check(
+    name = "--dry-run takes precedence over --check",
+    originalLayout = s"""/foobar.scala
+      |$original""".stripMargin,
+    args = Array(
+      "--dry-run",
+      "--check",
+      "-r",
+      "RedundantSyntax",
+      "foobar.scala"
+    ),
+    expectedLayout = s"""/foobar.scala
+      |$original""".stripMargin,
+    expectedExit = ExitStatus.Ok,
+    outputAssert = { out =>
+      assert(!out.contains("<expected fix>"))
+      assert(out.contains(s"1 file $fixableHint"), out)
+    }
+  )
+
+  check(
+    name = "--dry-run does not mask errors on a fixable file",
+    originalLayout = s"""/foobar.scala
+      |$original""".stripMargin,
+    args = Array(
+      "--dry-run",
+      "-r",
+      "RedundantSyntax",
+      "foobar.scala",
+      "missing.scala"
+    ),
+    expectedLayout = s"""/foobar.scala
+      |$original""".stripMargin,
+    expectedExit = ExitStatus.UnexpectedError,
+    outputAssert = { out =>
+      assert(out.contains("is not a file"))
+      assert(out.contains(s"1 file $fixableHint"), out)
+    }
+  )
+
+  check(
+    name = "--dry-run still reports non-fixable errors",
+    originalLayout = s"""/dir/a.scala
+      |$original
+      |/dir/b.scala
+      |object Broken {
+      |""".stripMargin,
+    args = Array("--dry-run", "-r", "RedundantSyntax", "dir"),
+    expectedLayout = s"""/dir/a.scala
+      |$original
+      |/dir/b.scala
+      |object Broken {
+      |""".stripMargin,
+    expectedExit = ExitStatus.ParseError
+  )
+
   check(
     name =
       "onTestFailure message not printed when mixed with non-fixable errors",

--- a/scalafix-tests/integration/src/test/scala/scalafix/tests/interfaces/ScalafixArgumentsSuite.scala
+++ b/scalafix-tests/integration/src/test/scala/scalafix/tests/interfaces/ScalafixArgumentsSuite.scala
@@ -415,6 +415,41 @@ class ScalafixArgumentsSuite extends AnyFunSuite with DiffAssertions {
     assert(contentAfterRun == fileEvaluation.previewPatches().get)
   }
 
+  fsTest("DRY_RUN reports lint errors without rewriting")() { case (api, cwd) =>
+    val main = cwd.resolve("src/Main.scala")
+    val contentBeforeRun =
+      FileIO.slurp(AbsolutePath(main), StandardCharsets.UTF_8)
+
+    val out = new ByteArrayOutputStream()
+    val args = api
+      .withRules(
+        List(
+          "RedundantSyntax", // syntactic rewrite
+          "DisableSyntax" // syntactic linter
+        ).asJava
+      )
+      .withParsedArguments(
+        List("--settings.DisableSyntax.noSemicolons", "true").asJava
+      )
+      .withPrintStream(new PrintStream(out))
+      .withMode(ScalafixMainMode.DRY_RUN)
+
+    val errors = args.run().toList.map(_.toString)
+    // the linter error is reported, but the fixable rewrite is not an error
+    assert(errors == List("LinterError"), out.toString)
+
+    val contentAfterRun =
+      FileIO.slurp(AbsolutePath(main), StandardCharsets.UTF_8)
+    assert(contentBeforeRun == contentAfterRun)
+
+    val stdout = fansi.Str(out.toString).plainText
+    assert(!stdout.contains("<expected fix>"), stdout)
+    assert(
+      stdout.contains("1 file can be fixed by running scalafix"),
+      stdout
+    )
+  }
+
   test("evaluate sees several patches for non-atomic patches") {
     val run = rawApi.withRules(List("CommentFileNonAtomic").asJava)
     val fileEvaluation = run.evaluate().getFileEvaluations.head


### PR DESCRIPTION
Closes #956.

Reports linter errors without writing to files or printing a diff:

```sh
$ scalafix --dry-run
src/main/scala/Main.scala:4:18: error: [DisableSyntax.noSemicolons] semicolons are disabled
    println("ok");
                 ^
2 files can be fixed by running scalafix without --dry-run
```

Unlike `--check`, pending rewrites are summarised as a count rather than a diff and don't fail the run on their own. Linter errors still exit `LinterError`.

Also adds `ScalafixMainMode.DRY_RUN` for the Java interfaces.
